### PR TITLE
fix: tighten PR audit trail follow-up

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -255,7 +255,9 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(logs.some((log) => log.phase === "verify.github" && log.message.includes("GitHub audit trail verified")));
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("Babysitter run complete")));
   assert.match(receivedPrompt, /commit it and push it to origin HEAD:feature\/verbose/i);
+  assert.match(receivedPrompt, /Only after the relevant verification succeeds, leave the GitHub reply\/comment/i);
   assert.match(receivedPrompt, /Reply with a short GitHub summary for every addressed feedback item/i);
+  assert.match(receivedPrompt, /For threaded review comments, reply on the same thread as the source comment, then resolve that thread/i);
   assert.match(receivedPrompt, /Resolve threaded review comments after replying to them/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.equal(receivedEnv?.GITHUB_TOKEN, "test-token");
@@ -300,6 +302,174 @@ test("babysitPR marks the run as error when the agent does not leave the require
         }
 
         return [existingItem];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: true,
+        reason: "Comment requires a code change",
+      }),
+      applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
+        onStdoutChunk?.("agent stdout line\n");
+        onStderrChunk?.("agent stderr line\n");
+        return {
+          code: 0,
+          stdout: "agent stdout line\n",
+          stderr: "agent stderr line\n",
+        };
+      },
+      runCommand: makeGitRunCommand({
+        localHeadSha: "def456",
+        remoteHeadSha: "def456",
+      }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(updated?.status, "error");
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub audit trail verification failed")));
+  assert.ok(logs.some((log) => log.phase === "cleanup" && log.message.includes("Worktree cleanup complete")));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR treats audit-trail replies as non-actionable follow-up comments", async () => {
+  const storage = new MemStorage();
+  const originalItem = makeFeedbackItem({
+    decision: "accept",
+    decisionReason: "Previously addressed",
+    action: "Please rename this variable.",
+    threadResolved: true,
+  });
+  const auditReply = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: "Implemented the rename and verified the failing test now passes.\n\ncodefactory-feedback:gh-review-comment-1",
+    bodyHtml: "<p>Implemented the rename and verified the failing test now passes.</p>",
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/octo/example/pull/42#discussion_r2",
+    threadResolved: true,
+    createdAt: "2026-03-15T10:05:00.000Z",
+    auditToken: "codefactory-feedback:gh-review-comment-2",
+  });
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [originalItem, auditReply],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [originalItem, auditReply],
+      fetchPullSummary: async () => makePullSummary(pr),
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => {
+        throw new Error("audit-trail replies should not be sent back to the coding agent");
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("audit-trail replies should not trigger a fix run");
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(updated?.status, "watching");
+  assert.equal(updated?.rejected, 1);
+  assert.equal(updated?.feedbackItems[1]?.decision, "reject");
+  assert.match(updated?.feedbackItems[1]?.decisionReason || "", /audit trail/i);
+  assert.ok(logs.some((log) => log.phase === "evaluate.comments" && log.message.includes("Ignored audit-trail follow-up comment")));
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("no necessary fixes identified")));
+});
+
+test("babysitPR requires threaded audit replies to land on the same review thread", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr);
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Implemented the requested rename.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Implemented the requested rename.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: "PRRT_kwDO_other_thread",
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    auditToken: "codefactory-feedback:gh-review-comment-2",
+    decision: null,
+    decisionReason: null,
+    action: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem];
+        }
+
+        return [
+          { ...existingItem, threadResolved: true },
+          followUp,
+        ];
       },
       fetchPullSummary: async () => pullSummary,
       listFailingStatuses: async () => [],

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -25,6 +25,7 @@ import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
 const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
