### PR TITLE
fix: move PR feedback follow-up into the babysitter

### DIFF
--- a/docs/plans/2026-03-15-app-owned-github-follow-up-design.md
+++ b/docs/plans/2026-03-15-app-owned-github-follow-up-design.md
@@ -1,0 +1,132 @@
+# App-Owned GitHub Follow-Up Design
+
+**Date:** 2026-03-15
+**Status:** Approved
+
+## Goal
+
+Move PR feedback replies and review-thread resolution out of the coding agent and into the app so babysitter runs no longer fail when sandboxed agent-side `gh api` calls cannot reach GitHub.
+
+## Problem
+
+The current babysitter contract tells the coding agent to:
+
+- push code changes,
+- post GitHub replies for addressed feedback,
+- resolve review threads.
+
+That design is brittle in this environment for two reasons:
+
+1. The agent runs inside a more constrained sandbox than the app runtime. Logs from 2026-03-15 show the agent could push code and post a top-level PR comment with `gh pr comment`, but could not perform the review-thread `gh api` calls required for inline replies and thread resolution.
+2. The app still treats unresolved review threads as a hard verification failure, so successful code changes are discarded as run failures when GitHub follow-up is incomplete.
+
+There is also a metadata weakness: `fetchReviewThreadLookup` only loads the first 100 comments per review thread, so long threads can leave `threadId` unset for later inline comments.
+
+## Requirements
+
+- Keep the agent focused on repository work: inspect, edit, test, commit, push.
+- Move GitHub follow-up into app-owned code that already uses Octokit and the app’s GitHub auth path.
+- Post one short, per-item follow-up for every accepted feedback item, with the exact audit token.
+- Resolve each addressed `review_thread` item after posting its in-thread reply.
+- Keep support for `review`, `review_thread`, and `general_comment` reply targets.
+- Fix review-thread lookup so inline comments in long threads still map to the correct `threadId`.
+- Preserve the existing post-run verification contract: a run only succeeds if the audit trail exists and review threads are actually resolved.
+
+## Recommended Approach
+
+Implement GitHub follow-up inside `server/github.ts` and orchestrate it from `PRBabysitter` after the agent finishes and branch movement is verified.
+
+### Why this approach
+
+- It uses the app’s existing Octokit/auth integration instead of depending on shelling out from a sandboxed agent.
+- It keeps deterministic operational behavior in the app and judgment-heavy code changes in the agent.
+- It lets verification assert against actions the app itself performed, reducing false failures.
+
+## Rejected Alternatives
+
+### 1. Keep GitHub follow-up in the agent
+
+This preserves the original boundary but keeps the most failure-prone part in the least reliable execution context. The logs already show that `gh api` connectivity differs from what the app runtime can do.
+
+### 2. Relax verification and accept unresolved threads
+
+This would make runs appear successful while leaving stale review threads open. That directly conflicts with the intended babysitter behavior.
+
+## Architecture
+
+### Agent responsibilities
+
+- Make targeted code changes for accepted feedback and failing statuses.
+- Run verification.
+- Commit and push to the PR head branch.
+- Summarize the changes in stdout/stderr so the app logs remain useful.
+
+The agent no longer owns GitHub replies or thread resolution.
+
+### App responsibilities
+
+- Prepare the isolated worktree.
+- Launch the agent with GitHub auth if useful for repo operations.
+- Verify clean worktree and pushed branch state.
+- Post GitHub follow-up comments/replies for accepted feedback items.
+- Resolve review threads after successful in-thread replies.
+- Re-sync GitHub feedback and verify the audit trail.
+
+## GitHub Follow-Up API Surface
+
+Add explicit helpers in `server/github.ts`:
+
+- `replyToReviewThread(...)`
+- `replyToReview(...)`
+- `replyToIssueComment(...)`
+- `resolveReviewThread(...)`
+- `postFollowUpForFeedbackItem(...)`
+
+`postFollowUpForFeedbackItem(...)` should switch on `replyKind`:
+
+- `review_thread`: reply in-thread using the thread id, then resolve the thread
+- `review`: post a PR review comment/body-level follow-up
+- `general_comment`: post a normal issue comment on the PR
+
+Each helper should use Octokit REST or GraphQL directly and route errors through the existing GitHub integration error wrapper.
+
+## Review Thread Lookup Fix
+
+The existing review-thread lookup must page nested thread comments, not just top-level thread pages. The cleanest shape is:
+
+- keep the current `reviewThreads(first: 100, after: $cursor)` pagination,
+- include `comments.pageInfo`,
+- for any thread with more nested comments, page that thread’s comments through a dedicated `node(id: $threadId)` query,
+- add every `databaseId` to the lookup map with `threadId` and `threadResolved`.
+
+This ensures the babysitter always has a usable thread id before it tries to reply or resolve.
+
+## Babysitter Flow Changes
+
+After the agent exits successfully and the branch state is verified:
+
+1. Build or reuse the app-owned Octokit client.
+2. For each accepted comment task, generate a short follow-up body containing:
+   - what was addressed or why it could not be safely applied,
+   - the exact audit token.
+3. Post the follow-up using the appropriate GitHub helper.
+4. Resolve the review thread when the item is `review_thread`.
+5. Re-sync feedback from GitHub.
+6. Verify the audit trail and resolved state.
+
+If app-owned follow-up fails for any item, fail the run and keep the PR in `error`.
+
+## Testing Strategy
+
+Add or extend tests for:
+
+- long-thread lookup pagination in `server/github.test.ts`,
+- reply/resolve helper request shapes in `server/github.test.ts`,
+- successful app-owned follow-up after an agent run in `server/babysitter.test.ts`,
+- failure propagation when GitHub follow-up fails in `server/babysitter.test.ts`.
+
+## Risks
+
+- GitHub GraphQL reply/resolve mutations need exact input ids and response parsing; the tests should pin the request shape tightly.
+- The app must not double-post replies on reruns. The audit-trail verification should stay token-based and the post-follow-up step should only run for accepted tasks in the current run window.
+- Reply text should remain short and deterministic; this is operational output, not a second agent reasoning surface.

