### PR TITLE
Show tracked repository links in dashboard

### DIFF
--- a/client/src/lib/repoHref.test.ts
+++ b/client/src/lib/repoHref.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getRepoHref } from "./repoHref.ts";
+
+test("getRepoHref encodes valid owner/name repositories", () => {
+  assert.equal(getRepoHref("octo-org/repo name"), "https://github.com/octo-org/repo%20name");
+});
+
+test("getRepoHref falls back to the original string when the repo has extra segments", () => {
+  assert.equal(getRepoHref("owner/repo/subpath"), "https://github.com/owner/repo/subpath");
+});
+
+test("getRepoHref falls back to the original string when owner or repo is missing", () => {
+  assert.equal(getRepoHref("owner"), "https://github.com/owner");
+  assert.equal(getRepoHref("owner/"), "https://github.com/owner/");
+  assert.equal(getRepoHref("/repo"), "https://github.com//repo");
+});

--- a/client/src/lib/repoHref.ts
+++ b/client/src/lib/repoHref.ts
@@ -1,0 +1,9 @@
+export function getRepoHref(repo: string): string {
+  const parts = repo.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return `https://github.com/${repo}`;
+  }
+
+  const [owner, name] = parts;
+  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -33,6 +33,15 @@ function formatPollInterval(pollIntervalMs?: number): string {
   return `${seconds}s`;
 }
 
+function getRepoHref(repo: string): string {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    return `https://github.com/${repo}`;
+  }
+
+  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
 function StatusDot({ status }: { status: PR["status"] }) {
   const cls =
     status === "watching" ? "bg-foreground/30" :
@@ -436,6 +445,29 @@ export default function Dashboard() {
               >
                 Watch
               </button>
+            </div>
+            <div className="mt-3">
+              <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                Tracked repositories
+              </div>
+              {repos.length === 0 ? (
+                <div className="text-[11px] text-muted-foreground">No repositories being watched yet.</div>
+              ) : (
+                <div className="space-y-1 text-[12px]">
+                  {repos.map((repo) => (
+                    <a
+                      key={repo}
+                      href={getRepoHref(repo)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-testid={`tracked-repo-${repo.replace("/", "-")}`}
+                      className="block break-all text-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+                    >
+                      {repo}
+                    </a>
+                  ))}
+                </div>
+              )}
             </div>
           </form>
           <div className="flex-1 overflow-y-auto">

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
+import { getRepoHref } from "@/lib/repoHref";
 import type { Config, FeedbackItem, LogEntry, PR } from "@shared/schema";
 import { toast } from "@/hooks/use-toast";
 
@@ -31,15 +32,6 @@ function formatStatusLabel(status: PR["status"]): string {
 function formatPollInterval(pollIntervalMs?: number): string {
   const seconds = Math.max(1, Math.round((pollIntervalMs ?? 120000) / 1000));
   return `${seconds}s`;
-}
-
-function getRepoHref(repo: string): string {
-  const [owner, name] = repo.split("/");
-  if (!owner || !name) {
-    return `https://github.com/${repo}`;
-  }
-
-  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
 }
 
 function StatusDot({ status }: { status: PR["status"] }) {


### PR DESCRIPTION
## Summary
- show the tracked repositories directly below the `owner/repo` watch input
- render each repository name as a GitHub link that opens in a new tab

## Testing
- npm run check
- npm run build