+const AUDIT_TOKEN_PATTERN = /\bcodefactory-feedback:[^\s<>()\[\]{}"']+/g;
 
 type GitHubService = {
   buildOctokit: typeof buildOctokit;
@@ -197,6 +198,10 @@ function buildAgentFixPrompt(params: {
     "Do not rewrite unrelated files.",
     "Use the available git and GitHub tooling in this environment.",
     "If GitHub authentication is available via GITHUB_TOKEN or GH_TOKEN, use it for any required GitHub follow-up.",
+    "Only after the relevant verification succeeds, leave the GitHub reply/comment for that feedback item.",
+    "For threaded review comments, reply on the same thread as the source comment, then resolve that thread after the reply is posted.",
+    "If verification fails or you cannot prove the issue is fixed, do not leave a success comment or resolve the thread; leave a short blocker explanation with the audit token instead.",
+    "Prefer GitHub CLI/API commands that target the exact sourceId/threadId provided for each item.",
     "If a task is invalid after inspection, leave a short GitHub explanation with the audit token and explain it in your final response.",
     "",
     "Approved review-comment tasks:",
@@ -207,18 +212,58 @@ function buildAgentFixPrompt(params: {
     "",
     "When done:",
     "1) Run the relevant verification for your changes.",
-    `2) If you changed code, commit it and push it to ${remoteName} HEAD:${pullSummary.headRef}.`,
-    "3) Reply with a short GitHub summary for every addressed feedback item and include the exact audit token for that item.",
-    "4) Resolve threaded review comments after replying to them.",
-    "5) If an item cannot be fixed safely, leave a short explanatory GitHub reply/comment with the audit token.",
-    "6) Summarize the code changes, verification, git actions, and GitHub follow-up you completed.",
+    "2) Confirm each addressed comment is actually resolved before any GitHub follow-up.",
+    `3) If you changed code, commit it and push it to ${remoteName} HEAD:${pullSummary.headRef}.`,
+    "4) Only after the relevant verification succeeds, reply with a short GitHub summary for every addressed feedback item and include the exact audit token for that item.",
+    "5) Resolve threaded review comments after replying to them on the same thread as the source comment.",
+    "6) If an item cannot be fixed safely or verification does not pass, leave a short explanatory GitHub reply/comment with the audit token instead of a success note.",
+    "7) Summarize the code changes, verification, git actions, and GitHub follow-up you completed.",
   ].join("\n");
+}
+
+function extractMentionedAuditTokens(body: string): string[] {
+  const matches = body.match(AUDIT_TOKEN_PATTERN);
+  if (!matches) {
+    return [];
+  }
+
+  return Array.from(new Set(matches));
+}
+
+function isAutomationAuditTrailFollowUp(item: FeedbackItem, feedbackItems: FeedbackItem[]): boolean {
+  const mentionedTokens = extractMentionedAuditTokens(item.body).filter((token) => token !== item.auditToken);
+  if (mentionedTokens.length === 0) {
+    return false;
+  }
+
+  const itemCreatedAtMs = new Date(item.createdAt).getTime();
+
+  return mentionedTokens.some((token) =>
+    feedbackItems.some((candidate) => {
+      if (candidate.id === item.id || candidate.auditToken !== token) {
+        return false;
+      }
+
+      const candidateCreatedAtMs = new Date(candidate.createdAt).getTime();
+      if (Number.isNaN(itemCreatedAtMs) || Number.isNaN(candidateCreatedAtMs)) {
+        return true;
+      }
+
+      return candidateCreatedAtMs <= itemCreatedAtMs;
+    })
+  );
 }
 
 function hasRecentAuditTrail(item: FeedbackItem, feedbackItems: FeedbackItem[], runStartedAtMs: number): boolean {
   return feedbackItems.some((candidate) => {
     if (candidate.id === item.id || !candidate.body.includes(item.auditToken)) {
       return false;
+    }
+
+    if (item.replyKind === "review_thread") {
+      if (!item.threadId || candidate.threadId !== item.threadId) {
+        return false;
+      }
     }
 
     const createdAtMs = new Date(candidate.createdAt).getTime();
@@ -595,6 +640,19 @@ export class PRBabysitter {
             line: item.line,
           },
         });
+
+        if (isAutomationAuditTrailFollowUp(item, pr.feedbackItems)) {
+          const reason = "Automation audit trail follow-up; no code change required";
+          commentDecisions.set(item.id, { decision: "reject", reason });
+          await queueLog(pr.id, "info", `Ignored audit-trail follow-up comment ${item.id}`, {
+            phase: "evaluate.comments",
+            metadata: {
+              feedbackId: item.id,
+              decision: "reject",
+            },
+          });
+          continue;
+        }
 
         const evaluation = await this.runtime.evaluateFixNecessityWithAgent({
           agent,

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -31,7 +31,7 @@ import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
 const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
-const AUDIT_TOKEN_PATTERN = /\bcodefactory-feedback:[^\s<>()\[\]{}"']+/g;
+const AUDIT_TOKEN_PATTERN = /\bcodefactory-feedback:[^\s<>()[\]{}"']+/g;
 
 type GitHubService = {
   addReactionToComment: typeof addReactionToComment;


### PR DESCRIPTION
## Summary
- require the coding agent to verify fixes before leaving audit-trail comments and resolving review threads
- ignore automation follow-up comments on later babysitter passes instead of recycling them into new work
- verify threaded audit replies land on the same review thread and cover the flow with regressions

## Testing
- ./node_modules/.bin/tsx --test server/*.test.ts
- ./node_modules/.bin/tsc --noEmit