### PR TITLE
Extract and include agent feedback summaries in PR follow-ups

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -254,11 +254,17 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
       applyFixesWithAgent: async ({ prompt, env, onStdoutChunk, onStderrChunk }) => {
         receivedPrompt = prompt;
         receivedEnv = env;
-        onStdoutChunk?.("agent stdout line\n");
+        const agentOutput = [
+          "agent stdout line",
+          "FEEDBACK_SUMMARY_START codefactory-feedback:gh-review-comment-1",
+          "Renamed the variable from `foo` to `bar` as requested.",
+          "FEEDBACK_SUMMARY_END",
+        ].join("\n") + "\n";
+        onStdoutChunk?.(agentOutput);
         onStderrChunk?.("agent stderr line\n");
         return {
           code: 0,
-          stdout: "agent stdout line\n",
+          stdout: agentOutput,
           stderr: "agent stderr line\n",
         };
       },
@@ -286,7 +292,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.deepEqual(postedFollowUps, [
     {
       id: "gh-review-comment-1",
-      body: "Addressed in commit `def456` by the latest babysitter run.\n\ncodefactory-feedback:gh-review-comment-1",
+      body: "Addressed in commit `def456` by the latest babysitter run.\n\nRenamed the variable from `foo` to `bar` as requested.\n\ncodefactory-feedback:gh-review-comment-1",
     },
   ]);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
