### PR TITLE
Move OpenAI API key to action input parameter

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -18,6 +18,7 @@ jobs:
 
       - uses: openai/codex-action@v1
         with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: |
             Review this pull request. Focus on:
             - Code correctness and potential bugs
@@ -25,5 +26,3 @@ jobs:
             - Performance concerns
             - Code style and readability
             Post your review as GitHub PR review comments.
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
Refactored the Codex code review workflow to pass the OpenAI API key as an explicit action input parameter instead of relying on environment variables.

## Key Changes
- Moved `OPENAI_API_KEY` from the `env` section to the `with` input parameters of the `openai/codex-action@v1` action
- Changed from `env: OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}` to `openai-api-key: ${{ secrets.OPENAI_API_KEY }}`

## Implementation Details
This change aligns with the action's expected input interface, making the configuration more explicit and maintainable. Using action inputs rather than environment variables is a cleaner approach that:
- Makes dependencies on secrets more visible in the workflow configuration
- Follows GitHub Actions best practices for passing parameters to actions
- Improves clarity about what configuration the action requires

https://claude.ai/code/session_01VVrgwFBrWe8XLfMcT7tfYw