### PR TITLE
Reduce console logging verbosity in development

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -57,7 +57,7 @@ async function buildAll() {
     },
     minify: true,
     external: externals,
-    logLevel: "info",
+    logLevel: "error",
   });
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,8 +23,13 @@ app.use(
 app.use(express.urlencoded({ extended: false }));
 
 export function log(message: string, source = "express") {
-  // Only errors are logged to the console; callers that need verbose
-  // output should use the structured logger (storage.addLog) instead.
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+  console.log(`${formattedTime} [${source}] ${message}`);
 }
 
 (async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,41 +23,9 @@ app.use(
 app.use(express.urlencoded({ extended: false }));
 
 export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
+  // Only errors are logged to the console; callers that need verbose
+  // output should use the structured logger (storage.addLog) instead.
 }
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: unknown;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
 
 (async () => {
   await registerRoutes(httpServer, app);

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import path from "path";
 import { nanoid } from "nanoid";
 
-const viteLogger = createLogger();
+const viteLogger = createLogger("error");
 
 export async function setupVite(server: Server, app: Express) {
   const serverOptions = {


### PR DESCRIPTION
## Summary
This PR reduces console logging verbosity by removing detailed request/response logging and adjusting log levels across the build and development server setup.

## Key Changes
- **Removed request logging middleware**: Deleted the Express middleware that logged all API requests with method, path, status code, duration, and response body
- **Simplified log function**: Converted the `log()` function to a no-op with a comment indicating that only errors should be logged to console, with verbose output directed to the structured logger instead
- **Adjusted build log level**: Changed esbuild's `logLevel` from "info" to "error" in `script/build.ts` to suppress non-error build messages
- **Adjusted Vite log level**: Changed Vite's logger initialization from default to "error" level in `server/vite.ts` to suppress non-error development server messages

## Implementation Details
The changes shift the logging strategy away from console-based verbose output toward a structured logging approach. The `log()` function is retained for backward compatibility but is now effectively disabled, with a comment directing developers to use `storage.addLog()` for verbose output that needs to be captured.

https://claude.ai/code/session_018UR2muSFRGtjGF1qu748rF