### PR TITLE
Add agent command visibility to PR comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5110,6 +5110,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -7454,6 +7455,19 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -412,7 +412,7 @@ function formatAgentCommandGitHubComment(agent: CodingAgent, prompt: string): st
     "<details>",
     "<summary>Agent prompt (click to expand)</summary>",
     "",
-    "```",
+    "```text",
     prompt,
     "```",
     "",
@@ -797,6 +797,22 @@ export class PRBabysitter {
         }
       };
 
+      const postAgentCommandComment = async (agent: CodingAgent, prompt: string) => {
+        try {
+          await this.github.postPRComment(
+            octokit,
+            parsedPr,
+            formatAgentCommandGitHubComment(agent, prompt),
+          );
+        } catch (error) {
+          await logBestEffortFailure(
+            pr.id,
+            "github.agent-command",
+            `Failed to post agent command comment: ${summarizeUnknownError(error)}`,
+          );
+        }
+      };
+
       const pendingComments = pr.feedbackItems.filter((item) => item.status === "pending");
       await queueLog(pr.id, "info", `Evaluating ${pendingComments.length} pending feedback item(s)`, {
         phase: "evaluate.comments",
@@ -1096,19 +1112,7 @@ export class PRBabysitter {
                 metadata: { agent, prompt: conflictPrompt },
               });
 
-              try {
-                await this.github.postPRComment(
-                  octokit,
-                  parsedPr,
-                  formatAgentCommandGitHubComment(agent, conflictPrompt),
-                );
-              } catch (error) {
-                await logBestEffortFailure(
-                  pr.id,
-                  "github.agent-command",
-                  `Failed to post agent command comment: ${summarizeUnknownError(error)}`,
-                );
-              }
+              await postAgentCommandComment(agent, conflictPrompt);
 
               const conflictResult = await this.runtime.applyFixesWithAgent({
                 agent,
@@ -1204,19 +1208,7 @@ export class PRBabysitter {
             });
 
             // Post agent command to GitHub PR as a comment for debugging visibility.
-            try {
-              await this.github.postPRComment(
-                octokit,
-                parsedPr,
-                formatAgentCommandGitHubComment(agent, fixPrompt),
-              );
-            } catch (error) {
-              await logBestEffortFailure(
-                pr.id,
-                "github.agent-command",
-                `Failed to post agent command comment: ${summarizeUnknownError(error)}`,
-              );
-            }
+            await postAgentCommandComment(agent, fixPrompt);
 
             // Update status replies: agent is starting.
             const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -18,6 +18,7 @@ import {
   listOpenPullsForRepo,
   parseRepoSlug,
   postFollowUpForFeedbackItem,
+  postPRComment,
   postStatusReplyForFeedbackItem,
   resolveReviewThread,
   resolveGitHubAuthToken,
@@ -42,6 +43,7 @@ type GitHubService = {
   listFailingStatuses: typeof listFailingStatuses;
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
   postFollowUpForFeedbackItem: typeof postFollowUpForFeedbackItem;
+  postPRComment: typeof postPRComment;
   postStatusReplyForFeedbackItem: typeof postStatusReplyForFeedbackItem;
   resolveReviewThread: typeof resolveReviewThread;
   resolveGitHubAuthToken: typeof resolveGitHubAuthToken;
@@ -63,6 +65,7 @@ const defaultGitHubService: GitHubService = {
   listFailingStatuses,
   listOpenPullsForRepo,
   postFollowUpForFeedbackItem,
+  postPRComment,
   postStatusReplyForFeedbackItem,
   resolveReviewThread,
   resolveGitHubAuthToken,
@@ -399,6 +402,21 @@ function buildFeedbackFollowUpBody(headSha: string, auditToken: string): string 
     summary,
     "",
     auditToken,
+  ].join("\n");
+}
+
+function formatAgentCommandGitHubComment(agent: CodingAgent, prompt: string): string {
+  return [
+    `\ud83e\udd16 **CodeFactory** dispatched \`${agent}\` with the following prompt:`,
+    "",
+    "<details>",
+    "<summary>Agent prompt (click to expand)</summary>",
+    "",
+    "```",
+    prompt,
+    "```",
+    "",
+    "</details>",
   ].join("\n");
 }
 
@@ -809,10 +827,16 @@ export class PRBabysitter {
           continue;
         }
 
+        const evalPrompt = buildCommentEvaluationPrompt({ pr, item });
+        await queueLog(pr.id, "info", `Evaluating feedback ${item.id} with ${agent}`, {
+          phase: "evaluate.comments",
+          metadata: { feedbackId: item.id, agent, prompt: evalPrompt },
+        });
+
         const evaluation = await this.runtime.evaluateFixNecessityWithAgent({
           agent,
           cwd: process.cwd(),
-          prompt: buildCommentEvaluationPrompt({ pr, item }),
+          prompt: evalPrompt,
         });
 
         const updated = applyEvaluationDecision(item, evaluation.needsFix, evaluation.reason);
@@ -868,15 +892,21 @@ export class PRBabysitter {
         phase: "evaluate.status",
       });
       for (const status of failingStatuses) {
+        const statusEvalPrompt = buildStatusEvaluationPrompt({
+          pr,
+          context: status.context,
+          description: status.description,
+          targetUrl: status.targetUrl,
+        });
+        await queueLog(pr.id, "info", `Evaluating failing status ${status.context} with ${agent}`, {
+          phase: "evaluate.status",
+          metadata: { context: status.context, agent, prompt: statusEvalPrompt },
+        });
+
         const evaluation = await this.runtime.evaluateFixNecessityWithAgent({
           agent,
           cwd: process.cwd(),
-          prompt: buildStatusEvaluationPrompt({
-            pr,
-            context: status.context,
-            description: status.description,
-            targetUrl: status.targetUrl,
-          }),
+          prompt: statusEvalPrompt,
         });
 
         if (evaluation.needsFix) {
@@ -1054,19 +1084,36 @@ export class PRBabysitter {
                   }
                 : undefined;
 
+              const conflictPrompt = buildConflictResolutionPrompt({
+                pr,
+                pullSummary,
+                remoteName,
+                conflictFiles,
+              });
+
               await queueLog(pr.id, "info", `Launching ${agent} to resolve merge conflicts`, {
                 phase: "conflict.agent",
+                metadata: { agent, prompt: conflictPrompt },
               });
+
+              try {
+                await this.github.postPRComment(
+                  octokit,
+                  parsedPr,
+                  formatAgentCommandGitHubComment(agent, conflictPrompt),
+                );
+              } catch (error) {
+                await logBestEffortFailure(
+                  pr.id,
+                  "github.agent-command",
+                  `Failed to post agent command comment: ${summarizeUnknownError(error)}`,
+                );
+              }
 
               const conflictResult = await this.runtime.applyFixesWithAgent({
                 agent,
                 cwd: worktreePath,
-                prompt: buildConflictResolutionPrompt({
-                  pr,
-                  pullSummary,
-                  remoteName,
-                  conflictFiles,
-                }),
+                prompt: conflictPrompt,
                 env: conflictAgentEnv,
                 onStdoutChunk: conflictStdout.onChunk,
                 onStderrChunk: conflictStderr.onChunk,
@@ -1143,10 +1190,33 @@ export class PRBabysitter {
                 }
               : undefined;
 
+            const fixPrompt = buildAgentFixPrompt({
+              pr,
+              pullSummary,
+              remoteName,
+              commentTasks,
+              statusTasks,
+            });
+
             await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
               phase: "agent",
-              metadata: { githubAuth: Boolean(githubToken) },
+              metadata: { githubAuth: Boolean(githubToken), prompt: fixPrompt },
             });
+
+            // Post agent command to GitHub PR as a comment for debugging visibility.
+            try {
+              await this.github.postPRComment(
+                octokit,
+                parsedPr,
+                formatAgentCommandGitHubComment(agent, fixPrompt),
+              );
+            } catch (error) {
+              await logBestEffortFailure(
+                pr.id,
+                "github.agent-command",
+                `Failed to post agent command comment: ${summarizeUnknownError(error)}`,
+              );
+            }
 
             // Update status replies: agent is starting.
             const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
@@ -1155,13 +1225,7 @@ export class PRBabysitter {
             const applyResult = await this.runtime.applyFixesWithAgent({
               agent,
               cwd: worktreePath,
-              prompt: buildAgentFixPrompt({
-                pr,
-                pullSummary,
-                remoteName,
-                commentTasks,
-                statusTasks,
-              }),
+              prompt: fixPrompt,
               env: agentEnv,
               onStdoutChunk: agentStdout.onChunk,
               onStderrChunk: agentStderr.onChunk,

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -405,16 +405,36 @@ function buildFeedbackFollowUpBody(headSha: string, auditToken: string): string 
   ].join("\n");
 }
 
+const CODEFACTORY_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
+
+function buildCodeFence(content: string): { open: string; close: string } {
+  let maxRun = 0;
+  const backtickRuns = content.match(/`{3,}/g);
+  if (backtickRuns) {
+    for (const run of backtickRuns) {
+      if (run.length > maxRun) maxRun = run.length;
+    }
+  }
+  const fence = "`".repeat(Math.max(3, maxRun + 1));
+  return { open: `${fence}text`, close: fence };
+}
+
+function isCodeFactoryComment(body: string): boolean {
+  return body.includes(CODEFACTORY_COMMENT_MARKER);
+}
+
 function formatAgentCommandGitHubComment(agent: CodingAgent, prompt: string): string {
+  const fence = buildCodeFence(prompt);
   return [
+    CODEFACTORY_COMMENT_MARKER,
     `\ud83e\udd16 **CodeFactory** dispatched \`${agent}\` with the following prompt:`,
     "",
     "<details>",
     "<summary>Agent prompt (click to expand)</summary>",
     "",
-    "```text",
+    fence.open,
     prompt,
-    "```",
+    fence.close,
     "",
     "</details>",
   ].join("\n");
@@ -829,6 +849,19 @@ export class PRBabysitter {
             line: item.line,
           },
         });
+
+        if (isCodeFactoryComment(item.body)) {
+          const reason = "CodeFactory-authored agent command comment; no code change required";
+          evaluatedItems.set(item.id, applyEvaluationDecision(item, false, reason));
+          await queueLog(pr.id, "info", `Ignored self-authored agent command comment ${item.id}`, {
+            phase: "evaluate.comments",
+            metadata: {
+              feedbackId: item.id,
+              decision: "reject",
+            },
+          });
+          continue;
+        }
 
         if (isAutomationAuditTrailFollowUp(item, pr.feedbackItems)) {
           const reason = "Automation audit trail follow-up; no code change required";

--- a/server/github.ts
+++ b/server/github.ts
@@ -547,6 +547,21 @@ export async function replyToIssueComment(
   );
 }
 
+export async function postPRComment(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+  body: string,
+): Promise<void> {
+  await withGitHubErrorHandling("PR comment", parsed, () =>
+    octokit.issues.createComment({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.number,
+      body,
+    }),
+  );
+}
+
 export async function postFollowUpForFeedbackItem(
   octokit: Octokit,
   parsed: ParsedPRUrl,


### PR DESCRIPTION
## Summary
This PR adds visibility into agent commands by posting the prompts used to dispatch coding agents as comments on pull requests. This improves debugging and transparency by allowing developers to see exactly what instructions were given to agents when they were launched.

## Key Changes
- **New `postPRComment` function** in `github.ts`: Exports a reusable function to post comments on pull requests via the GitHub API
- **New `formatAgentCommandGitHubComment` function** in `babysitter.ts`: Formats agent prompts into readable GitHub comments with collapsible details sections
- **Agent command logging**: Posts comments when launching agents in two scenarios:
  - Merge conflict resolution phase
  - Autonomous fix application phase
- **Prompt extraction**: Refactored prompt building to extract prompts into variables before agent execution, enabling both logging and commenting
- **Error handling**: Wrapped comment posting in try-catch blocks with best-effort failure logging to prevent agent execution from being blocked by comment posting failures
- **Enhanced metadata logging**: Added prompts to the metadata of existing log entries for evaluation phases (comments and status checks)

## Implementation Details
- The `postPRComment` function follows the existing pattern of other GitHub API calls with proper error handling via `withGitHubErrorHandling`
- Comments are formatted with emoji and collapsible sections for better readability in the PR UI
- Prompt variables are extracted before agent calls to avoid computing them twice and to enable logging before execution
- Comment posting failures are logged but don't interrupt the agent workflow, maintaining robustness

https://claude.ai/code/session_01TzL4BcoAdCyBhodbwy6392