### PR TITLE
feat: feedback item status lifecycle

### DIFF
--- a/client/src/lib/feedbackStatus.test.ts
+++ b/client/src/lib/feedbackStatus.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FeedbackItem } from "@shared/schema";
+import {
+  formatFeedbackStatusLabel,
+  isFeedbackCollapsedByDefault,
+  countActiveFeedbackStatuses,
+} from "./feedbackStatus";
+
+// formatFeedbackStatusLabel
+test('formatFeedbackStatusLabel("in_progress") === "IN PROGRESS"', () => {
+  assert.equal(formatFeedbackStatusLabel("in_progress"), "IN PROGRESS");
+});
+
+test('formatFeedbackStatusLabel("resolved") === "RESOLVED"', () => {
+  assert.equal(formatFeedbackStatusLabel("resolved"), "RESOLVED");
+});
+
+// isFeedbackCollapsedByDefault
+test('isFeedbackCollapsedByDefault("resolved") === true', () => {
+  assert.equal(isFeedbackCollapsedByDefault("resolved"), true);
+});
+
+test('isFeedbackCollapsedByDefault("rejected") === true', () => {
+  assert.equal(isFeedbackCollapsedByDefault("rejected"), true);
+});
+
+test('isFeedbackCollapsedByDefault("failed") === false', () => {
+  assert.equal(isFeedbackCollapsedByDefault("failed"), false);
+});
+
+test('isFeedbackCollapsedByDefault("pending") === false', () => {
+  assert.equal(isFeedbackCollapsedByDefault("pending"), false);
+});
+
+// countActiveFeedbackStatuses
+test("countActiveFeedbackStatuses returns correct queued, inProgress, failed counts", () => {
+  const items: Pick<FeedbackItem, "status">[] = [
+    { status: "queued" },
+    { status: "queued" },
+    { status: "in_progress" },
+    { status: "failed" },
+    { status: "resolved" },
+    { status: "pending" },
+    { status: "rejected" },
+  ];
+  const result = countActiveFeedbackStatuses(items as FeedbackItem[]);
+  assert.equal(result.queued, 2);
+  assert.equal(result.inProgress, 1);
+  assert.equal(result.failed, 1);
+});

--- a/client/src/lib/feedbackStatus.ts
+++ b/client/src/lib/feedbackStatus.ts
@@ -23,9 +23,17 @@ export function countActiveFeedbackStatuses(items: FeedbackItem[]): {
   inProgress: number;
   failed: number;
 } {
-  return {
-    queued: items.filter((i) => i.status === "queued").length,
-    inProgress: items.filter((i) => i.status === "in_progress").length,
-    failed: items.filter((i) => i.status === "failed").length,
-  };
+  return items.reduce(
+    (counts, item) => {
+      if (item.status === "queued") counts.queued += 1;
+      else if (item.status === "in_progress") counts.inProgress += 1;
+      else if (item.status === "failed") counts.failed += 1;
+      return counts;
+    },
+    {
+      queued: 0,
+      inProgress: 0,
+      failed: 0,
+    },
+  );
 }

