### PR TITLE
Make PR reference clickable and link to GitHub

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -604,9 +604,14 @@ export default function Dashboard() {
                     <div className="flex items-center gap-2">
                       <StatusDot status={selectedPR.status} />
                       <span className="truncate font-medium">{selectedPR.title}</span>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">
+                      <a
+                        href={selectedPR.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+                      >
                         {selectedPR.repo}#{selectedPR.number}
-                      </span>
+                      </a>
                     </div>
                     <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                       <span>status: {formatStatusLabel(selectedPR.status)}</span>


### PR DESCRIPTION
## Summary
Enhanced the pull request reference display in the dashboard by converting it from plain text to a clickable link that navigates to the PR on GitHub.

## Key Changes
- Converted the PR reference (`repo#number`) from a `<span>` to an `<a>` element
- Added `href` attribute pointing to `selectedPR.url` to enable navigation to the GitHub PR
- Added `target="_blank"` and `rel="noopener noreferrer"` for secure external link opening
- Enhanced styling with:
  - `underline` and `decoration-border` for visual link indication
  - `underline-offset-2` for better spacing
  - `transition-colors` and `hover:text-foreground` for interactive feedback on hover

## Implementation Details
The change maintains the existing layout and spacing while improving usability by allowing users to quickly navigate to the full PR details on GitHub directly from the dashboard view.

https://claude.ai/code/session_01Cr9JEa3DpNZDDr9rLE8cjU