--- a/docs/plans/2026-03-15-app-owned-github-follow-up.md
+++ b/docs/plans/2026-03-15-app-owned-github-follow-up.md
@@ -1,0 +1,105 @@
+# App-Owned GitHub Follow-Up Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the app, not the coding agent, post PR feedback follow-up replies and resolve review threads after a successful fix run.
+
+**Architecture:** Extend `server/github.ts` with explicit GitHub follow-up helpers plus robust review-thread lookup pagination, then refactor `PRBabysitter` to call those helpers after branch verification and before audit-trail verification. Keep the agent focused on code changes, tests, commit, and push.
+
+**Tech Stack:** Node.js, TypeScript, Octokit REST/GraphQL, existing babysitter/storage/github modules, Node test runner via `node --test --import tsx`
+
+---
+
+### Task 1: Document And Lock The Reply/Resolve Surface
+
+**Files:**
+- Modify: `server/github.ts`
+- Test: `server/github.test.ts`
+
+**Step 1: Add failing tests for review-thread pagination**
+
+- Simulate a review thread whose nested comments span multiple GraphQL pages.
+- Assert that the returned review comment item gets the correct `threadId` and `threadResolved`.
+
+**Step 2: Add failing tests for follow-up helpers**
+
+- Assert the correct request shape for:
+  - review-thread reply
+  - review-thread resolve
+  - review/body follow-up
+  - general PR comment follow-up
+
+**Step 3: Implement minimal GitHub helpers**
+
+- Add dedicated helper functions for reply and resolve operations.
+- Keep all errors wrapped in `GitHubIntegrationError`.
+
+**Step 4: Run targeted tests**
+
+Run: `node --test --import tsx server/github.test.ts`
+
+**Step 5: Commit**
+
+```bash
+git add server/github.ts server/github.test.ts
+git commit -m "feat: add app-owned github follow-up helpers"
+```
+
+### Task 2: Move Follow-Up Orchestration Into `PRBabysitter`
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Test: `server/babysitter.test.ts`
+
+**Step 1: Add failing tests for app-owned follow-up**
+
+- Success case: agent only changes code; babysitter posts follow-up itself and run ends in `watching`.
+- Failure case: GitHub reply/resolve helper throws; babysitter marks the PR run as `error`.
+
+**Step 2: Refactor the agent contract**
+
+- Remove instructions that make the agent responsible for replying/resolving comments.
+- Keep audit-token context in the prompt so the app can produce deterministic follow-up text.
+
+**Step 3: Implement babysitter-side follow-up**
+
+- After agent success and branch verification, post replies for accepted comment tasks.
+- Resolve review threads for `review_thread` items.
+- Re-sync feedback and keep the existing audit-trail verification.
+
+**Step 4: Run targeted tests**
+
+Run: `node --test --import tsx server/babysitter.test.ts`
+
+**Step 5: Commit**
+
+```bash
+git add server/babysitter.ts server/babysitter.test.ts
+git commit -m "feat: move pr feedback follow-up into babysitter"
+```
+
+### Task 3: End-To-End Verification
+
+**Files:**
+- Modify if needed: `tasks/lessons.md`
+
+**Step 1: Run the focused backend test suite**
+
+Run: `node --test --import tsx server/github.test.ts server/babysitter.test.ts`
+
+**Step 2: Run any directly impacted supporting tests**
+
+Run: `node --test --import tsx server/storage.test.ts`
+
+**Step 3: Review diffs and summarize operational behavior**
+
+- Confirm the app now owns GitHub follow-up.
+- Confirm review-thread metadata is present for long threads.
+- Confirm verification still fails if GitHub follow-up cannot be completed.
+
+**Step 4: Commit**
+
+```bash
+git add tasks/lessons.md
+git commit -m "docs: record babysitter github follow-up lesson"
+```

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -148,6 +148,12 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
     listOpenPullsForRepo: async () => {
       throw new Error("unused in this test");
     },
+    postFollowUpForFeedbackItem: async () => {
+      throw new Error("unused in this test");
+    },
+    resolveReviewThread: async () => {
+      throw new Error("unused in this test");
+    },
     resolveGitHubAuthToken: async () => undefined,
   });
 
@@ -183,6 +189,8 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   let receivedPrompt = "";
   let receivedEnv: NodeJS.ProcessEnv | undefined;
   let feedbackFetchCount = 0;
+  const postedFollowUps: Array<{ id: string; body: string }> = [];
+  const resolvedThreads: string[] = [];
   const pullSummary = makePullSummary(pr);
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
@@ -218,6 +226,12 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
       fetchPullSummary: async () => pullSummary,
       listFailingStatuses: async () => [],
       listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async (_octokit, _parsed, item, body) => {
+        postedFollowUps.push({ id: item.id, body });
+      },
+      resolveReviewThread: async (_octokit, _parsed, threadId) => {
+        resolvedThreads.push(threadId);
+      },
       resolveGitHubAuthToken: async () => "test-token",
     },
     {
@@ -251,12 +265,19 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
 
   assert.equal(updated?.status, "watching");
   assert.equal(updated?.accepted, 1);
+  assert.deepEqual(postedFollowUps, [
+    {
+      id: "gh-review-comment-1",
+      body: "Addressed in commit `def456` by the latest babysitter run.\n\ncodefactory-feedback:gh-review-comment-1",
+    },
+  ]);
+  assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
   assert.ok(logs.some((log) => log.phase === "worktree" && log.message.includes(`Preparing worktree in ${worktreeRoot}`)));
+  assert.ok(logs.some((log) => log.phase === "github.followup" && log.message.includes("GitHub follow-up complete for gh-review-comment-1")));
   assert.ok(logs.some((log) => log.phase === "verify.github" && log.message.includes("GitHub audit trail verified")));
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("Babysitter run complete")));
   assert.match(receivedPrompt, /commit it and push it to origin HEAD:feature\/verbose/i);
-  assert.match(receivedPrompt, /Reply with a short GitHub summary for every addressed feedback item/i);
-  assert.match(receivedPrompt, /Resolve threaded review comments after replying to them/i);
+  assert.match(receivedPrompt, /GitHub follow-up replies and review-thread resolution will be handled by the babysitter/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.equal(receivedEnv?.GITHUB_TOKEN, "test-token");
   assert.equal(receivedEnv?.GH_TOKEN, "test-token");
@@ -264,7 +285,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   delete process.env.CODEFACTORY_HOME;
 });
 
-test("babysitPR marks the run as error when the agent does not leave the required audit trail", async () => {
+test("babysitPR marks the run as error when app-owned GitHub follow-up fails", async () => {
   const storage = new MemStorage();
   const existingItem = makeFeedbackItem();
   const pr = await storage.addPR({
@@ -288,6 +309,7 @@ test("babysitPR marks the run as error when the agent does not leave the require
   process.env.CODEFACTORY_HOME = worktreeRoot;
   let feedbackFetchCount = 0;
   const pullSummary = makePullSummary(pr);
+  let applyCalled = false;
 
   const babysitter = new PRBabysitter(
     storage,
@@ -304,6 +326,10 @@ test("babysitPR marks the run as error when the agent does not leave the require
       fetchPullSummary: async () => pullSummary,
       listFailingStatuses: async () => [],
       listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => {
+        throw new Error("GitHub follow-up failed");
+      },
+      resolveReviewThread: async () => undefined,
       resolveGitHubAuthToken: async () => "test-token",
     },
     {
@@ -313,6 +339,7 @@ test("babysitPR marks the run as error when the agent does not leave the require
         reason: "Comment requires a code change",
       }),
       applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
+        applyCalled = true;
         onStdoutChunk?.("agent stdout line\n");
         onStderrChunk?.("agent stderr line\n");
         return {
@@ -333,9 +360,116 @@ test("babysitPR marks the run as error when the agent does not leave the require
   const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
 
+  assert.equal(applyCalled, true);
   assert.equal(updated?.status, "error");
-  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub audit trail verification failed")));
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub follow-up failed")));
   assert.ok(logs.some((log) => log.phase === "cleanup" && log.message.includes("Worktree cleanup complete")));
 
   delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR retries accepted feedback items that still need GitHub follow-up without rerunning the agent", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem({
+    decision: "accept",
+    decisionReason: "Already fixed in a previous run",
+    action: "Please rename this variable.",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let feedbackFetchCount = 0;
+  let applyCalled = false;
+  const postedFollowUps: Array<{ id: string; body: string }> = [];
+  const resolvedThreads: string[] = [];
+  const pullSummary = makePullSummary(pr);
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    decision: null,
+    decisionReason: null,
+    action: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem];
+        }
+
+        return [
+          { ...existingItem, threadResolved: true },
+          followUp,
+        ];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async (_octokit, _parsed, item, body) => {
+        postedFollowUps.push({ id: item.id, body });
+      },
+      resolveReviewThread: async (_octokit, _parsed, threadId) => {
+        resolvedThreads.push(threadId);
+      },
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No new code change required",
+      }),
+      applyFixesWithAgent: async () => {
+        applyCalled = true;
+        return {
+          code: 0,
+          stdout: "",
+          stderr: "",
+        };
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(applyCalled, false);
+  assert.equal(updated?.status, "watching");
+  assert.deepEqual(postedFollowUps, [
+    {
+      id: "gh-review-comment-1",
+      body: "Addressed in commit `abc123` by the latest babysitter run.\n\ncodefactory-feedback:gh-review-comment-1",
+    },
+  ]);
+  assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("awaiting GitHub follow-up")));
 });

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -473,3 +473,102 @@ test("babysitPR retries accepted feedback items that still need GitHub follow-up
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("awaiting GitHub follow-up")));
 });
