### PR TITLE
fix: improve agent runner timeout handling

### DIFF
--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -22,12 +22,20 @@ test("runCommand reports a timeout even when the child exits 0 after SIGTERM", a
 
 test("evaluateFixNecessityWithAgent throws a clear error when codex writes no output file", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-bin-"));
-  const fakeCodexPath = path.join(tempRoot, "codex");
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.exe" : "codex",
+  );
+  const exitHookPath = path.join(tempRoot, "exit-immediately.cjs");
   const originalPath = process.env.PATH;
+  const originalNodeOptions = process.env.NODE_OPTIONS;
 
   try {
-    await writeFile(fakeCodexPath, "#!/bin/sh\nexit 0\n", "utf8");
-    await chmod(fakeCodexPath, 0o755);
+    await copyFile(process.execPath, fakeCodexPath);
+    await writeFile(exitHookPath, "process.exit(0);\n", "utf8");
+    process.env.NODE_OPTIONS = [`--require=${exitHookPath}`, originalNodeOptions]
+      .filter(Boolean)
+      .join(" ");
     process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
 
     await assert.rejects(
@@ -40,6 +48,11 @@ test("evaluateFixNecessityWithAgent throws a clear error when codex writes no ou
       /without writing expected output file/,
     );
   } finally {
+    if (originalNodeOptions === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    }
     process.env.PATH = originalPath;
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { evaluateFixNecessityWithAgent, runCommand } from "./agentRunner";
+
+test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
+  const result = await runCommand(
+    process.execPath,
+    [
+      "-e",
+      "process.on('SIGTERM', () => process.exit(0)); setInterval(() => {}, 1000);",
+    ],
+    { timeoutMs: 50 },
+  );
+
+  assert.equal(result.code, 124);
+  assert.equal(result.timedOut, true);
+  assert.match(result.stderr, /timed out after 50ms/i);
+});
+
+test("evaluateFixNecessityWithAgent throws a clear error when codex writes no output file", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-bin-"));
+  const fakeCodexPath = path.join(tempRoot, "codex");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(fakeCodexPath, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(fakeCodexPath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+
+    await assert.rejects(
+      () =>
+        evaluateFixNecessityWithAgent({
+          agent: "codex",
+          cwd: process.cwd(),
+          prompt: "Respond with JSON.",
+        }),
+      /without writing expected output file/,
+    );
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -14,6 +14,8 @@ export type CommandResult = {
   stdout: string;
   stderr: string;
   code: number;
+  signal?: NodeJS.Signals | null;
+  timedOut?: boolean;
 };
 
 const AGENTS: CodingAgent[] = ["codex", "claude"];
@@ -79,7 +81,16 @@ export async function evaluateFixNecessityWithAgent(params: {
         throw new Error(`codex evaluation failed (${result.code}): ${result.stderr || result.stdout}`);
       }
 
-      const raw = await readFile(outputFile, "utf8");
+      let raw: string;
+      try {
+        raw = await readFile(outputFile, "utf8");
+      } catch (error) {
+        if (isMissingFileError(error)) {
+          const suffix = result.stderr ? `: ${result.stderr}` : "";
+          throw new Error(`codex evaluation completed without writing expected output file ${outputFile}${suffix}`);
+        }
+        throw error;
+      }
       return parseEvaluationOutput(raw);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
@@ -188,6 +199,10 @@ function tryParseJsonFromText(text: string): unknown {
   }
 }
 
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 export async function runCommand(
   command: string,
   args: string[],
@@ -210,8 +225,10 @@ export async function runCommand(
 
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
 
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill("SIGTERM");
     }, timeoutMs);
 
@@ -227,12 +244,21 @@ export async function runCommand(
       options?.onStderrChunk?.(text);
     });
 
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
       clearTimeout(timer);
+      const stderrParts = [stderr.trim()];
+      if (timedOut) {
+        stderrParts.push(`Command timed out after ${timeoutMs}ms`);
+      } else if (signal) {
+        stderrParts.push(`Command terminated by signal ${signal}`);
+      }
+
       resolve({
         stdout,
-        stderr,
-        code: code ?? 1,
+        stderr: stderrParts.filter(Boolean).join("\n"),
+        code: timedOut ? 124 : (code ?? 1),
+        signal,
+        timedOut,
       });
     });
 


### PR DESCRIPTION
## Summary
- return explicit timeout metadata from `runCommand` instead of letting SIGTERM-trapped children look successful
- surface a clearer error when Codex evaluation exits without writing its expected output file
- add focused regression coverage for both failure modes

## Why this is separate
The feedback-item-status lifecycle docs from mixed commit `71bbb65` already went out in PR #3. This PR intentionally carries only the `server/agentRunner.ts` and `server/agentRunner.test.ts` code/test changes.

## Verification
- `node --test --import tsx server/agentRunner.test.ts`
- `npm run check`