### PR TITLE
feat: link tracked PR repo to GitHub

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -64,10 +64,22 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
   const checkedAt = formatClock(pr.lastChecked);
 
   return (
-    <button
+    <div
       onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      role="button"
+      tabIndex={0}
       data-testid={`pr-row-${pr.id}`}
-      className={`w-full border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50 ${
+      className={`w-full border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
         isSelected ? "bg-muted" : ""
       }`}
     >
@@ -79,7 +91,15 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
             <span className="truncate">{pr.title}</span>
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
-            <span>{pr.repo}</span>
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+            >
+              {pr.repo}
+            </a>
             <span>{formatStatusLabel(pr.status)}</span>
             {pr.feedbackItems.length > 0 && (
               <span>{pr.accepted}a {pr.rejected}r {pr.flagged}f</span>
@@ -88,7 +108,7 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -94,7 +94,7 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
             <a
               href={pr.url}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               onClick={(event) => event.stopPropagation()}
               className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
             >


### PR DESCRIPTION
## Summary
- make the `owner/repo` label beside each tracked PR title a clickable link to the PR on GitHub
- preserve row selection behavior by using a keyboard-accessible container instead of nesting a link inside a button

## Testing
- npm run check
- npm run build