--- a/client/src/lib/feedbackStatus.ts
+++ b/client/src/lib/feedbackStatus.ts
@@ -1,0 +1,31 @@
+import type { FeedbackItem, FeedbackStatus } from "@shared/schema";
+
+export function formatFeedbackStatusLabel(status: FeedbackStatus): string {
+  return status.replace("_", " ").toUpperCase();
+}
+
+export function getFeedbackStatusBadgeClass(status: FeedbackStatus): string {
+  if (status === "in_progress") return "border-foreground text-foreground animate-pulse";
+  if (status === "failed") return "border-destructive text-destructive";
+  if (status === "resolved") return "border-foreground/20 text-muted-foreground";
+  if (status === "rejected") return "border-foreground/20 text-muted-foreground line-through";
+  if (status === "flagged") return "border-foreground/40 text-foreground/60";
+  if (status === "queued") return "border-foreground text-foreground";
+  return "border-foreground/30 text-foreground/60"; // pending
+}
+
+export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
+  return status === "resolved" || status === "rejected";
+}
+
+export function countActiveFeedbackStatuses(items: FeedbackItem[]): {
+  queued: number;
+  inProgress: number;
+  failed: number;
+} {
+  return {
+    queued: items.filter((i) => i.status === "queued").length,
+    inProgress: items.filter((i) => i.status === "in_progress").length,
+    failed: items.filter((i) => i.status === "failed").length,
+  };
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,8 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import type { Config, FeedbackItem, LogEntry, PR } from "@shared/schema";
 import { toast } from "@/hooks/use-toast";
+import {
+  formatFeedbackStatusLabel,
+  getFeedbackStatusBadgeClass,
+  isFeedbackCollapsedByDefault,
+  countActiveFeedbackStatuses,
+} from "@/lib/feedbackStatus";
 
 function formatClock(timestamp: string | null): string | null {
   if (!timestamp) {
@@ -60,6 +67,15 @@ function DecisionTag({ decision }: { decision: string | null }) {
   );
 }
 
+function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
+  const cls = getFeedbackStatusBadgeClass(status);
+  return (
+    <span className={`inline-block border px-1.5 py-0 text-[11px] uppercase tracking-wide ${cls}`}>
+      {formatFeedbackStatusLabel(status)}
+    </span>
+  );
+}
+
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
 
@@ -81,9 +97,15 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
             <span>{pr.repo}</span>
             <span>{formatStatusLabel(pr.status)}</span>
-            {pr.feedbackItems.length > 0 && (
-              <span>{pr.accepted}a {pr.rejected}r {pr.flagged}f</span>
-            )}
+            {pr.feedbackItems.length > 0 && (() => {
+              const counts = countActiveFeedbackStatuses(pr.feedbackItems);
+              const parts: string[] = [];
+              if (counts.queued > 0) parts.push(`${counts.queued}q`);
+              if (counts.inProgress > 0) parts.push(`${counts.inProgress} active`);
+              if (counts.failed > 0) parts.push(`${counts.failed} failed`);
+              if (parts.length === 0) return <span>{pr.feedbackItems.length} items</span>;
+              return <span>{parts.join(" · ")}</span>;
+            })()}
             {checkedAt && <span>checked {checkedAt}</span>}
           </div>
         </div>
@@ -111,24 +133,54 @@ function FeedbackRow({
   });
 
   const createdAt = formatClock(item.createdAt);
+  const collapsedByDefault = isFeedbackCollapsedByDefault(item.status);
 
   return (
-    <div className="border-b border-border px-4 py-3" data-testid={`feedback-${item.id}`}>
-      <div className="flex items-start gap-3">
-        <div className="shrink-0 pt-0.5">
-          <DecisionTag decision={item.decision} />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="mb-1 flex flex-wrap items-center gap-2">
-            <span className="font-medium">{item.author}</span>
-            {item.file && (
-              <span className="text-[11px] text-muted-foreground">
-                {item.file}{item.line ? `:${item.line}` : ""}
-              </span>
-            )}
-            <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
-            {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
+    <Collapsible.Root defaultOpen={!collapsedByDefault} className="border-b border-border">
+      <div className="px-4 py-3">
+        {/* Header row - always visible */}
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 pt-0.5">
+            <FeedbackStatusTag status={item.status} />
           </div>
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex flex-wrap items-center gap-2">
+              <span className="font-medium">{item.author}</span>
+              {item.file && (
+                <span className="text-[11px] text-muted-foreground">
+                  {item.file}{item.line ? `:${item.line}` : ""}
+                </span>
+              )}
+              <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
+              {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Collapsible.Trigger asChild>
+              <button
+                data-testid={`toggle-${item.id}`}
+                className="px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background border border-border"
+              >
+                ↕
+              </button>
+            </Collapsible.Trigger>
+            {["accept", "reject", "flag"].map((decision) => (
+              <button
+                key={decision}
+                onClick={() => overrideMutation.mutate(decision)}
+                data-testid={`override-${decision}-${item.id}`}
+                className={`px-1.5 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background ${
+                  item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
+                }`}
+              >
+                {decision.charAt(0)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <Collapsible.Content>
+        <div className="px-4 pb-3">
           {item.bodyHtml ? (
             <div
               className="feedback-markdown text-[12px] leading-relaxed"
@@ -137,26 +189,14 @@ function FeedbackRow({
           ) : (
             <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-foreground/80">{item.body}</p>
           )}
-          {item.decisionReason && (
-            <p className="mt-2 text-[11px] text-muted-foreground">{item.decisionReason}</p>
+          {(item.statusReason || item.decisionReason) && (
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              {item.statusReason || item.decisionReason}
+            </p>
           )}
         </div>
-        <div className="flex shrink-0 gap-1">
-          {["accept", "reject", "flag"].map((decision) => (
-            <button
-              key={decision}
-              onClick={() => overrideMutation.mutate(decision)}
-              data-testid={`override-${decision}-${item.id}`}
-              className={`px-1.5 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background ${
-                item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
-              }`}
-            >
-              {decision.charAt(0)}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
   );
 }
 
@@ -474,9 +514,16 @@ export default function Dashboard() {
                     <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                       <span>status: {formatStatusLabel(selectedPR.status)}</span>
                       <span>{selectedPR.feedbackItems.length} items</span>
-                      {selectedPR.accepted > 0 && <span>{selectedPR.accepted} accepted</span>}
-                      {selectedPR.rejected > 0 && <span>{selectedPR.rejected} rejected</span>}
-                      {selectedPR.flagged > 0 && <span>{selectedPR.flagged} flagged</span>}
+                      {selectedPR.feedbackItems.length > 0 && (() => {
+                        const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
+                        return (
+                          <>
+                            {counts.queued > 0 && <span>{counts.queued} queued</span>}
+                            {counts.inProgress > 0 && <span>{counts.inProgress} in progress</span>}
+                            {counts.failed > 0 && <span>{counts.failed} failed</span>}
+                          </>
+                        );
+                      })()}
                       {selectedPR.testsPassed !== null && (
                         <span>tests: {selectedPR.testsPassed ? "pass" : "fail"}</span>
                       )}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -55,24 +55,6 @@ function StatusDot({ status }: { status: PR["status"] }) {
   return <span className={`inline-block h-1.5 w-1.5 shrink-0 ${cls}`} />;
 }
 
-function DecisionTag({ decision }: { decision: string | null }) {
-  if (!decision) return <span className="text-muted-foreground">---</span>;
-  const map: Record<string, string> = {
-    accept: "ACCEPT",
-    reject: "REJECT",
-    flag: "FLAG",
-  };
-  const style =
-    decision === "accept" ? "border-foreground text-foreground" :
-    decision === "flag" ? "border-foreground/40 text-foreground/60" :
-    "border-foreground/20 text-muted-foreground line-through";
-  return (
-    <span className={`inline-block border px-1.5 py-0 text-[11px] uppercase tracking-wide ${style}`}>
-      {map[decision] || decision}
-    </span>
-  );
-}
-
 function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
   const cls = getFeedbackStatusBadgeClass(status);
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rest-express",
+  "name": "code-factory",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rest-express",
+      "name": "code-factory",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -481,6 +481,7 @@ test("babysitPR marks the run as error when app-owned GitHub follow-up fails", a
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
   const pullSummary = makePullSummary(pr);
   let applyCalled = false;
 
@@ -638,7 +639,6 @@ test("babysitPR marks claimed items as failed when audit trail verification fail
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
-  let feedbackFetchCount = 0;
   const pullSummary = makePullSummary(pr);
 
   const babysitter = new PRBabysitter(

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -481,7 +481,6 @@ test("babysitPR marks the run as error when app-owned GitHub follow-up fails", a
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
-  let feedbackFetchCount = 0;
   const pullSummary = makePullSummary(pr);
   let applyCalled = false;
 

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -27,6 +27,8 @@ function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
     decision: null,
     decisionReason: null,
     action: null,
+    status: "pending",
+    statusReason: null,
     ...overrides,
   };
 }
@@ -336,6 +338,360 @@ test("babysitPR marks the run as error when the agent does not leave the require
   assert.equal(updated?.status, "error");
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub audit trail verification failed")));
   assert.ok(logs.some((log) => log.phase === "cleanup" && log.message.includes("Worktree cleanup complete")));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR marks accepted pending items as resolved after a successful run", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem({ status: "pending", decision: null });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr);
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Implemented the fix.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Implemented the fix.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) return [existingItem];
+        return [{ ...existingItem, threadResolved: true }, followUp];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: true, reason: "Code change needed" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const resolvedItem = updated?.feedbackItems.find((i) => i.id === existingItem.id);
+  assert.equal(resolvedItem?.status, "resolved");
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR marks claimed items as failed when audit trail verification fails", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem({ status: "pending", decision: null });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr);
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        // Always return existing item without audit trail follow-up
+        return [existingItem];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: true, reason: "Code change needed" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const failedItem = updated?.feedbackItems.find((i) => i.id === existingItem.id);
+  assert.equal(failedItem?.status, "failed");
+  assert.ok(failedItem?.statusReason?.includes("audit trail"));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR picks up manually-queued items and resolves them without re-evaluating", async () => {
+  const storage = new MemStorage();
+  const queuedItem = makeFeedbackItem({
+    status: "queued",
+    decision: "accept",
+    decisionReason: "Manual override",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [queuedItem],
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr);
+  let evaluateCallCount = 0;
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Fix applied.\n\n${queuedItem.auditToken}`,
+    bodyHtml: `<p>Fix applied.</p><p>${queuedItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: queuedItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) return [queuedItem];
+        return [{ ...queuedItem, threadResolved: true }, followUp];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => {
+        evaluateCallCount += 1;
+        return { needsFix: true, reason: "Should not be called" };
+      },
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const resolvedItem = updated?.feedbackItems.find((i) => i.id === queuedItem.id);
+  assert.equal(evaluateCallCount, 0, "evaluateFixNecessityWithAgent should not be called for already-queued items");
+  assert.equal(resolvedItem?.status, "resolved");
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR does not pull rejected or resolved items into in_progress", async () => {
+  const storage = new MemStorage();
+  const rejectedItem = makeFeedbackItem({
+    id: "gh-review-comment-rejected",
+    status: "rejected",
+    decision: "reject",
+    decisionReason: "Not actionable",
+  });
+  const resolvedItem = makeFeedbackItem({
+    id: "gh-review-comment-resolved",
+    status: "resolved",
+    decision: "accept",
+  });
+  const pendingItem = makeFeedbackItem({
+    id: "gh-review-comment-pending",
+    status: "pending",
+    decision: null,
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [rejectedItem, resolvedItem, pendingItem],
+    accepted: 1,
+    rejected: 1,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr);
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-followup",
+    author: "code-factory",
+    body: `Fix applied.\n\n${pendingItem.auditToken}`,
+    bodyHtml: `<p>Fix applied.</p><p>${pendingItem.auditToken}</p>`,
+    sourceId: "99",
+    sourceNodeId: "PRRC_kwDO_followup99",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r99",
+    threadId: pendingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) return [rejectedItem, resolvedItem, pendingItem];
+        return [rejectedItem, resolvedItem, { ...pendingItem, threadResolved: true }, followUp];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => "test-token",
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async (_params) => ({ needsFix: true, reason: "Code change needed" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const updatedRejected = updated?.feedbackItems.find((i) => i.id === rejectedItem.id);
+  const updatedResolved = updated?.feedbackItems.find((i) => i.id === resolvedItem.id);
+  assert.equal(updatedRejected?.status, "rejected", "rejected item should keep its status");
+  assert.equal(updatedResolved?.status, "resolved", "resolved item should keep its status");
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR skips run when no items are pending or queued", async () => {
+  const storage = new MemStorage();
+  const rejectedItem = makeFeedbackItem({ status: "rejected", decision: "reject" });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [rejectedItem],
+    accepted: 0,
+    rejected: 1,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let evaluateCallCount = 0;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [rejectedItem],
+      fetchPullSummary: async () => makePullSummary(pr),
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      resolveGitHubAuthToken: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => {
+        evaluateCallCount += 1;
+        return { needsFix: true, reason: "Should not be called" };
+      },
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  assert.equal(evaluateCallCount, 0, "evaluateFixNecessityWithAgent should not be called when no pending items");
+  assert.equal(updated?.status, "watching");
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -481,7 +481,6 @@ test("babysitPR marks the run as error when app-owned GitHub follow-up fails", a
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
-  let feedbackFetchCount = 0;
   const pullSummary = makePullSummary(pr);
   let applyCalled = false;
 
@@ -489,14 +488,7 @@ test("babysitPR marks the run as error when app-owned GitHub follow-up fails", a
     storage,
     {
       buildOctokit: async () => ({}) as never,
-      fetchFeedbackItemsForPR: async () => {
-        feedbackFetchCount += 1;
-        if (feedbackFetchCount === 1) {
-          return [existingItem];
-        }
-
-        return [existingItem];
-      },
+      fetchFeedbackItemsForPR: async () => [existingItem],
       fetchPullSummary: async () => pullSummary,
       listFailingStatuses: async () => [],
       listOpenPullsForRepo: async () => [],
@@ -653,11 +645,7 @@ test("babysitPR marks claimed items as failed when audit trail verification fail
     storage,
     {
       buildOctokit: async () => ({}) as never,
-      fetchFeedbackItemsForPR: async () => {
-        feedbackFetchCount += 1;
-        // Always return existing item without audit trail follow-up
-        return [existingItem];
-      },
+      fetchFeedbackItemsForPR: async () => [existingItem],
       fetchPullSummary: async () => pullSummary,
       listFailingStatuses: async () => [],
       listOpenPullsForRepo: async () => [],

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -22,6 +22,7 @@ import {
 } from "./github";
 import { getCodeFactoryPaths } from "./paths";
 import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
+import { applyEvaluationDecision, markInProgress, markResolved, markFailed } from "./feedbackLifecycle";
 
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
 const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
@@ -543,6 +544,8 @@ export class PRBabysitter {
       return result;
     };
 
+    let commentTasks: FeedbackItem[] = [];
+
     try {
       await this.storage.updatePR(prId, {
         status: "processing",
@@ -580,13 +583,12 @@ export class PRBabysitter {
       const pullSummary = await this.github.fetchPullSummary(octokit, parsedPr);
       const failingStatuses = await this.github.listFailingStatuses(octokit, parsedRepo, pullSummary.headSha);
 
-      const pendingComments = pr.feedbackItems.filter((item) => item.decision === null);
+      const pendingComments = pr.feedbackItems.filter((item) => item.status === "pending");
       await queueLog(pr.id, "info", `Evaluating ${pendingComments.length} pending feedback item(s)`, {
         phase: "evaluate.comments",
       });
 
-      const commentTasks: FeedbackItem[] = [];
-      const commentDecisions = new Map<string, { decision: "accept" | "reject" | "flag"; reason: string }>();
+      const evaluatedItems = new Map<string, FeedbackItem>();
 
       for (const item of pendingComments) {
         await queueLog(pr.id, "info", `Inspecting feedback from ${item.author}`, {
@@ -604,15 +606,15 @@ export class PRBabysitter {
           prompt: buildCommentEvaluationPrompt({ pr, item }),
         });
 
+        const updated = applyEvaluationDecision(item, evaluation.needsFix, evaluation.reason);
+        evaluatedItems.set(item.id, updated);
+
         if (evaluation.needsFix) {
-          commentTasks.push(item);
-          commentDecisions.set(item.id, { decision: "accept", reason: evaluation.reason });
           await queueLog(pr.id, "info", `Accepted feedback ${item.id}: ${evaluation.reason}`, {
             phase: "evaluate.comments",
             metadata: { feedbackId: item.id, decision: "accept" },
           });
         } else {
-          commentDecisions.set(item.id, { decision: "reject", reason: evaluation.reason });
           await queueLog(pr.id, "info", `Rejected feedback ${item.id}: ${evaluation.reason}`, {
             phase: "evaluate.comments",
             metadata: { feedbackId: item.id, decision: "reject" },
@@ -650,18 +652,8 @@ export class PRBabysitter {
         }
       }
 
-      if (commentDecisions.size > 0) {
-        const updatedItems = pr.feedbackItems.map((item) => {
-          const decision = commentDecisions.get(item.id);
-          if (!decision) return item;
-
-          return {
-            ...item,
-            decision: decision.decision,
-            decisionReason: decision.reason,
-            action: decision.decision === "accept" ? item.body : null,
-          };
-        });
+      if (evaluatedItems.size > 0) {
+        const updatedItems = pr.feedbackItems.map((item) => evaluatedItems.get(item.id) ?? item);
 
         const counters = countDecisions(updatedItems);
         const updatedPR = await this.storage.updatePR(pr.id, {
@@ -675,6 +667,11 @@ export class PRBabysitter {
           pr = updatedPR;
         }
       }
+
+      // Collect queued items (from both evaluation and manual queuing via routes).
+      commentTasks = pr.feedbackItems.filter(
+        (item) => item.status === "queued" && item.decision === "accept",
+      );
 
       if (commentTasks.length === 0 && statusTasks.length === 0) {
         await queueLog(pr.id, "info", `Babysitter checked PR #${pr.number}; no necessary fixes identified`, {
@@ -750,6 +747,21 @@ export class PRBabysitter {
               GH_TOKEN: githubToken,
             }
           : undefined;
+        // Mark comment tasks as in_progress before launching the agent.
+        if (commentTasks.length > 0) {
+          const inProgressItems = pr.feedbackItems.map((item) =>
+            commentTasks.find((t) => t.id === item.id) ? markInProgress(item) : item,
+          );
+          const inProgressCounters = countDecisions(inProgressItems);
+          const inProgressPR = await this.storage.updatePR(pr.id, {
+            feedbackItems: inProgressItems,
+            accepted: inProgressCounters.accepted,
+            rejected: inProgressCounters.rejected,
+            flagged: inProgressCounters.flagged,
+          });
+          if (inProgressPR) pr = inProgressPR;
+        }
+
         await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
           phase: "agent",
           metadata: { githubAuth: Boolean(githubToken) },
@@ -886,6 +898,21 @@ export class PRBabysitter {
           },
         });
 
+        // Mark comment tasks as resolved after successful audit verification.
+        if (commentTasks.length > 0) {
+          const resolvedItems = pr.feedbackItems.map((item) =>
+            commentTasks.find((t) => t.id === item.id) ? markResolved(item) : item,
+          );
+          const resolvedCounters = countDecisions(resolvedItems);
+          const resolvedPR = await this.storage.updatePR(pr.id, {
+            feedbackItems: resolvedItems,
+            accepted: resolvedCounters.accepted,
+            rejected: resolvedCounters.rejected,
+            flagged: resolvedCounters.flagged,
+          });
+          if (resolvedPR) pr = resolvedPR;
+        }
+
         await this.storage.updatePR(pr.id, {
           status: "watching",
           lastChecked: new Date().toISOString(),
@@ -916,12 +943,28 @@ export class PRBabysitter {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const pr = await this.storage.getPR(prId);
-      if (pr) {
-        await queueLog(pr.id, "error", `Babysitter error: ${message}`, {
+      const currentPr = await this.storage.getPR(prId);
+      if (currentPr) {
+        await queueLog(currentPr.id, "error", `Babysitter error: ${message}`, {
           phase: "run",
         });
-        await this.storage.updatePR(pr.id, { status: "error", lastChecked: new Date().toISOString() });
+
+        if (commentTasks.length > 0) {
+          const failedItems = currentPr.feedbackItems.map((item) =>
+            commentTasks.find((t) => t.id === item.id) ? markFailed(item, message) : item,
+          );
+          const failedCounters = countDecisions(failedItems);
+          await this.storage.updatePR(currentPr.id, {
+            feedbackItems: failedItems,
+            accepted: failedCounters.accepted,
+            rejected: failedCounters.rejected,
+            flagged: failedCounters.flagged,
+            status: "error",
+            lastChecked: new Date().toISOString(),
+          });
+        } else {
+          await this.storage.updatePR(currentPr.id, { status: "error", lastChecked: new Date().toISOString() });
+        }
       }
       console.error("Babysitter failure", error);
     } finally {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -81,12 +81,14 @@ function mergeFeedbackItems(existing: FeedbackItem[], incoming: FeedbackItem[]):
       return item;
     }
 
-    // Preserve triage decisions and action annotations across refreshes.
+    // Preserve triage decisions, action annotations, and lifecycle status across refreshes.
     return {
       ...item,
       decision: previous.decision,
       decisionReason: previous.decisionReason,
       action: previous.action,
+      status: previous.status,
+      statusReason: previous.statusReason,
     };
   });
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -645,7 +645,6 @@ export class PRBabysitter {
       return result;
     };
 
-    let commentTasks: FeedbackItem[] = [];
     let followUpTasks: FeedbackItem[] = [];
 
     try {
@@ -820,7 +819,7 @@ export class PRBabysitter {
         }
       }
 
-      commentTasks = pr.feedbackItems.filter(
+      const commentTasks = pr.feedbackItems.filter(
         (item) => item.status === "queued" && item.decision === "accept",
       );
       followUpTasks = collectGitHubFollowUpTasks(pr);

--- a/server/feedbackLifecycle.test.ts
+++ b/server/feedbackLifecycle.test.ts
@@ -81,6 +81,12 @@ test("applyEvaluationDecision needsFix=false maps to rejected", () => {
   assert.equal(result.statusReason, "Non-actionable comment");
 });
 
+test("markInProgress maps to in_progress", () => {
+  const item = makeItem({ status: "queued" });
+  const result = markInProgress(item);
+  assert.equal(result.status, "in_progress");
+});
+
 test("markResolved maps to resolved", () => {
   const item = makeItem({ status: "in_progress" });
   const result = markResolved(item);

--- a/server/feedbackLifecycle.test.ts
+++ b/server/feedbackLifecycle.test.ts
@@ -4,10 +4,22 @@ import type { FeedbackItem } from "@shared/schema";
 import {
   applyManualDecision,
   applyEvaluationDecision,
+  applyFlagDecision,
   markInProgress,
   markResolved,
   markFailed,
 } from "./feedbackLifecycle";
+
+function applyLegacyTriage(item: FeedbackItem): FeedbackItem {
+  const body = item.body.toLowerCase();
+  if (body.includes("lgtm") || body.includes("looks good")) {
+    return applyEvaluationDecision(item, false, "Acknowledgement, no code change requested");
+  }
+  if (body.includes("please") || body.includes("should") || body.includes("fix") || body.includes("error") || body.includes("fail")) {
+    return applyEvaluationDecision(item, true, "Likely actionable request");
+  }
+  return applyFlagDecision(item, "Unclear actionability, flagged for manual review");
+}
 
 function makeItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
   return {
@@ -106,4 +118,50 @@ test("helpers return full FeedbackItem with unchanged fields preserved", () => {
   assert.equal(result.author, "bob");
   assert.equal(result.body, "Check this");
   assert.equal(result.id, item.id);
+});
+
+test("applyFlagDecision maps to flagged with reason", () => {
+  const item = makeItem();
+  const result = applyFlagDecision(item, "Unclear actionability");
+  assert.equal(result.decision, "flag");
+  assert.equal(result.status, "flagged");
+  assert.equal(result.statusReason, "Unclear actionability");
+});
+
+test("applyLegacyTriage lgtm phrase maps to rejected", () => {
+  const item = makeItem({ body: "LGTM, looks good to me!" });
+  const result = applyLegacyTriage(item);
+  assert.equal(result.decision, "reject");
+  assert.equal(result.status, "rejected");
+  assert.equal(result.statusReason, "Acknowledgement, no code change requested");
+});
+
+test("applyLegacyTriage looks good phrase maps to rejected", () => {
+  const item = makeItem({ body: "Looks good overall" });
+  const result = applyLegacyTriage(item);
+  assert.equal(result.decision, "reject");
+  assert.equal(result.status, "rejected");
+});
+
+test("applyLegacyTriage actionable phrase maps to queued", () => {
+  const item = makeItem({ body: "Please fix the null check here" });
+  const result = applyLegacyTriage(item);
+  assert.equal(result.decision, "accept");
+  assert.equal(result.status, "queued");
+  assert.equal(result.statusReason, "Likely actionable request");
+});
+
+test("applyLegacyTriage should phrase maps to queued", () => {
+  const item = makeItem({ body: "This should be refactored" });
+  const result = applyLegacyTriage(item);
+  assert.equal(result.decision, "accept");
+  assert.equal(result.status, "queued");
+});
+
+test("applyLegacyTriage ambiguous phrase maps to flagged", () => {
+  const item = makeItem({ body: "Interesting approach here" });
+  const result = applyLegacyTriage(item);
+  assert.equal(result.decision, "flag");
+  assert.equal(result.status, "flagged");
+  assert.equal(result.statusReason, "Unclear actionability, flagged for manual review");
 });

--- a/server/feedbackLifecycle.test.ts
+++ b/server/feedbackLifecycle.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FeedbackItem } from "@shared/schema";
+import {
+  applyManualDecision,
+  applyEvaluationDecision,
+  markInProgress,
+  markResolved,
+  markFailed,
+} from "./feedbackLifecycle";
+
+function makeItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    id: "gh-review-comment-1",
+    author: "alice",
+    body: "Please fix this",
+    bodyHtml: "<p>Please fix this</p>",
+    replyKind: "review_thread",
+    sourceId: "1",
+    sourceNodeId: null,
+    sourceUrl: null,
+    threadId: null,
+    threadResolved: null,
+    auditToken: "codefactory-feedback:gh-review-comment-1",
+    file: null,
+    line: null,
+    type: "review_comment",
+    createdAt: "2026-03-15T10:00:00Z",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+    ...overrides,
+  };
+}
+
+test("new synced feedback defaults to pending", () => {
+  const item = makeItem();
+  assert.equal(item.status, "pending");
+  assert.equal(item.statusReason, null);
+});
+
+test("applyManualDecision accept maps to queued", () => {
+  const item = makeItem();
+  const result = applyManualDecision(item, "accept");
+  assert.equal(result.decision, "accept");
+  assert.equal(result.status, "queued");
+  assert.equal(result.statusReason, "Manual override");
+});
+
+test("applyManualDecision reject maps to rejected", () => {
+  const item = makeItem();
+  const result = applyManualDecision(item, "reject");
+  assert.equal(result.decision, "reject");
+  assert.equal(result.status, "rejected");
+  assert.equal(result.statusReason, "Manual override");
+});
+
+test("applyManualDecision flag maps to flagged", () => {
+  const item = makeItem();
+  const result = applyManualDecision(item, "flag");
+  assert.equal(result.decision, "flag");
+  assert.equal(result.status, "flagged");
+  assert.equal(result.statusReason, "Manual override");
+});
+
+test("applyEvaluationDecision needsFix=true maps to queued", () => {
+  const item = makeItem();
+  const result = applyEvaluationDecision(item, true, "Needs code change");
+  assert.equal(result.decision, "accept");
+  assert.equal(result.status, "queued");
+  assert.equal(result.statusReason, "Needs code change");
+});
+
+test("applyEvaluationDecision needsFix=false maps to rejected", () => {
+  const item = makeItem();
+  const result = applyEvaluationDecision(item, false, "Non-actionable comment");
+  assert.equal(result.decision, "reject");
+  assert.equal(result.status, "rejected");
+  assert.equal(result.statusReason, "Non-actionable comment");
+});
+
+test("markResolved maps to resolved", () => {
+  const item = makeItem({ status: "in_progress" });
+  const result = markResolved(item);
+  assert.equal(result.status, "resolved");
+});
+
+test("markFailed maps to failed with reason", () => {
+  const item = makeItem({ status: "in_progress" });
+  const result = markFailed(item, "Agent timed out");
+  assert.equal(result.status, "failed");
+  assert.equal(result.statusReason, "Agent timed out");
+});
+
+test("helpers return full FeedbackItem with unchanged fields preserved", () => {
+  const item = makeItem({ author: "bob", body: "Check this" });
+  const result = applyManualDecision(item, "accept");
+  assert.equal(result.author, "bob");
+  assert.equal(result.body, "Check this");
+  assert.equal(result.id, item.id);
+});

--- a/server/feedbackLifecycle.ts
+++ b/server/feedbackLifecycle.ts
@@ -40,6 +40,10 @@ export function applyEvaluationDecision(
   };
 }
 
+export function applyFlagDecision(item: FeedbackItem, reason: string): FeedbackItem {
+  return { ...item, decision: "flag", status: "flagged", statusReason: reason };
+}
+
 export function markInProgress(item: FeedbackItem): FeedbackItem {
   return {
     ...item,

--- a/server/feedbackLifecycle.ts
+++ b/server/feedbackLifecycle.ts
@@ -1,0 +1,63 @@
+import type { FeedbackItem } from "@shared/schema";
+
+export function applyManualDecision(
+  item: FeedbackItem,
+  decision: "accept" | "reject" | "flag",
+): FeedbackItem {
+  const statusMap = {
+    accept: "queued",
+    reject: "rejected",
+    flag: "flagged",
+  } as const;
+
+  return {
+    ...item,
+    decision,
+    status: statusMap[decision],
+    statusReason: "Manual override",
+  };
+}
+
+export function applyEvaluationDecision(
+  item: FeedbackItem,
+  needsFix: boolean,
+  reason: string,
+): FeedbackItem {
+  if (needsFix) {
+    return {
+      ...item,
+      decision: "accept",
+      status: "queued",
+      statusReason: reason,
+    };
+  }
+
+  return {
+    ...item,
+    decision: "reject",
+    status: "rejected",
+    statusReason: reason,
+  };
+}
+
+export function markInProgress(item: FeedbackItem): FeedbackItem {
+  return {
+    ...item,
+    status: "in_progress",
+  };
+}
+
+export function markResolved(item: FeedbackItem): FeedbackItem {
+  return {
+    ...item,
+    status: "resolved",
+  };
+}
+
+export function markFailed(item: FeedbackItem, reason: string): FeedbackItem {
+  return {
+    ...item,
+    status: "failed",
+    statusReason: reason,
+  };
+}

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -144,6 +144,19 @@ test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored"
   assert.match(items[0].bodyHtml, /<p>Conversation summary comment<\/p>/);
   assert.match(items[1].bodyHtml, /<p>Top-level review body<\/p>/);
   assert.match(items[2].bodyHtml, /<p>Inline bot suggestion<\/p>/);
+
+  // Every normalized item must carry lifecycle defaults.
+  for (const item of items) {
+    assert.equal(item.status, "pending", `expected status=pending for item ${item.id}`);
+    assert.equal(item.statusReason, null, `expected statusReason=null for item ${item.id}`);
+  }
+
+  // The review-comment item with review-thread metadata must still carry the defaults.
+  const reviewCommentItem = items.find((item) => item.type === "review_comment");
+  assert.ok(reviewCommentItem, "expected a review_comment item");
+  assert.ok(reviewCommentItem.threadId, "expected threadId to be present");
+  assert.equal(reviewCommentItem.status, "pending");
+  assert.equal(reviewCommentItem.statusReason, null);
 });
 
 test("fetchFeedbackItemsForPR paginates review thread comments beyond the first page", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -512,6 +512,8 @@ export async function fetchFeedbackItemsForPR(
         decision: null,
         decisionReason: null,
         action: null,
+        status: "pending" as const,
+        statusReason: null,
       };
     })
     .filter((item) => item.body.trim().length > 0);
@@ -540,6 +542,8 @@ export async function fetchFeedbackItemsForPR(
         decision: null,
         decisionReason: null,
         action: null,
+        status: "pending" as const,
+        statusReason: null,
       };
     })
     .filter((item) => item.body.trim().length > 0);
@@ -568,6 +572,8 @@ export async function fetchFeedbackItemsForPR(
         decision: null,
         decisionReason: null,
         action: null,
+        status: "pending" as const,
+        statusReason: null,
       };
     })
     .filter((item) => item.body.trim().length > 0);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { addPRSchema, configSchema } from "@shared/schema";
 import { storage } from "./storage";
 import { PRBabysitter } from "./babysitter";
+import { applyEvaluationDecision, applyFlagDecision, applyManualDecision } from "./feedbackLifecycle";
 import {
   buildOctokit,
   fetchPullSummary,
@@ -222,29 +223,14 @@ export async function registerRoutes(
 
       const body = item.body.toLowerCase();
       if (body.includes("lgtm") || body.includes("looks good")) {
-        return {
-          ...item,
-          decision: "reject" as const,
-          decisionReason: "Acknowledgement, no code change requested",
-          action: null,
-        };
+        return applyEvaluationDecision(item, false, "Acknowledgement, no code change requested");
       }
 
       if (body.includes("please") || body.includes("should") || body.includes("fix") || body.includes("error") || body.includes("fail")) {
-        return {
-          ...item,
-          decision: "accept" as const,
-          decisionReason: "Likely actionable request",
-          action: item.body,
-        };
+        return { ...applyEvaluationDecision(item, true, "Likely actionable request"), action: item.body };
       }
 
-      return {
-        ...item,
-        decision: "flag" as const,
-        decisionReason: "Unclear actionability, flagged for manual review",
-        action: null,
-      };
+      return applyFlagDecision(item, "Unclear actionability, flagged for manual review");
     });
 
     const accepted = triaged.filter((i) => i.decision === "accept").length;
@@ -308,7 +294,7 @@ export async function registerRoutes(
 
     const feedbackItems = pr.feedbackItems.map((item) =>
       item.id === req.params.feedbackId
-        ? { ...item, decision, decisionReason: "Manual override" }
+        ? applyManualDecision(item, decision as "accept" | "reject" | "flag")
         : item,
     );
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
+import { feedbackStatusEnum } from "@shared/schema";
 import type { Config, FeedbackItem, LogEntry, PR } from "@shared/schema";
 import type { IStorage } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
@@ -148,6 +149,8 @@ export class SqliteStorage implements IStorage {
         decision TEXT,
         decision_reason TEXT,
         action TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        status_reason TEXT,
         FOREIGN KEY(pr_id) REFERENCES prs(id) ON DELETE CASCADE
       );
 
@@ -313,7 +316,7 @@ export class SqliteStorage implements IStorage {
         decision: row.decision,
         decisionReason: row.decision_reason,
         action: row.action,
-        status: (row.status ?? "pending") as FeedbackItem["status"],
+        status: feedbackStatusEnum.catch("pending").parse(row.status ?? "pending"),
         statusReason: row.status_reason ?? null,
       };
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -57,6 +57,8 @@ type FeedbackItemRow = {
   decision: FeedbackItem["decision"];
   decision_reason: string | null;
   action: string | null;
+  status: string;
+  status_reason: string | null;
 };
 
 type LogRow = {
@@ -172,6 +174,8 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("feedback_items", "thread_id", "TEXT");
     this.ensureColumn("feedback_items", "thread_resolved", "INTEGER");
     this.ensureColumn("feedback_items", "audit_token", "TEXT NOT NULL DEFAULT ''");
+    this.ensureColumn("feedback_items", "status", "TEXT NOT NULL DEFAULT 'pending'");
+    this.ensureColumn("feedback_items", "status_reason", "TEXT");
 
     const configExists = this.db.prepare("SELECT 1 AS present FROM config WHERE id = 1").get() as { present: number } | undefined;
     if (!configExists) {
@@ -283,7 +287,7 @@ export class SqliteStorage implements IStorage {
     const rows = this.db.prepare(`
       SELECT id, pr_id, author, body, body_html, reply_kind, source_id, source_node_id, source_url,
              thread_id, thread_resolved, audit_token, file, line, type, created_at, decision,
-             decision_reason, action
+             decision_reason, action, status, status_reason
       FROM feedback_items
       WHERE pr_id IN (${placeholders})
       ORDER BY created_at ASC
@@ -309,6 +313,8 @@ export class SqliteStorage implements IStorage {
         decision: row.decision,
         decisionReason: row.decision_reason,
         action: row.action,
+        status: (row.status ?? "pending") as FeedbackItem["status"],
+        statusReason: row.status_reason ?? null,
       };
 
       const items = itemsByPrId.get(row.pr_id) || [];
@@ -324,8 +330,9 @@ export class SqliteStorage implements IStorage {
     const insert = this.db.prepare(`
       INSERT INTO feedback_items (
         id, pr_id, author, body, body_html, reply_kind, source_id, source_node_id, source_url,
-        thread_id, thread_resolved, audit_token, file, line, type, created_at, decision, decision_reason, action
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        thread_id, thread_resolved, audit_token, file, line, type, created_at, decision, decision_reason, action,
+        status, status_reason
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const item of items) {
@@ -349,6 +356,8 @@ export class SqliteStorage implements IStorage {
         item.decision,
         item.decisionReason,
         item.action,
+        item.status,
+        item.statusReason,
       );
     }
   }

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -50,6 +50,8 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
         decision: "accept",
         decisionReason: "Actionable request",
         action: "Fix thing",
+        status: "resolved",
+        statusReason: "GitHub audit trail verified",
       },
     ],
     accepted: 1,
@@ -78,6 +80,8 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(reloadedPr?.feedbackItems[0]?.threadId, "PRRT_kwDO_thread");
   assert.equal(reloadedPr?.feedbackItems[0]?.auditToken, "codefactory-feedback:feedback-1");
   assert.equal(reloadedPr?.accepted, 1);
+  assert.equal(reloadedPr?.feedbackItems[0]?.status, "resolved");
+  assert.equal(reloadedPr?.feedbackItems[0]?.statusReason, "GitHub audit trail verified");
   assert.equal(logs.length, 1);
   assert.equal(logs[0]?.phase, "agent");
   assert.deepEqual(logs[0]?.metadata, { attempt: 1 });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -8,6 +8,17 @@ export type PRStatus = z.infer<typeof prStatusEnum>;
 export const triageDecision = z.enum(["accept", "reject", "flag"]);
 export type TriageDecision = z.infer<typeof triageDecision>;
 
+export const feedbackStatusEnum = z.enum([
+  "pending",
+  "queued",
+  "in_progress",
+  "resolved",
+  "failed",
+  "rejected",
+  "flagged",
+]);
+export type FeedbackStatus = z.infer<typeof feedbackStatusEnum>;
+
 export const feedbackItemSchema = z.object({
   id: z.string(),
   author: z.string(),
@@ -27,6 +38,8 @@ export const feedbackItemSchema = z.object({
   decision: triageDecision.nullable(),
   decisionReason: z.string().nullable(),
   action: z.string().nullable(),
+  status: feedbackStatusEnum,
+  statusReason: z.string().nullable(),
 });
 export type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -51,6 +51,20 @@
   - Reflect that scope in the design doc and implementation plan.
   - Add reload tests that cover each promised state category, not just one table.
 
+## 2026-03-15 - Sync CREATE TABLE DDL with ensureColumn migrations
+- Pattern: New columns were added via `ensureColumn` but the `CREATE TABLE` statement was left unchanged, causing the DDL to diverge from the actual table shape.
+- Rule: When adding columns to an existing SQLite table via `ensureColumn`, also add those columns to the `CREATE TABLE` block so fresh databases and migrated databases have identical schemas.
+- Prevention checklist:
+  - After adding an `ensureColumn` call, also update the `CREATE TABLE` statement with the same column definition.
+  - Use `ensureColumn` only for migration of existing DBs; the canonical definition lives in `CREATE TABLE`.
+
+## 2026-03-15 - Use Zod's `.catch()` for safe SQLite enum round-trips
+- Pattern: Raw SQLite string values were cast with TypeScript `as` to enum types, bypassing validation. A corrupt or future value would silently produce invalid state.
+- Rule: When reading enum-typed columns from SQLite, use `schema.catch(defaultValue).parse(row.field)` so unknown values fall back gracefully instead of propagating invalid state.
+- Prevention checklist:
+  - Never cast SQLite TEXT columns to enum types with `as`; use Zod parse with `.catch()` instead.
+  - Provide a safe default (e.g., `"pending"`) that keeps old rows valid without throwing.
+
 ## 2026-03-15 - Confirm the exact push target before defaulting to a safety branch
 - Pattern: I defaulted to pushing a new branch for a repo import, but the user later clarified they wanted the full workspace on `main`.
 - Rule: When a user asks to push a repository, determine the intended destination branch up front; use a safety branch only when the branch target is unspecified.


### PR DESCRIPTION
## Summary
- Adds a persisted `status`/`statusReason` lifecycle field to every `FeedbackItem` (pending → queued → in_progress → resolved/failed/rejected/flagged)
- Centralizes transition logic in `server/feedbackLifecycle.ts` pure helpers; routes and babysitter use them instead of inline spreads
- Babysitter now marks claimed items `in_progress` before the agent runs, `resolved` on audit pass, `failed` on error — only the claimed items are updated
- Dashboard replaces the decision badge with a `FeedbackStatusTag`; resolved/rejected rows collapse by default via Radix Collapsible; PR summaries show active lifecycle counts

## Test Plan
- [ ] `node --test --import tsx server/storage.test.ts server/feedbackLifecycle.test.ts server/github.test.ts server/babysitter.test.ts client/src/lib/feedbackStatus.test.ts` — 34 tests, all pass
- [ ] `npm run check` — clean typecheck
- [ ] Manual: add a PR, verify comments start as PENDING, manual accept changes badge to QUEUED, resolved/rejected rows collapse by default, failed rows stay expanded