@@ -297,6 +303,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.match(receivedPrompt, /commit it and push it to origin HEAD:feature\/verbose/i);
   assert.match(receivedPrompt, /GitHub follow-up replies and review-thread resolution will be handled by the babysitter/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
+  assert.match(receivedPrompt, /FEEDBACK_SUMMARY_START/);
   assert.equal(receivedEnv?.GITHUB_TOKEN, "test-token");
   assert.equal(receivedEnv?.GH_TOKEN, "test-token");
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -281,8 +281,11 @@ function buildAgentFixPrompt(params: {
     "When done:",
     "1) Run the relevant verification for your changes.",
     `2) If you changed code, commit it and push it to ${remoteName} HEAD:${pullSummary.headRef}.`,
-    "3) Summarize every addressed or blocked feedback item in your final response and include the exact audit token for each item.",
-    "4) Summarize the code changes, verification, and git actions you completed.",
+    "3) For each feedback item you addressed or were blocked on, emit a summary block in the following format:",
+    "   FEEDBACK_SUMMARY_START <auditToken>",
+    "   <A concise 1-2 sentence summary of what you did or why you were blocked>",
+    "   FEEDBACK_SUMMARY_END",
+    "   Include one block per audit token. These summaries will be posted as follow-up comments on the PR.",
   ].join("\n");
 }
 
@@ -293,6 +296,22 @@ function extractMentionedAuditTokens(body: string): string[] {
   }
 
   return Array.from(new Set(matches));
+}
+
+const FEEDBACK_SUMMARY_BLOCK = /FEEDBACK_SUMMARY_START\s+(codefactory-feedback:[^\s]+)\s*\n([\s\S]*?)FEEDBACK_SUMMARY_END/g;
+
+function extractAgentSummaries(agentOutput: string): Map<string, string> {
+  const summaries = new Map<string, string>();
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(FEEDBACK_SUMMARY_BLOCK.source, FEEDBACK_SUMMARY_BLOCK.flags);
+  while ((match = pattern.exec(agentOutput)) !== null) {
+    const auditToken = match[1];
+    const summary = match[2].trim();
+    if (auditToken && summary) {
+      summaries.set(auditToken, summary);
+    }
+  }
+  return summaries;
 }
 
 function isAutomationAuditTrailFollowUp(item: FeedbackItem, feedbackItems: FeedbackItem[]): boolean {
@@ -392,17 +411,21 @@ function collectGitHubFollowUpTasks(pr: PR): FeedbackItem[] {
   return pr.feedbackItems.filter((item) => needsGitHubFollowUp(item, pr.feedbackItems));
 }
 
-function buildFeedbackFollowUpBody(headSha: string, auditToken: string): string {
+function buildFeedbackFollowUpBody(headSha: string, auditToken: string, agentSummary?: string): string {
   const shortSha = headSha.trim() ? headSha.trim().slice(0, 7) : "";
-  const summary = shortSha
+  const headline = shortSha
     ? `Addressed in commit \`${shortSha}\` by the latest babysitter run.`
     : "Addressed in the latest babysitter run.";
 
-  return [
-    summary,
-    "",
-    auditToken,
-  ].join("\n");
+  const parts = [headline];
+
+  if (agentSummary) {
+    parts.push("", agentSummary);
+  }
+
+  parts.push("", auditToken);
+
+  return parts.join("\n");
 }
 
 const CODEFACTORY_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
@@ -1008,6 +1031,7 @@ export class PRBabysitter {
       let headShaForFollowUp = pullSummary.headSha;
       let branchMoved = false;
       let remoteNameForLogs: string | null = null;
+      let agentSummaries = new Map<string, string>();
 
       if (hasConflicts) {
         await queueLog(pr.id, "info", `PR #${pr.number} has merge conflicts with base branch ${pullSummary.baseRef}`, {
@@ -1267,9 +1291,12 @@ export class PRBabysitter {
             // Update status replies: agent succeeded.
             await Promise.all(commentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
 
+            // Extract per-feedback-item summaries from agent output.
+            agentSummaries = extractAgentSummaries(applyResult.stdout);
+
             await queueLog(pr.id, "info", `${agent} completed successfully`, {
               phase: "agent",
-              metadata: { code: applyResult.code },
+              metadata: { code: applyResult.code, extractedSummaries: agentSummaries.size },
             });
           }
 
@@ -1408,7 +1435,7 @@ export class PRBabysitter {
             },
           });
 
-          const body = buildFeedbackFollowUpBody(headShaForFollowUp, item.auditToken);
+          const body = buildFeedbackFollowUpBody(headShaForFollowUp, item.auditToken, agentSummaries.get(item.auditToken));
           await this.github.postFollowUpForFeedbackItem(octokit, parsedPr, item, body);
         }
 


### PR DESCRIPTION
## Summary
This change enhances the babysitter's feedback follow-up mechanism by extracting structured summaries from the agent's output and including them in GitHub follow-up comments. Instead of just posting the audit token, follow-up comments now include a concise summary of what the agent did or why it was blocked.

## Key Changes
- **Updated agent prompt**: Modified the instructions to ask the agent to emit structured `FEEDBACK_SUMMARY_START`/`FEEDBACK_SUMMARY_END` blocks with audit tokens and concise summaries for each feedback item addressed or blocked on
- **Added summary extraction**: Implemented `extractAgentSummaries()` function that parses the agent output using regex to extract audit tokens and their corresponding summaries into a Map
- **Enhanced follow-up comments**: Updated `buildFeedbackFollowUpBody()` to accept an optional `agentSummary` parameter and include it in the follow-up comment body between the headline and audit token
- **Integrated extraction into workflow**: Added a call to `extractAgentSummaries()` after successful agent execution to populate the summaries map, which is then passed when building follow-up comments
- **Updated tests**: Modified test to verify the new structured output format and confirm that agent summaries are correctly extracted and included in follow-up comments

## Implementation Details
- The regex pattern `FEEDBACK_SUMMARY_BLOCK` captures audit tokens in the format `codefactory-feedback:*` and extracts the summary text between the markers
- Summaries are stored in a Map keyed by audit token for efficient lookup when building follow-ups
- The extraction happens after agent completion but before follow-up comments are posted, ensuring all summaries are available
- Logging includes the count of extracted summaries for observability

https://claude.ai/code/session_01HMqETyPyrWQEsf6V3cV1fU