### PR TITLE
Add agent activity indicator to PR rows and details

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -4,6 +4,7 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
 import type { Config, FeedbackItem, LogEntry, PR } from "@shared/schema";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
 import {
   formatFeedbackStatusLabel,
@@ -64,6 +65,38 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
   );
 }
 
+function AgentIndicator({ pr }: { pr: PR }) {
+  const agentCount = pr.feedbackItems.filter((item) => item.status === "in_progress").length;
+  const isProcessing = pr.status === "processing";
+
+  if (!isProcessing && agentCount === 0) {
+    return null;
+  }
+
+  const label = agentCount > 0
+    ? `${agentCount} agent${agentCount !== 1 ? "s" : ""} running on this PR`
+    : "Agent run active on this PR";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex shrink-0 cursor-default items-center gap-0.5 text-[12px]"
+          data-testid={`agent-indicator-${pr.id}`}
+        >
+          <span className="animate-pulse">🤖</span>
+          {agentCount > 0 && (
+            <span className="text-[10px] text-muted-foreground">{agentCount}</span>
+          )}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="text-xs">{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
 
@@ -93,6 +126,7 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
           <div className="flex items-center gap-3">
             <span className="w-12 shrink-0 text-muted-foreground">#{pr.number}</span>
             <span className="truncate">{pr.title}</span>
+            <AgentIndicator pr={pr} />
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
             <a
@@ -604,6 +638,7 @@ export default function Dashboard() {
                     <div className="flex items-center gap-2">
                       <StatusDot status={selectedPR.status} />
                       <span className="truncate font-medium">{selectedPR.title}</span>
+                      <AgentIndicator pr={selectedPR} />
                       <span className="shrink-0 text-[11px] text-muted-foreground">
                         {selectedPR.repo}#{selectedPR.number}
                       </span>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -66,7 +66,7 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
 }
 
 function AgentIndicator({ pr }: { pr: PR }) {
-  const agentCount = pr.feedbackItems.filter((item) => item.status === "in_progress").length;
+  const agentCount = countActiveFeedbackStatuses(pr.feedbackItems).inProgress;
   const isProcessing = pr.status === "processing";
 
   if (!isProcessing && agentCount === 0) {


### PR DESCRIPTION
## Summary
This PR adds a visual indicator to show when agents are actively processing pull requests. The indicator displays a pulsing robot emoji with a count of running agents and appears in both the PR list and the PR detail view.

## Key Changes
- **New `AgentIndicator` component**: Displays agent activity status with a tooltip showing detailed information
  - Shows a pulsing 🤖 emoji when agents are running or PR is being processed
  - Displays the count of agents currently running on the PR
  - Includes a tooltip with descriptive text about the agent activity
  - Returns `null` when there's no active processing to avoid unnecessary UI clutter

- **Updated PR row display**: Added `AgentIndicator` to the main PR list view, positioned after the PR title

- **Updated PR detail header**: Added `AgentIndicator` to the selected PR detail panel header for consistency

- **UI imports**: Added Tooltip components from the UI library to support the indicator's tooltip functionality

## Implementation Details
- The indicator checks two conditions: if the PR status is "processing" or if there are feedback items with "in_progress" status
- The agent count is derived from filtering feedback items by "in_progress" status
- The tooltip message dynamically pluralizes "agent/agents" based on the count
- Uses a pulsing animation on the robot emoji to draw attention to active processing
- Includes a `data-testid` attribute for testing purposes

https://claude.ai/code/session_0177UWKypL1ZRuRG1VYoXexR