### PR TITLE
Add archived PRs view and auto-archive closed pull requests

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -25,6 +25,10 @@ function formatStatusLabel(status: PR["status"]): string {
     return "attention needed";
   }
 
+  if (status === "archived") {
+    return "archived";
+  }
+
   return "watching";
 }
 
@@ -38,6 +42,7 @@ function StatusDot({ status }: { status: PR["status"] }) {
     status === "watching" ? "bg-foreground/30" :
     status === "processing" ? "bg-foreground animate-pulse" :
     status === "done" ? "bg-foreground" :
+    status === "archived" ? "bg-foreground/15" :
     "bg-destructive";
   return <span className={`inline-block h-1.5 w-1.5 shrink-0 ${cls}`} />;
 }
@@ -95,9 +100,11 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
 function FeedbackRow({
   item,
   prId,
+  readOnly,
 }: {
   item: FeedbackItem;
   prId: string;
+  readOnly?: boolean;
 }) {
   const overrideMutation = useMutation({
     mutationFn: async (decision: string) => {
@@ -141,20 +148,22 @@ function FeedbackRow({
             <p className="mt-2 text-[11px] text-muted-foreground">{item.decisionReason}</p>
           )}
         </div>
-        <div className="flex shrink-0 gap-1">
-          {["accept", "reject", "flag"].map((decision) => (
-            <button
-              key={decision}
-              onClick={() => overrideMutation.mutate(decision)}
-              data-testid={`override-${decision}-${item.id}`}
-              className={`px-1.5 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background ${
-                item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
-              }`}
-            >
-              {decision.charAt(0)}
-            </button>
-          ))}
-        </div>
+        {!readOnly && (
+          <div className="flex shrink-0 gap-1">
+            {["accept", "reject", "flag"].map((decision) => (
+              <button
+                key={decision}
+                onClick={() => overrideMutation.mutate(decision)}
+                data-testid={`override-${decision}-${item.id}`}
+                className={`px-1.5 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background ${
+                  item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
+                }`}
+              >
+                {decision.charAt(0)}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -255,10 +264,20 @@ export default function Dashboard() {
   const [selectedPRId, setSelectedPRId] = useState<string | null>(null);
   const [addUrl, setAddUrl] = useState("");
   const [addRepo, setAddRepo] = useState("");
+  const [viewMode, setViewMode] = useState<"active" | "archived">("active");
 
   const { data: prs = [], isLoading } = useQuery<PR[]>({
     queryKey: ["/api/prs"],
     refetchInterval: 3000,
+  });
+
+  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PR[]>({
+    queryKey: ["/api/prs/archived"],
+    queryFn: async () => {
+      const res = await apiRequest("GET", "/api/prs/archived");
+      return res.json();
+    },
+    refetchInterval: 10000,
   });
 
   const { data: config } = useQuery<Config>({
@@ -271,20 +290,23 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
+  const displayedPRs = viewMode === "active" ? prs : archivedPRs;
+  const isArchived = viewMode === "archived";
+
   useEffect(() => {
-    if (prs.length === 0) {
+    if (displayedPRs.length === 0) {
       if (selectedPRId !== null) {
         setSelectedPRId(null);
       }
       return;
     }
 
-    if (!selectedPRId || !prs.some((pr) => pr.id === selectedPRId)) {
-      setSelectedPRId(prs[0].id);
+    if (!selectedPRId || !displayedPRs.some((pr) => pr.id === selectedPRId)) {
+      setSelectedPRId(displayedPRs[0].id);
     }
-  }, [prs, selectedPRId]);
+  }, [displayedPRs, selectedPRId]);
 
-  const selectedPR = prs.find((pr) => pr.id === selectedPRId) ?? null;
+  const selectedPR = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
 
   const addMutation = useMutation({
     mutationFn: async (url: string) => {
@@ -383,70 +405,100 @@ export default function Dashboard() {
 
       <div className="flex flex-1 overflow-hidden">
         <div className="flex w-80 shrink-0 flex-col border-r border-border">
-          <div className="border-b border-border px-3 py-2 text-[11px] text-muted-foreground">
-            Add a PR or watch a repo. Sync and babysit start automatically.
+          <div className="flex border-b border-border">
+            <button
+              onClick={() => setViewMode("active")}
+              data-testid="tab-active"
+              className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors ${
+                viewMode === "active"
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Active ({prs.length})
+            </button>
+            <button
+              onClick={() => setViewMode("archived")}
+              data-testid="tab-archived"
+              className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors ${
+                viewMode === "archived"
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Archived ({archivedPRs.length})
+            </button>
           </div>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (addUrl.trim()) addMutation.mutate(addUrl.trim());
-            }}
-            className="border-b border-border p-3"
-          >
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={addUrl}
-                onChange={(e) => setAddUrl(e.target.value)}
-                placeholder="github.com/owner/repo/pull/123"
-                data-testid="input-add-pr"
-                className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-foreground focus:outline-none"
-              />
-              <button
-                type="submit"
-                disabled={addMutation.isPending || !addUrl.trim()}
-                data-testid="button-add-pr"
-                className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+          {!isArchived && (
+            <>
+              <div className="border-b border-border px-3 py-2 text-[11px] text-muted-foreground">
+                Add a PR or watch a repo. Sync and babysit start automatically.
+              </div>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (addUrl.trim()) addMutation.mutate(addUrl.trim());
+                }}
+                className="border-b border-border p-3"
               >
-                Add
-              </button>
-            </div>
-          </form>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (addRepo.trim()) addRepoMutation.mutate(addRepo.trim());
-            }}
-            className="border-b border-border p-3"
-          >
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={addRepo}
-                onChange={(e) => setAddRepo(e.target.value)}
-                placeholder="owner/repo"
-                data-testid="input-add-repo"
-                className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-foreground focus:outline-none"
-              />
-              <button
-                type="submit"
-                disabled={addRepoMutation.isPending || !addRepo.trim()}
-                data-testid="button-add-repo"
-                className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={addUrl}
+                    onChange={(e) => setAddUrl(e.target.value)}
+                    placeholder="github.com/owner/repo/pull/123"
+                    data-testid="input-add-pr"
+                    className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-foreground focus:outline-none"
+                  />
+                  <button
+                    type="submit"
+                    disabled={addMutation.isPending || !addUrl.trim()}
+                    data-testid="button-add-pr"
+                    className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                  >
+                    Add
+                  </button>
+                </div>
+              </form>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (addRepo.trim()) addRepoMutation.mutate(addRepo.trim());
+                }}
+                className="border-b border-border p-3"
               >
-                Watch
-              </button>
-            </div>
-          </form>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={addRepo}
+                    onChange={(e) => setAddRepo(e.target.value)}
+                    placeholder="owner/repo"
+                    data-testid="input-add-repo"
+                    className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-foreground focus:outline-none"
+                  />
+                  <button
+                    type="submit"
+                    disabled={addRepoMutation.isPending || !addRepo.trim()}
+                    data-testid="button-add-repo"
+                    className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                  >
+                    Watch
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
           <div className="flex-1 overflow-y-auto">
-            {isLoading ? (
+            {(isArchived ? isLoadingArchived : isLoading) ? (
               <div className="p-4 text-[12px] text-muted-foreground">Loading...</div>
-            ) : prs.length === 0 ? (
+            ) : displayedPRs.length === 0 ? (
               <div className="p-4 text-[12px] text-muted-foreground">
-                No PRs tracked yet. Add a repository to watch or add a PR URL.
+                {isArchived
+                  ? "No archived PRs. Closed PRs are archived automatically."
+                  : "No PRs tracked yet. Add a repository to watch or add a PR URL."}
               </div>
             ) : (
-              prs.map((pr) => (
+              displayedPRs.map((pr) => (
                 <PRRow
                   key={pr.id}
                   pr={pr}
@@ -486,14 +538,16 @@ export default function Dashboard() {
                       {selectedPR.lastChecked && <span>checked {formatClock(selectedPR.lastChecked)}</span>}
                     </div>
                   </div>
-                  <button
-                    onClick={() => applyMutation.mutate(selectedPR.id)}
-                    disabled={applyMutation.isPending || selectedPR.status === "processing"}
-                    data-testid="button-apply"
-                    className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
-                  >
-                    {selectedPR.status === "processing" ? "Running" : "Run now"}
-                  </button>
+                  {!isArchived && (
+                    <button
+                      onClick={() => applyMutation.mutate(selectedPR.id)}
+                      disabled={applyMutation.isPending || selectedPR.status === "processing"}
+                      data-testid="button-apply"
+                      className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                    >
+                      {selectedPR.status === "processing" ? "Running" : "Run now"}
+                    </button>
+                  )}
                 </div>
                 <div className="text-[11px] text-muted-foreground">
                   Background watcher syncs GitHub feedback and pushes approved fixes automatically.
@@ -507,7 +561,7 @@ export default function Dashboard() {
                   </div>
                 ) : (
                   selectedPR.feedbackItems.map((item) => (
-                    <FeedbackRow key={item.id} item={item} prId={selectedPR.id} />
+                    <FeedbackRow key={item.id} item={item} prId={selectedPR.id} readOnly={isArchived} />
                   ))
                 )}
               </div>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -273,10 +273,6 @@ export default function Dashboard() {
 
   const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PR[]>({
     queryKey: ["/api/prs/archived"],
-    queryFn: async () => {
-      const res = await apiRequest("GET", "/api/prs/archived");
-      return res.json();
-    },
     refetchInterval: 10000,
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rest-express",
+  "name": "code-factory",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rest-express",
+      "name": "code-factory",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -146,7 +146,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1503,7 +1502,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4209,7 +4207,6 @@
       "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4243,7 +4240,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4255,7 +4251,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4529,7 +4524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4542,6 +4536,20 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/bytes": {
@@ -4897,7 +4905,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5058,7 +5065,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.3.tgz",
       "integrity": "sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -5212,8 +5218,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5309,7 +5314,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6683,7 +6687,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6823,7 +6826,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7123,7 +7125,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7150,7 +7151,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7164,7 +7164,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7755,7 +7754,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7898,7 +7896,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7945,7 +7942,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8663,7 +8659,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9241,7 +9236,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9311,7 +9305,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -87,7 +87,10 @@ export async function evaluateFixNecessityWithAgent(params: {
       } catch (error) {
         if (isMissingFileError(error)) {
           const suffix = result.stderr ? `: ${result.stderr}` : "";
-          throw new Error(`codex evaluation completed without writing expected output file ${outputFile}${suffix}`);
+          throw new Error(
+            `codex evaluation completed without writing expected output file ${outputFile}${suffix}`,
+            { cause: error },
+          );
         }
         throw error;
       }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -389,6 +389,19 @@ export class PRBabysitter {
         continue;
       }
 
+      const openNumbers = new Set(openPulls.map((p) => p.number));
+
+      // Archive tracked PRs that are no longer open on GitHub
+      const trackedForRepo = tracked.filter((pr) => pr.repo === repoSlug);
+      for (const pr of trackedForRepo) {
+        if (!openNumbers.has(pr.number) && pr.status !== "archived") {
+          await this.storage.updatePR(pr.id, { status: "archived" });
+          await this.storage.addLog(pr.id, "info", `PR #${pr.number} is no longer open on GitHub — archived`, {
+            phase: "watcher",
+          });
+        }
+      }
+
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -9,9 +9,15 @@ export class MemStorage implements IStorage {
   private config: Config = { ...DEFAULT_CONFIG };
 
   async getPRs(): Promise<PR[]> {
-    return Array.from(this.prs.values()).sort(
-      (a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime()
-    );
+    return Array.from(this.prs.values())
+      .filter((pr) => pr.status !== "archived")
+      .sort((a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime());
+  }
+
+  async getArchivedPRs(): Promise<PR[]> {
+    return Array.from(this.prs.values())
+      .filter((pr) => pr.status === "archived")
+      .sort((a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime());
   }
 
   async getPR(id: string): Promise<PR | undefined> {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -113,6 +113,11 @@ export async function registerRoutes(
     res.json(prs);
   });
 
+  app.get("/api/prs/archived", async (_req, res) => {
+    const prs = await storage.getArchivedPRs();
+    res.json(prs);
+  });
+
   app.get("/api/prs/:id", async (req, res) => {
     const pr = await storage.getPR(req.params.id);
     if (!pr) return res.status(404).json({ error: "PR not found" });

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -358,6 +358,21 @@ export class SqliteStorage implements IStorage {
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, added_at
       FROM prs
+      WHERE status != 'archived'
+      ORDER BY datetime(added_at) DESC
+    `).all() as PRRow[];
+
+    const itemsByPrId = this.getFeedbackItemsForPRIds(rows.map((row) => row.id));
+
+    return rows.map((row) => this.parsePRRow(row, itemsByPrId.get(row.id) || []));
+  }
+
+  async getArchivedPRs(): Promise<PR[]> {
+    const rows = this.db.prepare(`
+      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+             tests_passed, lint_passed, last_checked, added_at
+      FROM prs
+      WHERE status = 'archived'
       ORDER BY datetime(added_at) DESC
     `).all() as PRRow[];
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,6 +5,7 @@ import { SqliteStorage } from "./sqliteStorage";
 export interface IStorage {
   // PRs
   getPRs(): Promise<PR[]>;
+  getArchivedPRs(): Promise<PR[]>;
   getPR(id: string): Promise<PR | undefined>;
   getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined>;
   addPR(pr: Omit<PR, "id" | "addedAt">): Promise<PR>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // ── Types for PR feedback workflow ──────────────────────────
 
-export const prStatusEnum = z.enum(["watching", "processing", "done", "error"]);
+export const prStatusEnum = z.enum(["watching", "processing", "done", "error", "archived"]);
 export type PRStatus = z.infer<typeof prStatusEnum>;
 
 export const triageDecision = z.enum(["accept", "reject", "flag"]);


### PR DESCRIPTION
## Summary
This PR adds support for archiving closed pull requests and provides a separate view for archived PRs in the dashboard. Closed PRs are now automatically archived by the babysitter, and users can toggle between active and archived PR lists.

## Key Changes

- **Auto-archive closed PRs**: The babysitter now automatically archives tracked PRs that are no longer open on GitHub, with appropriate logging
- **Archived status support**: Added "archived" to the PR status enum alongside existing statuses (watching, processing, done, error)
- **Dual PR views**: Dashboard now has tabs to switch between "Active" and "Archived" PR lists with counts
- **Read-only archived view**: Archived PRs display feedback items but disable action buttons (override decisions and "Run now")
- **Backend API endpoint**: New `/api/prs/archived` endpoint to fetch archived PRs separately
- **Storage layer updates**: Both SQLite and memory storage implementations now filter PRs by status and provide `getArchivedPRs()` method
- **UI enhancements**: 
  - Added visual indicator for archived status (dimmed dot)
  - Conditional rendering of add PR/repo forms (hidden in archived view)
  - Appropriate empty state messages for each view
  - Tab styling with PR counts

## Implementation Details

- Archived PRs are filtered out from the main `getPRs()` query and returned separately via `getArchivedPRs()`
- The babysitter checks GitHub for open PRs and archives any tracked PRs that are no longer open
- The `FeedbackRow` component accepts a `readOnly` prop to disable interactive elements when viewing archived PRs
- Archived view has a longer refetch interval (10s vs 3s) since archived PRs change less frequently
- The dashboard maintains separate selected PR state across both views

https://claude.ai/code/session_01VUHr9a3rk4a2fWxhG6qvuz