+
+test("babysitPR resolves lingering review threads without reposting an existing audit trail", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem({
+    decision: "accept",
+    decisionReason: "Already fixed in a previous run",
+    action: "Please rename this variable.",
+  });
+  const priorFollowUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: false,
+    createdAt: new Date().toISOString(),
+    decision: null,
+    decisionReason: null,
+    action: null,
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem, priorFollowUp],
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let feedbackFetchCount = 0;
+  let applyCalled = false;
+  const postedFollowUps: Array<{ id: string; body: string }> = [];
+  const resolvedThreads: string[] = [];
+  const pullSummary = makePullSummary(pr);
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem, priorFollowUp];
+        }
+
+        return [
+          { ...existingItem, threadResolved: true },
+          priorFollowUp,
+        ];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async (_octokit, _parsed, item, body) => {
+        postedFollowUps.push({ id: item.id, body });
+      },
+      resolveReviewThread: async (_octokit, _parsed, threadId) => {
+        resolvedThreads.push(threadId);
+      },
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No new code change required",
+      }),
+      applyFixesWithAgent: async () => {
+        applyCalled = true;
+        return {
+          code: 0,
+          stdout: "",
+          stderr: "",
+        };
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+
+  assert.equal(applyCalled, false);
+  assert.equal(updated?.status, "watching");
+  assert.deepEqual(postedFollowUps, []);
+  assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
+});

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -16,6 +16,8 @@ import {
   listFailingStatuses,
   listOpenPullsForRepo,
   parseRepoSlug,
+  postFollowUpForFeedbackItem,
+  resolveReviewThread,
   resolveGitHubAuthToken,
   type GitHubPullSummary,
   type ParsedPRUrl,
@@ -32,6 +34,8 @@ type GitHubService = {
   fetchPullSummary: typeof fetchPullSummary;
   listFailingStatuses: typeof listFailingStatuses;
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
+  postFollowUpForFeedbackItem: typeof postFollowUpForFeedbackItem;
+  resolveReviewThread: typeof resolveReviewThread;
   resolveGitHubAuthToken: typeof resolveGitHubAuthToken;
 };
 
@@ -48,6 +52,8 @@ const defaultGitHubService: GitHubService = {
   fetchPullSummary,
   listFailingStatuses,
   listOpenPullsForRepo,
+  postFollowUpForFeedbackItem,
+  resolveReviewThread,
   resolveGitHubAuthToken,
 };
 
@@ -195,9 +201,9 @@ function buildAgentFixPrompt(params: {
     "Make only targeted changes that resolve the approved tasks.",
     "Do not wait for user input, confirmation, or approval at any point.",
     "Do not rewrite unrelated files.",
-    "Use the available git and GitHub tooling in this environment.",
-    "If GitHub authentication is available via GITHUB_TOKEN or GH_TOKEN, use it for any required GitHub follow-up.",
-    "If a task is invalid after inspection, leave a short GitHub explanation with the audit token and explain it in your final response.",
+    "Use the available git tooling in this environment.",
+    "GitHub follow-up replies and review-thread resolution will be handled by the babysitter after your run.",
+    "If a task is invalid after inspection, explain it in your final response and include the exact audit token.",
     "",
     "Approved review-comment tasks:",
     commentSection,
@@ -208,14 +214,16 @@ function buildAgentFixPrompt(params: {
     "When done:",
     "1) Run the relevant verification for your changes.",
     `2) If you changed code, commit it and push it to ${remoteName} HEAD:${pullSummary.headRef}.`,
-    "3) Reply with a short GitHub summary for every addressed feedback item and include the exact audit token for that item.",
-    "4) Resolve threaded review comments after replying to them.",
-    "5) If an item cannot be fixed safely, leave a short explanatory GitHub reply/comment with the audit token.",
-    "6) Summarize the code changes, verification, git actions, and GitHub follow-up you completed.",
+    "3) Summarize every addressed or blocked feedback item in your final response and include the exact audit token for each item.",
+    "4) Summarize the code changes, verification, and git actions you completed.",
   ].join("\n");
 }
 
-function hasRecentAuditTrail(item: FeedbackItem, feedbackItems: FeedbackItem[], runStartedAtMs: number): boolean {
+function hasAuditTrail(
+  item: FeedbackItem,
+  feedbackItems: FeedbackItem[],
+  runStartedAtMs?: number,
+): boolean {
   return feedbackItems.some((candidate) => {
     if (candidate.id === item.id || !candidate.body.includes(item.auditToken)) {
       return false;
@@ -226,20 +234,24 @@ function hasRecentAuditTrail(item: FeedbackItem, feedbackItems: FeedbackItem[], 
       return false;
     }
 
-    return createdAtMs >= runStartedAtMs;
+    if (typeof runStartedAtMs === "number") {
+      return createdAtMs >= runStartedAtMs;
+    }
+
+    return true;
   });
 }
 
 function collectAuditTrailErrors(params: {
   pr: PR;
-  commentTasks: FeedbackItem[];
+  followUpTasks: FeedbackItem[];
   runStartedAtMs: number;
 }): string[] {
-  const { pr, commentTasks, runStartedAtMs } = params;
+  const { pr, followUpTasks, runStartedAtMs } = params;
   const errors: string[] = [];
 
-  for (const item of commentTasks) {
-    if (!hasRecentAuditTrail(item, pr.feedbackItems, runStartedAtMs)) {
+  for (const item of followUpTasks) {
+    if (!hasAuditTrail(item, pr.feedbackItems, runStartedAtMs)) {
       errors.push(`missing audit trail for ${item.id}`);
     }
 
@@ -252,6 +264,35 @@ function collectAuditTrailErrors(params: {
   }
 
   return errors;
+}
+
+function needsGitHubFollowUp(item: FeedbackItem, feedbackItems: FeedbackItem[]): boolean {
+  if (item.decision !== "accept") {
+    return false;
+  }
+
+  if (!hasAuditTrail(item, feedbackItems)) {
+    return true;
+  }
+
+  return item.replyKind === "review_thread" && !item.threadResolved;
+}
+
+function collectGitHubFollowUpTasks(pr: PR): FeedbackItem[] {
+  return pr.feedbackItems.filter((item) => needsGitHubFollowUp(item, pr.feedbackItems));
+}
+
+function buildFeedbackFollowUpBody(headSha: string, auditToken: string): string {
+  const shortSha = headSha.trim() ? headSha.trim().slice(0, 7) : "";
+  const summary = shortSha
+    ? `Addressed in commit \`${shortSha}\` by the latest babysitter run.`
+    : "Addressed in the latest babysitter run.";
+
+  return [
+    summary,
+    "",
+    auditToken,
+  ].join("\n");
 }
 
 function formatCommand(command: string, args: string[]): string {
@@ -674,7 +715,9 @@ export class PRBabysitter {
         }
       }
 
-      if (commentTasks.length === 0 && statusTasks.length === 0) {
+      const followUpTasks = collectGitHubFollowUpTasks(pr);
+
+      if (commentTasks.length === 0 && statusTasks.length === 0 && followUpTasks.length === 0) {
         await queueLog(pr.id, "info", `Babysitter checked PR #${pr.number}; no necessary fixes identified`, {
           phase: "run",
         });
@@ -685,233 +728,288 @@ export class PRBabysitter {
         return;
       }
 
-      await queueLog(
-        pr.id,
-        "info",
-        `Babysitter preparing fix run with ${commentTasks.length} comment task(s) and ${statusTasks.length} status task(s) using ${agent}`,
-        {
-          phase: "run",
-          metadata: {
-            commentTasks: commentTasks.length,
-            statusTasks: statusTasks.length,
-            agent,
+      let headShaForFollowUp = pullSummary.headSha;
+      let branchMoved = false;
+      let remoteNameForLogs: string | null = null;
+
+      if (commentTasks.length > 0 || statusTasks.length > 0) {
+        await queueLog(
+          pr.id,
+          "info",
+          `Babysitter preparing fix run with ${commentTasks.length} comment task(s), ${statusTasks.length} status task(s), and ${followUpTasks.length} GitHub follow-up task(s) using ${agent}`,
+          {
+            phase: "run",
+            metadata: {
+              commentTasks: commentTasks.length,
+              statusTasks: statusTasks.length,
+              followUpTasks: followUpTasks.length,
+              agent,
+            },
           },
-        },
-      );
+        );
 
-      const codeFactoryPaths = getCodeFactoryPaths();
-      await queueLog(pr.id, "info", `Preparing worktree in ${codeFactoryPaths.rootDir}`, {
-        phase: "worktree",
-      });
-      const { repoCacheDir, worktreePath, healed, remoteName } = await preparePrWorktree({
-        rootDir: codeFactoryPaths.rootDir,
-        repoFullName: pullSummary.repoFullName,
-        repoCloneUrl: pullSummary.repoCloneUrl,
-        headRepoFullName: pullSummary.headRepoFullName,
-        headRepoCloneUrl: pullSummary.headRepoCloneUrl,
-        headRef: pullSummary.headRef,
-        prNumber: pr.number,
-        runId,
-        runCommand: this.runtime.runCommand,
-      });
-
-      try {
-        await queueLog(pr.id, "info", `Worktree ready at ${worktreePath}`, {
+        const codeFactoryPaths = getCodeFactoryPaths();
+        await queueLog(pr.id, "info", `Preparing worktree in ${codeFactoryPaths.rootDir}`, {
           phase: "worktree",
-          metadata: { remoteName, healed },
         });
-        if (healed) {
-          await queueLog(pr.id, "info", "Repo cache required auto-heal before the worktree was created", {
-            phase: "worktree",
-            metadata: { repoCacheDir },
-          });
-        }
-        await queueLog(pr.id, "info", `Prepared PR head from remote ${remoteName}`, {
-          phase: "worktree",
-          metadata: { remoteName, headRef: pullSummary.headRef },
-        });
-        await queueLog(pr.id, "info", "Ensuring git identity", {
-          phase: "git.identity",
-        });
-        await ensureGitIdentity(worktreePath, this.runtime.runCommand);
-        await queueLog(pr.id, "info", "Git identity ready", {
-          phase: "git.identity",
-        });
-
-        const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info");
-        const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "warn");
-        const githubToken = await this.github.resolveGitHubAuthToken(config);
-        const agentEnv = githubToken
-          ? {
-              ...process.env,
-              GITHUB_TOKEN: githubToken,
-              GH_TOKEN: githubToken,
-            }
-          : undefined;
-        await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
-          phase: "agent",
-          metadata: { githubAuth: Boolean(githubToken) },
-        });
-
-        const applyResult = await this.runtime.applyFixesWithAgent({
-          agent,
-          cwd: worktreePath,
-          prompt: buildAgentFixPrompt({
-            pr,
-            pullSummary,
-            remoteName,
-            commentTasks,
-            statusTasks,
-          }),
-          env: agentEnv,
-          onStdoutChunk: agentStdout.onChunk,
-          onStderrChunk: agentStderr.onChunk,
-        });
-        await agentStdout.flush();
-        await agentStderr.flush();
-
-        if (applyResult.code !== 0) {
-          throw new Error(`Agent apply failed (${applyResult.code}): ${applyResult.stderr || applyResult.stdout}`);
-        }
-        await queueLog(pr.id, "info", `${agent} completed successfully`, {
-          phase: "agent",
-          metadata: { code: applyResult.code },
-        });
-
-        const status = await runLoggedCommand({
-          currentPrId: pr.id,
-          command: "git",
-          args: ["status", "--porcelain"],
-          cwd: worktreePath,
-          timeoutMs: 5000,
-          phase: "verify.git.status",
-          successMessage: "Collected worktree git status",
-        });
-        if (status.code !== 0) {
-          throw new Error(`git status failed: ${status.stderr || status.stdout}`);
-        }
-
-        if (status.stdout.trim()) {
-          throw new Error(`Agent left uncommitted changes in the worktree: ${status.stdout.trim()}`);
-        }
-        await queueLog(pr.id, "info", "Worktree is clean after agent run", {
-          phase: "verify.git.status",
-        });
-
-        const localHead = await runLoggedCommand({
-          currentPrId: pr.id,
-          command: "git",
-          args: ["rev-parse", "HEAD"],
-          cwd: worktreePath,
-          timeoutMs: 5000,
-          phase: "verify.git.local-head",
-          successMessage: "Collected worktree HEAD",
-        });
-        if (localHead.code !== 0) {
-          throw new Error(`git rev-parse HEAD failed: ${localHead.stderr || localHead.stdout}`);
-        }
-
-        const remoteFetch = await runLoggedCommand({
-          currentPrId: pr.id,
-          command: "git",
-          args: ["-C", repoCacheDir, "fetch", remoteName, pullSummary.headRef],
-          timeoutMs: 120000,
-          phase: "verify.git.fetch-head",
-          successMessage: `Fetched ${remoteName}/${pullSummary.headRef} for verification`,
-        });
-        if (remoteFetch.code !== 0) {
-          throw new Error(`git fetch ${remoteName} ${pullSummary.headRef} failed: ${remoteFetch.stderr || remoteFetch.stdout}`);
-        }
-
-        const remoteHead = await runLoggedCommand({
-          currentPrId: pr.id,
-          command: "git",
-          args: ["-C", repoCacheDir, "rev-parse", "FETCH_HEAD"],
-          timeoutMs: 5000,
-          phase: "verify.git.remote-head",
-          successMessage: "Collected remote PR head SHA",
-        });
-        if (remoteHead.code !== 0) {
-          throw new Error(`git rev-parse FETCH_HEAD failed: ${remoteHead.stderr || remoteHead.stdout}`);
-        }
-
-        const localHeadSha = localHead.stdout.trim();
-        const remoteHeadSha = remoteHead.stdout.trim();
-        const branchMoved = remoteHeadSha !== pullSummary.headSha;
-        const localCommitCreated = localHeadSha !== pullSummary.headSha;
-
-        if (localCommitCreated && remoteHeadSha !== localHeadSha) {
-          throw new Error("Agent created a local commit but did not push it to the PR head branch");
-        }
-
-        if (statusTasks.length > 0 && !branchMoved) {
-          throw new Error("Agent did not update the PR head branch for accepted failing status tasks");
-        }
-
-        await queueLog(pr.id, "info", "Verified git branch state after agent run", {
-          phase: "verify.git",
-          metadata: {
-            initialHeadSha: pullSummary.headSha,
-            localHeadSha,
-            remoteHeadSha,
-            branchMoved,
-            localCommitCreated,
-            remoteName,
-          },
-        });
-
-        pr = await this.syncFeedbackForPR(pr.id, {
+        const { repoCacheDir, worktreePath, healed, remoteName } = await preparePrWorktree({
+          rootDir: codeFactoryPaths.rootDir,
+          repoFullName: pullSummary.repoFullName,
+          repoCloneUrl: pullSummary.repoCloneUrl,
+          headRepoFullName: pullSummary.headRepoFullName,
+          headRepoCloneUrl: pullSummary.headRepoCloneUrl,
+          headRef: pullSummary.headRef,
+          prNumber: pr.number,
           runId,
-          logStart: true,
-          phase: "verify.sync",
+          runCommand: this.runtime.runCommand,
         });
 
-        const auditTrailErrors = collectAuditTrailErrors({
-          pr,
-          commentTasks,
-          runStartedAtMs: auditWindowStartMs,
-        });
-        if (auditTrailErrors.length > 0) {
-          throw new Error(`GitHub audit trail verification failed: ${auditTrailErrors.join("; ")}`);
+        remoteNameForLogs = remoteName;
+
+        try {
+          await queueLog(pr.id, "info", `Worktree ready at ${worktreePath}`, {
+            phase: "worktree",
+            metadata: { remoteName, healed },
+          });
+          if (healed) {
+            await queueLog(pr.id, "info", "Repo cache required auto-heal before the worktree was created", {
+              phase: "worktree",
+              metadata: { repoCacheDir },
+            });
+          }
+          await queueLog(pr.id, "info", `Prepared PR head from remote ${remoteName}`, {
+            phase: "worktree",
+            metadata: { remoteName, headRef: pullSummary.headRef },
+          });
+          await queueLog(pr.id, "info", "Ensuring git identity", {
+            phase: "git.identity",
+          });
+          await ensureGitIdentity(worktreePath, this.runtime.runCommand);
+          await queueLog(pr.id, "info", "Git identity ready", {
+            phase: "git.identity",
+          });
+
+          const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info");
+          const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "warn");
+          const githubToken = await this.github.resolveGitHubAuthToken(config);
+          const agentEnv = githubToken
+            ? {
+                ...process.env,
+                GITHUB_TOKEN: githubToken,
+                GH_TOKEN: githubToken,
+              }
+            : undefined;
+          await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
+            phase: "agent",
+            metadata: { githubAuth: Boolean(githubToken) },
+          });
+
+          const applyResult = await this.runtime.applyFixesWithAgent({
+            agent,
+            cwd: worktreePath,
+            prompt: buildAgentFixPrompt({
+              pr,
+              pullSummary,
+              remoteName,
+              commentTasks,
+              statusTasks,
+            }),
+            env: agentEnv,
+            onStdoutChunk: agentStdout.onChunk,
+            onStderrChunk: agentStderr.onChunk,
+          });
+          await agentStdout.flush();
+          await agentStderr.flush();
+
+          if (applyResult.code !== 0) {
+            throw new Error(`Agent apply failed (${applyResult.code}): ${applyResult.stderr || applyResult.stdout}`);
+          }
+          await queueLog(pr.id, "info", `${agent} completed successfully`, {
+            phase: "agent",
+            metadata: { code: applyResult.code },
+          });
+
+          const status = await runLoggedCommand({
+            currentPrId: pr.id,
+            command: "git",
+            args: ["status", "--porcelain"],
+            cwd: worktreePath,
+            timeoutMs: 5000,
+            phase: "verify.git.status",
+            successMessage: "Collected worktree git status",
+          });
+          if (status.code !== 0) {
+            throw new Error(`git status failed: ${status.stderr || status.stdout}`);
+          }
+
+          if (status.stdout.trim()) {
+            throw new Error(`Agent left uncommitted changes in the worktree: ${status.stdout.trim()}`);
+          }
+          await queueLog(pr.id, "info", "Worktree is clean after agent run", {
+            phase: "verify.git.status",
+          });
+
+          const localHead = await runLoggedCommand({
+            currentPrId: pr.id,
+            command: "git",
+            args: ["rev-parse", "HEAD"],
+            cwd: worktreePath,
+            timeoutMs: 5000,
+            phase: "verify.git.local-head",
+            successMessage: "Collected worktree HEAD",
+          });
+          if (localHead.code !== 0) {
+            throw new Error(`git rev-parse HEAD failed: ${localHead.stderr || localHead.stdout}`);
+          }
+
+          const remoteFetch = await runLoggedCommand({
+            currentPrId: pr.id,
+            command: "git",
+            args: ["-C", repoCacheDir, "fetch", remoteName, pullSummary.headRef],
+            timeoutMs: 120000,
+            phase: "verify.git.fetch-head",
+            successMessage: `Fetched ${remoteName}/${pullSummary.headRef} for verification`,
+          });
+          if (remoteFetch.code !== 0) {
+            throw new Error(`git fetch ${remoteName} ${pullSummary.headRef} failed: ${remoteFetch.stderr || remoteFetch.stdout}`);
+          }
+
+          const remoteHead = await runLoggedCommand({
+            currentPrId: pr.id,
+            command: "git",
+            args: ["-C", repoCacheDir, "rev-parse", "FETCH_HEAD"],
+            timeoutMs: 5000,
+            phase: "verify.git.remote-head",
+            successMessage: "Collected remote PR head SHA",
+          });
+          if (remoteHead.code !== 0) {
+            throw new Error(`git rev-parse FETCH_HEAD failed: ${remoteHead.stderr || remoteHead.stdout}`);
+          }
+
+          const localHeadSha = localHead.stdout.trim();
+          const remoteHeadSha = remoteHead.stdout.trim();
+          branchMoved = remoteHeadSha !== pullSummary.headSha;
+          const localCommitCreated = localHeadSha !== pullSummary.headSha;
+
+          if (localCommitCreated && remoteHeadSha !== localHeadSha) {
+            throw new Error("Agent created a local commit but did not push it to the PR head branch");
+          }
+
+          if (statusTasks.length > 0 && !branchMoved) {
+            throw new Error("Agent did not update the PR head branch for accepted failing status tasks");
+          }
+
+          headShaForFollowUp = localHeadSha;
+
+          await queueLog(pr.id, "info", "Verified git branch state after agent run", {
+            phase: "verify.git",
+            metadata: {
+              initialHeadSha: pullSummary.headSha,
+              localHeadSha,
+              remoteHeadSha,
+              branchMoved,
+              localCommitCreated,
+              remoteName,
+            },
+          });
+        } finally {
+          try {
+            await queueLog(pr.id, "info", "Cleaning up worktree", {
+              phase: "cleanup",
+            });
+            await removePrWorktree({
+              repoCacheDir,
+              worktreePath,
+              runCommand: this.runtime.runCommand,
+            });
+            await queueLog(pr.id, "info", "Worktree cleanup complete", {
+              phase: "cleanup",
+            });
+          } catch (cleanupError) {
+            const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+            await queueLog(pr.id, "error", `Worktree cleanup failed: ${cleanupMessage}`, {
+              phase: "cleanup",
+            });
+          }
         }
+      } else {
+        await queueLog(
+          pr.id,
+          "info",
+          `Babysitter found ${followUpTasks.length} accepted feedback item(s) awaiting GitHub follow-up`,
+          {
+            phase: "run",
+            metadata: {
+              followUpTasks: followUpTasks.length,
+              agent,
+            },
+          },
+        );
+      }
 
-        await queueLog(pr.id, "info", "GitHub audit trail verified", {
-          phase: "verify.github",
+      for (const item of followUpTasks) {
+        await queueLog(pr.id, "info", `Posting GitHub follow-up for ${item.id}`, {
+          phase: "github.followup",
           metadata: {
-            verifiedComments: commentTasks.length,
-            remoteName,
-            branchMoved,
+            feedbackId: item.id,
+            replyKind: item.replyKind,
           },
         });
 
-        await this.storage.updatePR(pr.id, {
-          status: "watching",
-          lastChecked: new Date().toISOString(),
-        });
-        await queueLog(pr.id, "info", "Babysitter run complete", {
-          phase: "run",
-          metadata: { remoteName, branchMoved },
-        });
-      } finally {
-        try {
-          await queueLog(pr.id, "info", "Cleaning up worktree", {
-            phase: "cleanup",
-          });
-          await removePrWorktree({
-            repoCacheDir,
-            worktreePath,
-            runCommand: this.runtime.runCommand,
-          });
-          await queueLog(pr.id, "info", "Worktree cleanup complete", {
-            phase: "cleanup",
-          });
-        } catch (cleanupError) {
-          const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-          await queueLog(pr.id, "error", `Worktree cleanup failed: ${cleanupMessage}`, {
-            phase: "cleanup",
-          });
+        const body = buildFeedbackFollowUpBody(headShaForFollowUp, item.auditToken);
+        await this.github.postFollowUpForFeedbackItem(octokit, parsedPr, item, body);
+
+        if (item.replyKind === "review_thread") {
+          if (!item.threadId) {
+            throw new Error(`Missing review thread metadata for ${item.id}`);
+          }
+
+          await this.github.resolveReviewThread(octokit, parsedPr, item.threadId);
         }
+
+        await queueLog(pr.id, "info", `GitHub follow-up complete for ${item.id}`, {
+          phase: "github.followup",
+          metadata: {
+            feedbackId: item.id,
+            replyKind: item.replyKind,
+            resolved: item.replyKind === "review_thread",
+          },
+        });
       }
+
+      pr = await this.syncFeedbackForPR(pr.id, {
+        runId,
+        logStart: true,
+        phase: "verify.sync",
+      });
+
+      const auditTrailErrors = collectAuditTrailErrors({
+        pr,
+        followUpTasks,
+        runStartedAtMs: auditWindowStartMs,
+      });
+      if (auditTrailErrors.length > 0) {
+        throw new Error(`GitHub audit trail verification failed: ${auditTrailErrors.join("; ")}`);
+      }
+
+      await queueLog(pr.id, "info", "GitHub audit trail verified", {
+        phase: "verify.github",
+        metadata: {
+          verifiedComments: followUpTasks.length,
+          remoteName: remoteNameForLogs,
+          branchMoved,
+        },
+      });
+
+      await this.storage.updatePR(pr.id, {
+        status: "watching",
+        lastChecked: new Date().toISOString(),
+      });
+      await queueLog(pr.id, "info", "Babysitter run complete", {
+        phase: "run",
+        metadata: { remoteName: remoteNameForLogs, branchMoved },
+      });
+      return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const pr = await this.storage.getPR(prId);

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -948,18 +948,23 @@ export class PRBabysitter {
       }
 
       for (const item of followUpTasks) {
-        await queueLog(pr.id, "info", `Posting GitHub follow-up for ${item.id}`, {
-          phase: "github.followup",
-          metadata: {
-            feedbackId: item.id,
-            replyKind: item.replyKind,
-          },
-        });
+        const shouldPostFollowUp = !hasAuditTrail(item, pr.feedbackItems);
+        const shouldResolveThread = item.replyKind === "review_thread" && !item.threadResolved;
 
-        const body = buildFeedbackFollowUpBody(headShaForFollowUp, item.auditToken);
-        await this.github.postFollowUpForFeedbackItem(octokit, parsedPr, item, body);
+        if (shouldPostFollowUp) {
+          await queueLog(pr.id, "info", `Posting GitHub follow-up for ${item.id}`, {
+            phase: "github.followup",
+            metadata: {
+              feedbackId: item.id,
+              replyKind: item.replyKind,
+            },
+          });
 
-        if (item.replyKind === "review_thread") {
+          const body = buildFeedbackFollowUpBody(headShaForFollowUp, item.auditToken);
+          await this.github.postFollowUpForFeedbackItem(octokit, parsedPr, item, body);
+        }
+
+        if (shouldResolveThread) {
           if (!item.threadId) {
             throw new Error(`Missing review thread metadata for ${item.id}`);
           }
@@ -972,7 +977,8 @@ export class PRBabysitter {
           metadata: {
             feedbackId: item.id,
             replyKind: item.replyKind,
-            resolved: item.replyKind === "review_thread",
+            posted: shouldPostFollowUp,
+            resolved: shouldResolveThread,
           },
         });
       }

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { Config } from "@shared/schema";
-import { fetchFeedbackItemsForPR } from "./github";
+import type { Config, FeedbackItem } from "@shared/schema";
+import {
+  fetchFeedbackItemsForPR,
+  postFollowUpForFeedbackItem,
+  resolveReviewThread,
+} from "./github";
 
 const config: Config = {
   githubToken: "",
@@ -15,6 +19,30 @@ const config: Config = {
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],
 };
+
+function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    id: "gh-review-comment-1",
+    author: "reviewer",
+    body: "Please fix this",
+    bodyHtml: "<p>Please fix this</p>",
+    replyKind: "review_thread",
+    sourceId: "1",
+    sourceNodeId: "PRRC_kwDO_comment",
+    sourceUrl: "https://github.com/octo/example/pull/42#discussion_r1",
+    threadId: "THREAD_node_123",
+    threadResolved: false,
+    auditToken: "codefactory-feedback:gh-review-comment-1",
+    file: "src/example.ts",
+    line: 12,
+    type: "review_comment",
+    createdAt: "2026-03-15T10:45:00Z",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    ...overrides,
+  };
+}
 
 test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored", async () => {
   let callIndex = 0;
@@ -151,6 +179,7 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
   const listReviews = Symbol("listReviews");
   const listIssueComments = Symbol("listIssueComments");
   const graphqlCalls: Array<{
+    query: string;
     threadId?: string;
     cursor?: string | null;
   }> = [];
@@ -185,12 +214,9 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
 
       throw new Error("Unexpected paginate call");
     },
-    request: async (_route: string, params: {
-      query: string;
-      threadId?: string;
-      cursor?: string | null;
-    }) => {
+    request: async (_route: string, params: { query: string; threadId?: string; cursor?: string | null }) => {
       graphqlCalls.push({
+        query: params.query,
         threadId: params.threadId,
         cursor: params.cursor ?? null,
       });
@@ -227,30 +253,26 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
         };
       }
 
-      if (params.query.includes("CodeFactoryReviewThreadComments")) {
-        assert.equal(params.threadId, "THREAD_node_999");
-        assert.equal(params.cursor, "cursor-100");
+      assert.equal(params.threadId, "THREAD_node_999");
+      assert.equal(params.cursor, "cursor-100");
 
-        return {
-          data: {
-            node: {
-              id: "THREAD_node_999",
-              isResolved: true,
-              comments: {
-                nodes: [
-                  { databaseId: 101 },
-                ],
-                pageInfo: {
-                  hasNextPage: false,
-                  endCursor: null,
-                },
+      return {
+        data: {
+          node: {
+            id: "THREAD_node_999",
+            isResolved: true,
+            comments: {
+              nodes: [
+                { databaseId: 101 },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
               },
             },
           },
-        };
-      }
-
-      throw new Error("Unexpected GraphQL query");
+        },
+      };
     },
     pulls: {
       listReviewComments,
@@ -271,7 +293,10 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
   assert.equal(items[0]?.sourceId, "101");
   assert.equal(items[0]?.threadId, "THREAD_node_999");
   assert.equal(items[0]?.threadResolved, true);
-  assert.deepEqual(graphqlCalls, [
+  assert.deepEqual(graphqlCalls.map(({ threadId, cursor }) => ({
+    threadId,
+    cursor,
+  })), [
     {
       threadId: undefined,
       cursor: null,
@@ -279,6 +304,112 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
     {
       threadId: "THREAD_node_999",
       cursor: "cursor-100",
+    },
+  ]);
+  assert.match(graphqlCalls[0]?.query || "", /CodeFactoryReviewThreads/);
+  assert.match(graphqlCalls[1]?.query || "", /CodeFactoryReviewThreadComments/);
+});
+
+test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThread resolves them", async () => {
+  const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
+
+  const octokit = {
+    request: async (route: string, params: Record<string, unknown>) => {
+      requests.push({ route, params });
+      return {
+        data: {
+          ok: true,
+        },
+      };
+    },
+    issues: {
+      createComment: async () => {
+        throw new Error("unexpected issue comment");
+      },
+    },
+  };
+
+  await postFollowUpForFeedbackItem(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    makeFeedbackItem(),
+    "Addressed in the latest babysitter update.\n\ncodefactory-feedback:gh-review-comment-1",
+  );
+  await resolveReviewThread(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    "THREAD_node_123",
+  );
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0]?.route, "POST /graphql");
+  assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
+  assert.equal(requests[0]?.params.threadId, "THREAD_node_123");
+  assert.equal(
+    requests[0]?.params.body,
+    "Addressed in the latest babysitter update.\n\ncodefactory-feedback:gh-review-comment-1",
+  );
+  assert.equal(requests[1]?.route, "POST /graphql");
+  assert.match(String(requests[1]?.params.query || ""), /resolveReviewThread/);
+  assert.equal(requests[1]?.params.threadId, "THREAD_node_123");
+});
+
+test("postFollowUpForFeedbackItem routes review and general comments to PR comments", async () => {
+  const comments: Array<Record<string, unknown>> = [];
+
+  const octokit = {
+    request: async () => {
+      throw new Error("unexpected graphql request");
+    },
+    issues: {
+      createComment: async (params: Record<string, unknown>) => {
+        comments.push(params);
+        return {
+          data: {
+            id: 123,
+          },
+        };
+      },
+    },
+  };
+
+  await postFollowUpForFeedbackItem(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    makeFeedbackItem({
+      id: "gh-review-2",
+      replyKind: "review",
+      type: "review",
+      threadId: null,
+      threadResolved: null,
+    }),
+    "Review follow-up",
+  );
+  await postFollowUpForFeedbackItem(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    makeFeedbackItem({
+      id: "gh-issue-comment-3",
+      replyKind: "general_comment",
+      type: "general_comment",
+      threadId: null,
+      threadResolved: null,
+    }),
+    "General follow-up",
+  );
+
+  assert.deepEqual(comments, [
+    {
+      owner: "octo",
+      repo: "example",
+      issue_number: 42,
+      body: "Review follow-up",
+    },
+    {
+      owner: "octo",
+      repo: "example",
+      issue_number: 42,
+      body: "General follow-up",
     },
   ]);
 });

--- a/server/github.ts
+++ b/server/github.ts
@@ -63,7 +63,6 @@ const REVIEW_THREADS_QUERY = `
     }
   }
 `;
-
 const REVIEW_THREAD_COMMENTS_QUERY = `
   query CodeFactoryReviewThreadComments($threadId: ID!, $cursor: String) {
     node(id: $threadId) {
@@ -79,6 +78,25 @@ const REVIEW_THREAD_COMMENTS_QUERY = `
             endCursor
           }
         }
+      }
+    }
+  }
+`;
+const REVIEW_THREAD_REPLY_MUTATION = `
+  mutation CodeFactoryReplyToReviewThread($threadId: ID!, $body: String!) {
+    addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) {
+      comment {
+        id
+      }
+    }
+  }
+`;
+const RESOLVE_REVIEW_THREAD_MUTATION = `
+  mutation CodeFactoryResolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread {
+        id
+        isResolved
       }
     }
   }
@@ -145,23 +163,20 @@ type ReviewThreadLookup = Map<number, {
   threadId: string;
   threadResolved: boolean;
 }>;
-
-type ReviewThreadCommentNode = {
-  databaseId?: number | null;
-};
-
 type ReviewThreadCommentsConnection = {
-  nodes?: ReviewThreadCommentNode[];
+  nodes?: Array<{
+    databaseId?: number | null;
+  }> | null;
   pageInfo?: {
     hasNextPage?: boolean | null;
     endCursor?: string | null;
-  };
+  } | null;
 };
 
 type ReviewThreadNode = {
   id?: string | null;
   isResolved?: boolean | null;
-  comments?: ReviewThreadCommentsConnection;
+  comments?: ReviewThreadCommentsConnection | null;
 };
 
 export function buildFeedbackAuditToken(feedbackId: string): string {
@@ -340,6 +355,74 @@ function shouldIgnoreAuthor(
   return false;
 }
 
+function addReviewThreadCommentsToLookup(
+  lookup: ReviewThreadLookup,
+  threadId: string,
+  threadResolved: boolean,
+  comments?: ReviewThreadCommentsConnection | null,
+): void {
+  for (const comment of comments?.nodes || []) {
+    if (typeof comment?.databaseId !== "number") {
+      continue;
+    }
+
+    lookup.set(comment.databaseId, {
+      threadId,
+      threadResolved,
+    });
+  }
+}
+
+async function appendPaginatedReviewThreadComments(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  lookup: ReviewThreadLookup,
+  thread: ReviewThreadNode,
+): Promise<void> {
+  if (!thread.id) {
+    return;
+  }
+
+  let cursor = thread.comments?.pageInfo?.hasNextPage && thread.comments.pageInfo.endCursor
+    ? thread.comments.pageInfo.endCursor
+    : null;
+  let threadResolved = Boolean(thread.isResolved);
+
+  while (cursor) {
+    const response = await withGitHubErrorHandling("review thread comments", parsed, () =>
+      octokit.request("POST /graphql", {
+        query: REVIEW_THREAD_COMMENTS_QUERY,
+        threadId: thread.id,
+        cursor,
+      }),
+    );
+
+    const paginatedThread = (response.data as {
+      node?: ReviewThreadNode | null;
+    }).node;
+
+    if (!paginatedThread?.id) {
+      break;
+    }
+
+    if (typeof paginatedThread.isResolved === "boolean") {
+      threadResolved = paginatedThread.isResolved;
+    }
+
+    addReviewThreadCommentsToLookup(
+      lookup,
+      paginatedThread.id,
+      threadResolved,
+      paginatedThread.comments,
+    );
+
+    const pageInfo = paginatedThread.comments?.pageInfo;
+    cursor = pageInfo?.hasNextPage && pageInfo.endCursor
+      ? pageInfo.endCursor
+      : null;
+  }
+}
+
 async function fetchReviewThreadLookup(
   octokit: Octokit,
   parsed: ParsedPRUrl,
@@ -392,70 +475,88 @@ async function fetchReviewThreadLookup(
   return lookup;
 }
 
-function addReviewThreadCommentsToLookup(
-  lookup: ReviewThreadLookup,
-  threadId: string,
-  threadResolved: boolean,
-  comments?: ReviewThreadCommentsConnection,
-): void {
-  for (const comment of comments?.nodes || []) {
-    if (typeof comment?.databaseId !== "number") {
-      continue;
-    }
-
-    lookup.set(comment.databaseId, {
-      threadId,
-      threadResolved,
-    });
-  }
-}
-
-async function appendPaginatedReviewThreadComments(
+export async function replyToReviewThread(
   octokit: Octokit,
   parsed: ParsedPRUrl,
-  lookup: ReviewThreadLookup,
-  thread: ReviewThreadNode,
+  threadId: string,
+  body: string,
 ): Promise<void> {
-  if (!thread.id) {
+  await withGitHubErrorHandling("review thread reply", parsed, () =>
+    octokit.request("POST /graphql", {
+      query: REVIEW_THREAD_REPLY_MUTATION,
+      threadId,
+      body,
+    }),
+  );
+}
+
+export async function resolveReviewThread(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  threadId: string,
+): Promise<void> {
+  await withGitHubErrorHandling("review thread resolution", parsed, () =>
+    octokit.request("POST /graphql", {
+      query: RESOLVE_REVIEW_THREAD_MUTATION,
+      threadId,
+    }),
+  );
+}
+
+export async function replyToReview(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  body: string,
+): Promise<void> {
+  await withGitHubErrorHandling("review follow-up", parsed, () =>
+    octokit.issues.createComment({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.number,
+      body,
+    }),
+  );
+}
+
+export async function replyToIssueComment(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  body: string,
+): Promise<void> {
+  await withGitHubErrorHandling("issue comment follow-up", parsed, () =>
+    octokit.issues.createComment({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.number,
+      body,
+    }),
+  );
+}
+
+export async function postFollowUpForFeedbackItem(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  item: FeedbackItem,
+  body: string,
+): Promise<void> {
+  if (item.replyKind === "review_thread") {
+    if (!item.threadId) {
+      throw new GitHubIntegrationError(
+        `GitHub could not determine the review thread for feedback item ${item.id} on ${formatGitHubTarget(parsed)}.`,
+        502,
+      );
+    }
+
+    await replyToReviewThread(octokit, parsed, item.threadId, body);
     return;
   }
 
-  let cursor = thread.comments?.pageInfo?.hasNextPage && thread.comments.pageInfo.endCursor
-    ? thread.comments.pageInfo.endCursor
-    : null;
-  let threadResolved = Boolean(thread.isResolved);
-
-  while (cursor) {
-    const response = await withGitHubErrorHandling("review thread comments", parsed, () =>
-      octokit.request("POST /graphql", {
-        query: REVIEW_THREAD_COMMENTS_QUERY,
-        threadId: thread.id,
-        cursor,
-      }),
-    );
-
-    const paginatedThread = (response.data as {
-      node?: ReviewThreadNode;
-    }).node;
-
-    if (!paginatedThread?.id) {
-      break;
-    }
-
-    if (typeof paginatedThread.isResolved === "boolean") {
-      threadResolved = paginatedThread.isResolved;
-    }
-
-    addReviewThreadCommentsToLookup(
-      lookup,
-      paginatedThread.id,
-      threadResolved,
-      paginatedThread.comments,
-    );
-
-    const pageInfo = paginatedThread.comments?.pageInfo;
-    cursor = pageInfo?.hasNextPage && pageInfo.endCursor ? pageInfo.endCursor : null;
+  if (item.replyKind === "review") {
+    await replyToReview(octokit, parsed, body);
+    return;
   }
+
+  await replyToIssueComment(octokit, parsed, body);
 }
 
 export async function fetchFeedbackItemsForPR(


### PR DESCRIPTION
## Summary
- move GitHub follow-up replies and review-thread resolution out of the coding agent and into the babysitter
- page nested review-thread comments so inline feedback on long threads still resolves to the correct thread metadata
- retry already-accepted feedback items that still lack an audit trail or remain unresolved instead of getting stuck forever
- add focused coverage for thread pagination, app-owned follow-up, and follow-up-only retry runs

## Root cause
The March 15 logs showed that the agent could push code but could not complete inline review-thread `gh api` calls from its sandbox, so the babysitter failed verification with unresolved review threads. Accepted comments also were not retried on later runs once their decision had already been recorded.

## Verification
- `node --test --import tsx server/github.test.ts server/babysitter.test.ts server/storage.test.ts`
- `npm run check`

## Notes
I created this PR from a fresh branch off `main` and cherry-picked only commit `6251f24`, so it excludes unrelated local work in the current workspace.