### PR TITLE
Fix dropped repo watch reruns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.worktrees

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { addPRSchema, configSchema } from "@shared/schema";
 import { storage } from "./storage";
 import { PRBabysitter } from "./babysitter";
+import { createWatcherScheduler } from "./watcherScheduler";
 import {
   buildOctokit,
   fetchPullSummary,
@@ -20,20 +21,14 @@ export async function registerRoutes(
   const babysitter = new PRBabysitter(storage);
   let watcherTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
-  let watcherRunning = false;
 
-  const runWatcher = async () => {
-    if (watcherRunning) return;
-    watcherRunning = true;
-
-    try {
-      await babysitter.syncAndBabysitTrackedRepos();
-    } catch (error) {
+  const watcherScheduler = createWatcherScheduler(
+    () => babysitter.syncAndBabysitTrackedRepos(),
+    (error) => {
       console.error("Repository babysitter watcher failed", error);
-    } finally {
-      watcherRunning = false;
-    }
-  };
+    },
+  );
+  const runWatcher = watcherScheduler.run;
 
   const refreshWatcherSchedule = async () => {
     const config = await storage.getConfig();

--- a/server/watcherScheduler.test.ts
+++ b/server/watcherScheduler.test.ts
@@ -54,3 +54,56 @@ test("createWatcherScheduler reruns once when triggered during an active run", a
   assert.equal(runCount, 2);
   assert.deepEqual(errors, []);
 });
+
+test("createWatcherScheduler keeps queued run promises pending until the queued rerun finishes", async () => {
+  const firstStarted = deferred();
+  const releaseFirstRun = deferred();
+  const secondStarted = deferred();
+  const releaseSecondRun = deferred();
+  const errors: unknown[] = [];
+  let runCount = 0;
+  let queuedRunResolved = false;
+
+  const scheduler = createWatcherScheduler(async () => {
+    runCount += 1;
+
+    if (runCount === 1) {
+      firstStarted.resolve();
+      await releaseFirstRun.promise;
+      return;
+    }
+
+    if (runCount === 2) {
+      secondStarted.resolve();
+      await releaseSecondRun.promise;
+      return;
+    }
+
+    throw new Error(`unexpected run ${runCount}`);
+  }, (error) => {
+    errors.push(error);
+  });
+
+  const initialRun = scheduler.run();
+  await firstStarted.promise;
+
+  const queuedRun = scheduler.run().then(() => {
+    queuedRunResolved = true;
+  });
+
+  await Promise.resolve();
+  assert.equal(queuedRunResolved, false);
+
+  releaseFirstRun.resolve();
+  await secondStarted.promise;
+
+  await Promise.resolve();
+  assert.equal(queuedRunResolved, false);
+
+  releaseSecondRun.resolve();
+  await Promise.all([initialRun, queuedRun]);
+
+  assert.equal(runCount, 2);
+  assert.equal(queuedRunResolved, true);
+  assert.deepEqual(errors, []);
+});

--- a/server/watcherScheduler.test.ts
+++ b/server/watcherScheduler.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWatcherScheduler } from "./watcherScheduler";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
+test("createWatcherScheduler reruns once when triggered during an active run", async () => {
+  const firstStarted = deferred();
+  const releaseFirstRun = deferred();
+  const secondStarted = deferred();
+  const errors: unknown[] = [];
+  let runCount = 0;
+
+  const scheduler = createWatcherScheduler(async () => {
+    runCount += 1;
+
+    if (runCount === 1) {
+      firstStarted.resolve();
+      await releaseFirstRun.promise;
+      return;
+    }
+
+    if (runCount === 2) {
+      secondStarted.resolve();
+      return;
+    }
+
+    throw new Error(`unexpected run ${runCount}`);
+  }, (error) => {
+    errors.push(error);
+  });
+
+  const initialRun = scheduler.run();
+  await firstStarted.promise;
+
+  const queuedRun = scheduler.run();
+  const duplicateQueuedRun = scheduler.run();
+
+  releaseFirstRun.resolve();
+
+  await secondStarted.promise;
+  await Promise.all([initialRun, queuedRun, duplicateQueuedRun]);
+
+  assert.equal(runCount, 2);
+  assert.deepEqual(errors, []);
+});

--- a/server/watcherScheduler.ts
+++ b/server/watcherScheduler.ts
@@ -8,30 +8,32 @@ export function createWatcherScheduler(
   task: () => Promise<void>,
   onError: WatcherErrorHandler,
 ): WatcherScheduler {
-  let running = false;
+  let activeRun: Promise<void> | null = null;
   let rerunRequested = false;
 
-  const run = async (): Promise<void> => {
-    if (running) {
+  const run = (): Promise<void> => {
+    if (activeRun) {
       rerunRequested = true;
-      return;
+      return activeRun;
     }
 
-    running = true;
+    activeRun = (async () => {
+      try {
+        do {
+          rerunRequested = false;
 
-    try {
-      do {
-        rerunRequested = false;
+          try {
+            await task();
+          } catch (error) {
+            onError(error);
+          }
+        } while (rerunRequested);
+      } finally {
+        activeRun = null;
+      }
+    })();
 
-        try {
-          await task();
-        } catch (error) {
-          onError(error);
-        }
-      } while (rerunRequested);
-    } finally {
-      running = false;
-    }
+    return activeRun;
   };
 
   return { run };

--- a/server/watcherScheduler.ts
+++ b/server/watcherScheduler.ts
@@ -1,0 +1,38 @@
+type WatcherErrorHandler = (error: unknown) => void;
+
+export type WatcherScheduler = {
+  run: () => Promise<void>;
+};
+
+export function createWatcherScheduler(
+  task: () => Promise<void>,
+  onError: WatcherErrorHandler,
+): WatcherScheduler {
+  let running = false;
+  let rerunRequested = false;
+
+  const run = async (): Promise<void> => {
+    if (running) {
+      rerunRequested = true;
+      return;
+    }
+
+    running = true;
+
+    try {
+      do {
+        rerunRequested = false;
+
+        try {
+          await task();
+        } catch (error) {
+          onError(error);
+        }
+      } while (rerunRequested);
+    } finally {
+      running = false;
+    }
+  };
+
+  return { run };
+}


### PR DESCRIPTION
## Summary
- queue one follow-up watcher pass when a trigger arrives during an active run
- route watcher execution through the new scheduler helper
- add a regression test for the lost-trigger case

## Testing
- node --import tsx --test server/*.test.ts
- npm run check