### PR TITLE
docs: require PRs for completed work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`client/src/` hosts the React dashboard, including pages, hooks, and UI primitives. `server/` contains the Express entrypoint, GitHub integration, PR babysitter/worktree logic, storage adapters, and the current `*.test.ts` files. `shared/schema.ts` defines Zod contracts shared across the app. `script/build.ts` builds the production bundle into `dist/`; treat `dist/` as generated output. Planning and QA artifacts live in `docs/plans/`, `dogfood-output/`, and `tasks/`.
+
+## Build, Test, and Development Commands
+Use `npm install` to install dependencies. `npm run dev` starts the local service in development mode on `PORT` or `5001`. `npm run build` bundles the client and server into `dist/`, and `npm run start` runs `dist/index.cjs` in production mode. `npm run check` runs the strict TypeScript typecheck. Run the current test suite with `node --test --import tsx server/*.test.ts`. Use `npm run db:push` only when changing schema-backed database behavior; it requires `DATABASE_URL`.
+
+## Coding Style & Naming Conventions
+Use strict TypeScript, 2-space indentation, double quotes, and semicolons to match the existing code. Keep React code under `client/src/`, server modules under `server/`, and shared contracts in `shared/`. Prefer the existing path aliases: `@/` for client imports and `@shared/` for shared modules. Follow established file naming: camelCase for server helpers such as `repoWorkspace.ts`, kebab-case for route files such as `not-found.tsx`, and `*.test.ts` for tests.
+
+## Testing Guidelines
+Tests use the Node test runner with `tsx` and are currently colocated in `server/`. Add focused regression coverage for changes to storage, GitHub sync, repo workspace isolation, or babysitter flows. For filesystem behavior, prefer temp directories over repo-local fixtures so tests remain isolated and repeatable.
+
+## Commit & Pull Request Guidelines
+Recent commits favor short imperative summaries, usually with prefixes like `feat:`, `fix:`, and `docs:`. Keep PRs narrow, explain the behavior change, and list the commands you ran to verify it. Include screenshots for dashboard UI changes. Always start work in a git worktree created from a freshly updated `main`, then push to a branch instead of `main` unless the user explicitly asks for a direct push. Always open a PR when completed work is ready unless the user explicitly instructs otherwise.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -99,3 +99,12 @@
   - Check that every declared dependency bucket, including `optionalDependencies`, appears in `package-lock.json`.
   - Run `npm ci` in the branch before opening or updating a PR when dependency metadata changes.
   - If CI reports a manifest-lock mismatch, inspect the exact missing package from the log instead of assuming the root dependency lists are sufficient.
+
+## 2026-03-15 - Treat PR creation as a default completion step
+- Pattern: I documented branch-push safety rules but did not explicitly require opening a PR for finished work.
+- Rule: When work is complete in this repository, open a PR unless the user explicitly says not to.
+- Prevention checklist:
+  - Re-read the repo workflow instructions before closing a task and confirm whether PR creation is mandatory.
+  - Treat "push to a branch" and "open a PR" as separate requirements, and satisfy both.
+  - If the current worktree contains unrelated changes, isolate the task in a fresh worktree before creating the PR.
+  - Call out any explicit user instruction to skip PR creation in the final handoff.


### PR DESCRIPTION
## Summary
- add AGENTS.md repository guidance with an explicit requirement to open a PR for completed work
- add a lessons entry so future sessions treat PR creation as part of completion

## Verification
- reviewed the diff for AGENTS.md and tasks/lessons.md
