### PR TITLE
Add PR ready-to-merge indicator when all feedback is resolved

### DIFF
--- a/client/src/lib/feedbackStatus.test.ts
+++ b/client/src/lib/feedbackStatus.test.ts
@@ -48,29 +48,15 @@ test("isPRReadyToMerge returns true when all resolved or rejected", () => {
   assert.equal(isPRReadyToMerge(items as FeedbackItem[]), true);
 });
 
-test("isPRReadyToMerge returns false when any item is pending", () => {
-  const items: Pick<FeedbackItem, "status">[] = [
-    { status: "resolved" },
-    { status: "pending" },
-  ];
-  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
-});
-
-test("isPRReadyToMerge returns false when any item is in_progress", () => {
-  const items: Pick<FeedbackItem, "status">[] = [
-    { status: "resolved" },
-    { status: "in_progress" },
-  ];
-  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
-});
-
-test("isPRReadyToMerge returns false when any item is failed", () => {
-  const items: Pick<FeedbackItem, "status">[] = [
-    { status: "resolved" },
-    { status: "failed" },
-  ];
-  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
-});
+for (const status of ["pending", "in_progress", "failed", "queued", "flagged"] as const) {
+  test(`isPRReadyToMerge returns false when any item is ${status}`, () => {
+    const items: Pick<FeedbackItem, "status">[] = [
+      { status: "resolved" },
+      { status },
+    ];
+    assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
+  });
+}
 
 // countActiveFeedbackStatuses
 test("countActiveFeedbackStatuses returns correct queued, inProgress, failed counts", () => {

--- a/client/src/lib/feedbackStatus.test.ts
+++ b/client/src/lib/feedbackStatus.test.ts
@@ -5,6 +5,7 @@ import {
   formatFeedbackStatusLabel,
   isFeedbackCollapsedByDefault,
   countActiveFeedbackStatuses,
+  isPRReadyToMerge,
 } from "./feedbackStatus";
 
 // formatFeedbackStatusLabel
@@ -31,6 +32,44 @@ test('isFeedbackCollapsedByDefault("failed") === false', () => {
 
 test('isFeedbackCollapsedByDefault("pending") === false', () => {
   assert.equal(isFeedbackCollapsedByDefault("pending"), false);
+});
+
+// isPRReadyToMerge
+test("isPRReadyToMerge returns false for empty items", () => {
+  assert.equal(isPRReadyToMerge([]), false);
+});
+
+test("isPRReadyToMerge returns true when all resolved or rejected", () => {
+  const items: Pick<FeedbackItem, "status">[] = [
+    { status: "resolved" },
+    { status: "rejected" },
+    { status: "resolved" },
+  ];
+  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), true);
+});
+
+test("isPRReadyToMerge returns false when any item is pending", () => {
+  const items: Pick<FeedbackItem, "status">[] = [
+    { status: "resolved" },
+    { status: "pending" },
+  ];
+  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
+});
+
+test("isPRReadyToMerge returns false when any item is in_progress", () => {
+  const items: Pick<FeedbackItem, "status">[] = [
+    { status: "resolved" },
+    { status: "in_progress" },
+  ];
+  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
+});
+
+test("isPRReadyToMerge returns false when any item is failed", () => {
+  const items: Pick<FeedbackItem, "status">[] = [
+    { status: "resolved" },
+    { status: "failed" },
+  ];
+  assert.equal(isPRReadyToMerge(items as FeedbackItem[]), false);
 });
 
 // countActiveFeedbackStatuses

--- a/client/src/lib/feedbackStatus.ts
+++ b/client/src/lib/feedbackStatus.ts
@@ -14,8 +14,12 @@ export function getFeedbackStatusBadgeClass(status: FeedbackStatus): string {
   return "border-foreground/30 text-foreground/60"; // pending
 }
 
-export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
+function isTerminalFeedbackStatus(status: FeedbackStatus): boolean {
   return status === "resolved" || status === "rejected";
+}
+
+export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
+  return isTerminalFeedbackStatus(status);
 }
 
 /**
@@ -24,7 +28,7 @@ export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
  */
 export function isPRReadyToMerge(items: FeedbackItem[]): boolean {
   if (items.length === 0) return false;
-  return items.every((item) => item.status === "resolved" || item.status === "rejected");
+  return items.every((item) => isTerminalFeedbackStatus(item.status));
 }
 
 export function countActiveFeedbackStatuses(items: FeedbackItem[]): {

--- a/client/src/lib/feedbackStatus.ts
+++ b/client/src/lib/feedbackStatus.ts
@@ -18,6 +18,15 @@ export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
   return status === "resolved" || status === "rejected";
 }
 
+/**
+ * A PR is ready to merge when it has feedback items and every item
+ * has reached a terminal state (resolved or rejected).
+ */
+export function isPRReadyToMerge(items: FeedbackItem[]): boolean {
+  if (items.length === 0) return false;
+  return items.every((item) => item.status === "resolved" || item.status === "rejected");
+}
+
 export function countActiveFeedbackStatuses(items: FeedbackItem[]): {
   queued: number;
   inProgress: number;

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -10,6 +10,7 @@ import {
   getFeedbackStatusBadgeClass,
   isFeedbackCollapsedByDefault,
   countActiveFeedbackStatuses,
+  isPRReadyToMerge,
 } from "@/lib/feedbackStatus";
 
 function formatClock(timestamp: string | null): string | null {
@@ -66,6 +67,7 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
 
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
+  const readyToMerge = isPRReadyToMerge(pr.feedbackItems);
 
   return (
     <div
@@ -94,6 +96,20 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
             <span className="w-12 shrink-0 text-muted-foreground">#{pr.number}</span>
             <span className="truncate">{pr.title}</span>
           </div>
+          {readyToMerge && (
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              data-testid={`ready-to-merge-${pr.id}`}
+              className="mt-1.5 ml-[3.75rem] inline-flex items-center gap-1.5 border border-green-600 bg-green-600/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider text-green-500 transition-colors hover:bg-green-600/20"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+              Ready to merge
+              <span className="text-[10px] normal-case tracking-normal text-green-500/70">— click to open PR</span>
+            </a>
+          )}
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
             <a
               href={pr.url}
@@ -646,6 +662,19 @@ export default function Dashboard() {
                     </button>
                   )}
                 </div>
+                {isPRReadyToMerge(selectedPR.feedbackItems) && (
+                  <a
+                    href={selectedPR.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="detail-ready-to-merge"
+                    className="mt-2 inline-flex items-center gap-2 border border-green-600 bg-green-600/10 px-3 py-1.5 text-[12px] font-medium uppercase tracking-wider text-green-500 transition-colors hover:bg-green-600/20"
+                  >
+                    <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                    All comments resolved — ready to merge
+                    <span className="text-[11px] normal-case tracking-normal text-green-500/70">Open PR on GitHub →</span>
+                  </a>
+                )}
                 <div className="text-[11px] text-muted-foreground">
                   Background watcher syncs GitHub feedback and pushes approved fixes automatically.
                 </div>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest } from "@/lib/queryClient";
@@ -65,6 +65,41 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
   );
 }
 
+function ReadyToMergeIndicator({
+  href,
+  testId,
+  label,
+  hint,
+  className,
+  dotClassName,
+  hintClassName,
+  onClick,
+}: {
+  href: string;
+  testId: string;
+  label: string;
+  hint?: string;
+  className: string;
+  dotClassName: string;
+  hintClassName?: string;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={onClick}
+      data-testid={testId}
+      className={`inline-flex items-center border border-green-600 bg-green-600/10 font-medium uppercase text-green-500 transition-colors hover:bg-green-600/20 ${className}`}
+    >
+      <span className={`inline-block rounded-full bg-green-500 ${dotClassName}`} />
+      {label}
+      {hint && <span className={hintClassName}>{hint}</span>}
+    </a>
+  );
+}
+
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
   const readyToMerge = isPRReadyToMerge(pr.feedbackItems);
@@ -97,18 +132,16 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
             <span className="truncate">{pr.title}</span>
           </div>
           {readyToMerge && (
-            <a
+            <ReadyToMergeIndicator
               href={pr.url}
-              target="_blank"
-              rel="noopener noreferrer"
+              testId={`ready-to-merge-${pr.id}`}
+              label="Ready to merge"
+              hint="— click to open PR"
               onClick={(event) => event.stopPropagation()}
-              data-testid={`ready-to-merge-${pr.id}`}
-              className="mt-1.5 ml-[3.75rem] inline-flex items-center gap-1.5 border border-green-600 bg-green-600/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider text-green-500 transition-colors hover:bg-green-600/20"
-            >
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
-              Ready to merge
-              <span className="text-[10px] normal-case tracking-normal text-green-500/70">— click to open PR</span>
-            </a>
+              className="mt-1.5 ml-[3.75rem] gap-1.5 px-2 py-0.5 text-[11px] tracking-wider"
+              dotClassName="h-1.5 w-1.5"
+              hintClassName="text-[10px] normal-case tracking-normal text-green-500/70"
+            />
           )}
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
             <a
@@ -663,17 +696,15 @@ export default function Dashboard() {
                   )}
                 </div>
                 {isPRReadyToMerge(selectedPR.feedbackItems) && (
-                  <a
+                  <ReadyToMergeIndicator
                     href={selectedPR.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-testid="detail-ready-to-merge"
-                    className="mt-2 inline-flex items-center gap-2 border border-green-600 bg-green-600/10 px-3 py-1.5 text-[12px] font-medium uppercase tracking-wider text-green-500 transition-colors hover:bg-green-600/20"
-                  >
-                    <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
-                    All comments resolved — ready to merge
-                    <span className="text-[11px] normal-case tracking-normal text-green-500/70">Open PR on GitHub →</span>
-                  </a>
+                    testId="detail-ready-to-merge"
+                    label="All comments resolved — ready to merge"
+                    hint="Open PR on GitHub →"
+                    className="mt-2 gap-2 px-3 py-1.5 text-[12px] tracking-wider"
+                    dotClassName="h-2 w-2"
+                    hintClassName="text-[11px] normal-case tracking-normal text-green-500/70"
+                  />
                 )}
                 <div className="text-[11px] text-muted-foreground">
                   Background watcher syncs GitHub feedback and pushes approved fixes automatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,7 +148,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1685,7 +1684,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4469,7 +4467,6 @@
       "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4503,7 +4500,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4515,7 +4511,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4639,7 +4634,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -4878,7 +4872,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5097,7 +5090,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5495,7 +5487,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5703,7 +5694,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.3.tgz",
       "integrity": "sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -5857,8 +5847,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5954,7 +5943,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6037,7 +6025,6 @@
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7571,18 +7558,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -7827,7 +7802,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7967,7 +7941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8299,7 +8272,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8326,7 +8298,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8340,7 +8311,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8966,7 +8936,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9109,7 +9078,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9169,7 +9137,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9710,7 +9677,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9935,7 +9901,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10513,7 +10478,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10638,7 +10602,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
This PR adds a visual indicator to show when a pull request is ready to merge, displayed when all feedback items have reached a terminal state (resolved or rejected).

## Key Changes
- **New utility function**: Added `isPRReadyToMerge()` to `feedbackStatus.ts` that determines if a PR is ready to merge by checking if all feedback items are either resolved or rejected
- **Dashboard UI updates**: 
  - Added a "Ready to merge" badge in the PR row list view with a link to open the PR on GitHub
  - Added a prominent "All comments resolved — ready to merge" button in the PR detail panel
- **Test coverage**: Added comprehensive test suite for `isPRReadyToMerge()` covering:
  - Empty feedback items (returns false)
  - All resolved/rejected items (returns true)
  - Various blocking statuses (pending, in_progress, failed)

## Implementation Details
- The `isPRReadyToMerge()` function requires at least one feedback item and checks that all items have terminal status
- The ready-to-merge indicator is only displayed when the condition is met, providing clear visual feedback to users
- Both UI locations (list and detail views) include direct links to the PR on GitHub for quick access
- The implementation uses consistent styling with green accent colors to indicate the positive "ready" state

https://claude.ai/code/session_01C6NLBb5LXpFhWtgMXKidZE