### PR TITLE
docs: add workflow lessons

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -60,7 +60,7 @@
   - When an explicit user branch target conflicts with my default safety preference, follow the explicit target.
 
 ## 2026-03-15 - Confirm which docs already shipped before opening a follow-up PR
-- Pattern: I was about to open a second PR from a mixed commit that bundled code changes with planning docs the user had already sent in another PR.
+- Pattern: I was about to open a second PR from a mixed commit that bundled code changes with planning docs that had already shipped in another PR.
 - Rule: Before creating a follow-up PR from a mixed commit, verify which files already belong to existing PRs and split the new branch so it contains only the remaining intended changes.
 - Prevention checklist:
   - Inspect the full mixed commit, not just the code paths I care about.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -58,3 +58,29 @@
   - Extract both the remote and branch target before initializing or pushing a repo.
   - If the user says "everything", include previously excluded workspace files unless they are ignored or clearly machine-local.
   - When an explicit user branch target conflicts with my default safety preference, follow the explicit target.
+
+## 2026-03-15 - Confirm which docs already shipped before opening a follow-up PR
+- Pattern: I was about to open a second PR from a mixed commit that bundled code changes with planning docs the user had already sent in another PR.
+- Rule: Before creating a follow-up PR from a mixed commit, verify which files already belong to existing PRs and split the new branch so it contains only the remaining intended changes.
+- Prevention checklist:
+  - Inspect the full mixed commit, not just the code paths I care about.
+  - Ask whether any docs or supporting files already shipped in another PR before reusing a previous commit.
+  - Build follow-up PR branches from `main` and cherry-pick or restage only the intended files.
+  - Re-read the final staged file list before pushing a new PR branch.
+
+## 2026-03-15 - Capture the fresh-main worktree rule in repo guidance
+- Pattern: I wrote the repository guide without stating the required workflow of starting work from a git worktree based on a freshly updated `main`.
+- Rule: When documenting or following this repository's workflow, explicitly require a fresh `main` update and a new worktree before making changes.
+- Prevention checklist:
+  - Check for repo-specific branch and worktree rules before drafting contributor docs.
+  - If the repo uses isolated branches, state the exact starting point: update `main`, create worktree, then branch.
+  - Re-read workflow sections to confirm they include branch base, isolation model, and push target.
+
+## 2026-03-15 - Ship lesson updates with the same rigor as code changes
+- Pattern: I opened the implementation PR but left the required `tasks/lessons.md` update unshipped until the user asked for a separate PR.
+- Rule: When a user correction adds a lesson, treat that lesson update as a deliverable and explicitly decide whether it belongs in the active PR or a separate PR before closing the task.
+- Prevention checklist:
+  - After each user correction, verify whether `tasks/lessons.md` changed and whether that change still needs to ship.
+  - Before opening a PR, inspect staged and unstaged diffs for pending lesson updates.
+  - If lessons should be isolated from product changes, create a docs-only branch from fresh `main` and open that PR in the same session.
+  - Call out any intentionally unshipped lesson updates in the final handoff.


### PR DESCRIPTION
## Summary
- add a lesson about splitting follow-up PRs from mixed changes
- add a lesson that repo guidance must explicitly start from fresh `main` in a new worktree
- add a lesson to ship `tasks/lessons.md` updates with the same rigor as code changes

## Testing
- git diff --check