### PR TITLE
feat: safe update drain mode and crash-resume agent runs

### DIFF
--- a/docs/plans/2026-03-18-safe-update-drain-and-agent-resume-implementation.md
+++ b/docs/plans/2026-03-18-safe-update-drain-and-agent-resume-implementation.md
@@ -1,0 +1,192 @@
+# Safe Update Drain And Agent Resume Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add persisted drain-mode lifecycle control plus crash-resume for in-flight agent runs with replay of the exact saved prompt and at-most-once side effects.
+
+**Architecture:** Extend storage with durable runtime/run tables, teach `PRBabysitter` to persist run phases and recover interrupted runs, and gate watcher/manual triggers when drain mode is enabled. Recovery reuses existing babysitter reconciliation, with replay skipped if PR head already moved.
+
+**Tech Stack:** TypeScript, Express, SQLite (`node:sqlite`), Node test runner (`node --test --import tsx`).
+
+---
+
+### Task 1: Add Shared Runtime And Agent Run Schemas
+
+**Files:**
+- Modify: `shared/schema.ts`
+
+**Step 1: Write failing type usage check in plan review**
+Expect compile references to `AgentRun`/`RuntimeState` to fail before schema types exist.
+
+**Step 2: Run typecheck to confirm baseline**
+Run: `npm run check`
+Expected: PASS baseline before edits.
+
+**Step 3: Add minimal shared schemas/types**
+Add:
+- `agentRunStatusEnum`
+- `agentRunSchema`
+- `runtimeStateSchema`
+- exported types for each.
+
+**Step 4: Run typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: add runtime and agent-run shared schemas"`
+
+### Task 2: Extend Storage Interface And Memory Storage
+
+**Files:**
+- Modify: `server/storage.ts`
+- Modify: `server/memoryStorage.ts`
+
+**Step 1: Write failing storage tests (in Task 4) that require new methods**
+Expected failure: missing storage methods.
+
+**Step 2: Add storage interface methods**
+Add methods for:
+- runtime state get/update
+- agent run get/list/upsert.
+
+**Step 3: Implement `MemStorage` runtime/run support**
+Add in-memory backing maps and deterministic sorting/filtering for run listing.
+
+**Step 4: Run targeted tests**
+Run: `node --test --import tsx server/storage.test.ts`
+Expected: still failing until SQLite implementation is complete.
+
+**Step 5: Commit**
+`git commit -m "feat: extend storage contract for runtime and agent runs"`
+
+### Task 3: Implement SQLite Runtime/Run Persistence
+
+**Files:**
+- Modify: `server/sqliteStorage.ts`
+
+**Step 1: Add failing persistence assertions in `server/storage.test.ts`**
+Cover reload of `runtime_state` and `agent_runs`.
+
+**Step 2: Run test to confirm failure**
+Run: `node --test --import tsx server/storage.test.ts`
+Expected: FAIL due missing tables/methods.
+
+**Step 3: Implement schema + methods**
+Add:
+- tables `runtime_state` and `agent_runs`
+- bootstrap defaults
+- row parsers
+- get/update runtime state
+- get/list/upsert agent runs.
+
+**Step 4: Re-run storage tests**
+Run: `node --test --import tsx server/storage.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: persist runtime lifecycle and agent run journal in sqlite"`
+
+### Task 4: Add Babysitter Drain Gating And Run Journaling
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Add failing babysitter tests**
+Add tests for:
+- skip runs during drain mode
+- run record persisted with prompt and final status.
+
+**Step 2: Run tests to confirm failure**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL.
+
+**Step 3: Implement journaling + drain behavior**
+Implement:
+- run phase/status persistence (`running/completed/failed`)
+- persisted prompt and initial head SHA before agent execution
+- drain gate in `syncAndBabysitTrackedRepos` and `babysitPR`
+- helpers: active run count + wait-for-idle.
+
+**Step 4: Re-run babysitter tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: add babysitter drain gating and durable run journaling"`
+
+### Task 5: Implement Startup Recovery And Replay/Skip Logic
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/routes.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Add failing recovery tests**
+Add tests for:
+- replay with saved prompt when head unchanged
+- skip replay when head moved and continue reconciliation.
+
+**Step 2: Run tests to confirm failure**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL.
+
+**Step 3: Implement recovery flow**
+Add:
+- `resumeInterruptedRuns()` in babysitter
+- startup trigger from `registerRoutes`
+- replay using persisted prompt/agent context
+- replay skip on head-sha mismatch.
+
+**Step 4: Re-run tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: recover interrupted runs with replay-safe semantics"`
+
+### Task 6: Add Runtime Lifecycle API Endpoints
+
+**Files:**
+- Modify: `server/routes.ts`
+
+**Step 1: Add failing API behavior checks (lightweight via existing tests or manual validation)**
+Expected: endpoints unavailable before implementation.
+
+**Step 2: Implement endpoints**
+Add:
+- `GET /api/runtime`
+- `POST /api/runtime/drain` with `enabled/reason/waitForIdle/timeoutMs`.
+
+**Step 3: Add manual verification script**
+Use API calls while run is active and confirm drain wait semantics.
+
+**Step 4: Run targeted test suite**
+Run: `node --test --import tsx server/storage.test.ts server/babysitter.test.ts server/watcherScheduler.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: expose runtime drain lifecycle endpoints"`
+
+### Task 7: Final Verification Sweep
+
+**Files:**
+- Modify: only files above as needed
+
+**Step 1: Run full targeted backend tests**
+Run: `node --test --import tsx server/*.test.ts`
+Expected: PASS.
+
+**Step 2: Run strict typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 3: Summarize behavior diff**
+Document:
+- pre-change interruption risk,
+- post-change drain/recovery guarantees,
+- known caveats.
+
+**Step 4: Commit final fixes**
+`git commit -m "test: verify safe update drain and crash-resume flow"`

--- a/docs/plans/2026-03-18-safe-update-drain-and-agent-resume-prd.md
+++ b/docs/plans/2026-03-18-safe-update-drain-and-agent-resume-prd.md
@@ -1,0 +1,174 @@
+# Product Requirements Document: Safe Updates With Drain Mode And Crash-Resume Agent Runs
+
+**Date:** 2026-03-18  
+**Status:** Draft (approved direction: Option 2)  
+**Owner:** Code Factory
+
+## Background
+Code Factory can run multiple long-lived PR babysitter runs concurrently (one per PR). Today, process restarts or updates can interrupt active runs. We need a safe update lifecycle that:
+
+1. avoids interrupting active work during planned updates, and
+2. resumes interrupted agent work after unplanned crashes/restarts with the exact same prompt.
+
+The runtime model is explicitly **single local process**.
+
+## Problem Statement
+Without lifecycle coordination, a restart can leave PRs in uncertain state:
+- active agent processes are terminated,
+- in-flight prompts are lost,
+- side effects (pushes, GitHub comments, thread resolution) can be duplicated on replay,
+- operators cannot safely trigger app updates while work is in progress.
+
+## Goals
+1. Add a **drain mode** that prevents new babysitter runs and allows in-flight runs to finish before update/restart.
+2. Persist durable **agent run records** with enough state to replay interrupted runs.
+3. On restart, recover interrupted runs and replay using the **exact persisted prompt**.
+4. Enforce **at-most-once side effects** for replayed runs (no duplicate push/comment/thread resolution).
+5. Keep implementation aligned with current architecture (Express + SQLite + PRBabysitter).
+
+## Non-Goals
+1. Multi-process coordination across multiple Code Factory instances.
+2. Distributed locks or leader election.
+3. Desktop-shell migration (Tauri/Neutralino) in this phase.
+4. Full workflow redesign of babysitter logic.
+
+## User Stories
+1. As an operator, I can request update mode and wait until active runs finish before restarting.
+2. As an operator, after a crash/restart, interrupted runs resume automatically without manual intervention.
+3. As a reviewer, I do not see duplicate follow-up comments or duplicate thread resolutions.
+4. As a maintainer, I can inspect run phase/history to understand where interruption happened.
+
+## Functional Requirements
+
+### R1: Drain Mode (Planned Update Path)
+1. Runtime must expose a persisted drain flag (`drain_mode`).
+2. While drain mode is enabled:
+   - watcher-triggered runs must not start,
+   - manual run triggers must return a conflict response,
+   - existing in-flight runs are allowed to continue.
+3. API must support enabling drain mode and optionally waiting for idle (`activeRuns == 0`).
+4. API must support disabling drain mode after restart/maintenance.
+
+### R2: Durable Agent Run Journal
+1. Every babysitter run must write a durable run record:
+   - `run_id`, `pr_id`, `status`, `phase`, `preferred_agent`, `resolved_agent`,
+   - `prompt` (exact prompt used for agent execution),
+   - `initial_head_sha`,
+   - timestamps and error fields.
+2. Run record status transitions must be persisted at key boundaries:
+   - started,
+   - prompt prepared,
+   - agent running,
+   - agent finished,
+   - follow-up/reconcile,
+   - completed/failed.
+
+### R3: Restart Recovery
+1. On server startup, system must query run records with `status=running`.
+2. For each interrupted run:
+   - if replay data is sufficient (`prompt`, `resolved_agent`, `initial_head_sha`), execute recovery,
+   - otherwise mark run failed and schedule normal babysitter reconciliation.
+3. Recovery must replay the **persisted prompt exactly** when replay is required.
+
+### R4: At-Most-Once Side Effects During Recovery
+1. Before replaying agent prompt, system must compare current PR head SHA vs persisted `initial_head_sha`:
+   - if head already moved, skip prompt replay and continue reconciliation only,
+   - if head unchanged, replay prompt.
+2. GitHub follow-up actions must be idempotent:
+   - do not post duplicate audit-trail replies,
+   - do not re-resolve already-resolved review threads.
+3. Branch update validation must ensure no duplicate/contradictory push behavior.
+
+### R5: Operational Visibility
+1. Logs must include drain mode transitions and recovery decisions.
+2. Logs must clearly indicate replay vs skip-replay paths.
+3. API must expose runtime lifecycle status and active run count.
+
+## Data Model Requirements
+
+### Table: `runtime_state` (singleton)
+- `id` (fixed 1)
+- `drain_mode` (boolean)
+- `drain_requested_at` (timestamp nullable)
+- `drain_reason` (text nullable)
+
+### Table: `agent_runs`
+- `id` (run id, primary key)
+- `pr_id` (foreign key to `prs`)
+- `preferred_agent` (`codex|claude`)
+- `resolved_agent` (`codex|claude`, nullable)
+- `status` (`running|completed|failed`)
+- `phase` (string)
+- `prompt` (text nullable)
+- `initial_head_sha` (text nullable)
+- `metadata_json` (nullable)
+- `last_error` (text nullable)
+- `created_at`, `updated_at`
+
+## Lifecycle/State Machine
+
+### Run Status
+- `running` -> `completed`
+- `running` -> `failed`
+
+### Key Phases (minimum)
+- `run.started`
+- `run.sync`
+- `run.prompt-prepared`
+- `run.agent-running`
+- `run.agent-finished`
+- `run.reconcile`
+- `run.completed`
+- `run.failed`
+
+## API Requirements
+1. `GET /api/runtime`
+   - returns persisted runtime state and active run count.
+2. `POST /api/runtime/drain`
+   - body: `{ enabled: boolean, reason?: string, waitForIdle?: boolean, timeoutMs?: number }`
+   - when `enabled=true`, transitions to drain mode and optionally waits for idle.
+
+## Recovery Algorithm (High Level)
+1. Load interrupted runs (`status=running`).
+2. For each run in creation order:
+   - load PR + fresh pull summary,
+   - if head SHA differs from `initial_head_sha`: skip replay, reconcile follow-up state,
+   - else: prepare worktree, rerun stored prompt with stored agent, verify git state,
+   - run reconciliation pass to complete GitHub audit trail and feedback lifecycle,
+   - mark run completed or failed.
+
+## Acceptance Criteria
+1. Enabling drain mode prevents new runs from watcher/manual endpoints.
+2. `drain+wait` returns idle only after all in-flight runs complete.
+3. Crash simulation during `agent-running` results in resumed run replay with identical prompt.
+4. If crash occurs after push but before follow-up completion, restart does not replay prompt and does not duplicate push.
+5. Replayed/reconciled runs do not produce duplicate audit-trail comments or thread resolutions.
+6. Interrupted run records are visible with accurate final status.
+
+## Test Plan Requirements
+1. Storage tests:
+   - `runtime_state` persistence across restart,
+   - `agent_runs` persistence and filtering.
+2. Babysitter tests:
+   - replay path when head unchanged,
+   - skip-replay path when head changed,
+   - idempotent follow-up behavior on recovery.
+3. Route tests (or integration tests):
+   - drain-mode gating for watcher/manual run triggers,
+   - drain-and-wait idle behavior.
+4. End-to-end manual validation:
+   - start run, force process kill, restart, verify resumed prompt and no duplicate side effects.
+
+## Rollout Plan
+1. Ship persistence model + no-op runtime endpoints first.
+2. Add drain gating.
+3. Add startup recovery flow behind feature flag (optional).
+4. Enable by default after validation in dogfood.
+
+## Risks
+1. Recovery complexity in large monolithic `babysitPR` path.
+2. False-positive replay skip if SHA movement comes from unrelated external push.
+3. Long-running drain windows may delay updates.
+
+## Future Considerations
+Desktop packaging (Tauri/Neutralino) can improve update UX later, but correctness still depends on this run-journaling and recovery model.

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -172,6 +172,57 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("babysitPR skips new runs while drain mode is enabled", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [makeFeedbackItem()],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  await storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-03-18T10:00:00.000Z",
+    drainReason: "planned update",
+  });
+
+  const babysitter = new PRBabysitter(storage, {
+    buildOctokit: async () => ({}) as never,
+    fetchFeedbackItemsForPR: async () => {
+      throw new Error("should not fetch feedback while draining");
+    },
+    fetchPullSummary: async () => {
+      throw new Error("unused");
+    },
+    listFailingStatuses: async () => [],
+    listOpenPullsForRepo: async () => [],
+    postFollowUpForFeedbackItem: async () => undefined,
+    resolveReviewThread: async () => undefined,
+    resolveGitHubAuthToken: async () => undefined,
+    addReactionToComment: async () => undefined,
+    postStatusReplyForFeedbackItem: async () => null,
+    updateStatusReply: async () => undefined,
+    postPRComment: async () => undefined,
+  });
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const logs = await storage.getLogs(pr.id);
+  const runs = await storage.listAgentRuns();
+  assert.ok(logs.some((log) => log.message.includes("drain mode is enabled")));
+  assert.equal(runs.length, 0);
+});
+
 test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and verifies audit trail", async () => {
   const storage = new MemStorage();
   const existingItem = makeFeedbackItem();
@@ -279,10 +330,16 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
 
   const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
+  const runs = await storage.listAgentRuns();
   const fixRunLog = logs.find((log) => log.phase === "run" && log.message.includes("Babysitter preparing fix run"));
 
   assert.equal(updated?.status, "watching");
   assert.equal(updated?.accepted, 1);
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0]?.status, "completed");
+  assert.equal(runs[0]?.resolvedAgent, "codex");
+  assert.equal(runs[0]?.initialHeadSha, "abc123");
+  assert.match(runs[0]?.prompt || "", /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.ok(fixRunLog);
   assert.equal(
     fixRunLog.message,
@@ -1215,6 +1272,219 @@ test("babysitPR retries accepted in-progress feedback items that still need GitH
   ]);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("awaiting GitHub follow-up")));
+});
+
+test("resumeInterruptedRuns replays the persisted prompt when the PR head has not moved", async () => {
+  const storage = new MemStorage();
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  const existingItem = makeFeedbackItem({
+    decision: "accept",
+    decisionReason: "Recovery replay",
+    action: "Please rename this variable.",
+    status: "in_progress",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  await storage.upsertAgentRun({
+    id: "run-replay-1",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "running",
+    phase: "run.agent-running",
+    prompt: "REPLAY EXACT PROMPT",
+    initialHeadSha: "abc123",
+    metadata: { recoveryMode: true },
+    lastError: null,
+    createdAt: "2026-03-18T10:00:00.000Z",
+    updatedAt: "2026-03-18T10:01:00.000Z",
+  });
+
+  let capturedPrompt = "";
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr, { headSha: "abc123" });
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    auditToken: "codefactory-feedback:gh-review-comment-2",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem];
+        }
+        return [{ ...existingItem, threadResolved: true }, followUp];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => undefined,
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => undefined,
+      postPRComment: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "No new evaluation needed" }),
+      applyFixesWithAgent: async ({ prompt }) => {
+        capturedPrompt = prompt;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+    },
+  );
+
+  await babysitter.resumeInterruptedRuns();
+
+  const run = await storage.getAgentRun("run-replay-1");
+  assert.equal(capturedPrompt, "REPLAY EXACT PROMPT");
+  assert.equal(run?.status, "completed");
+  assert.equal(run?.phase, "run.completed");
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("resumeInterruptedRuns skips prompt replay when the PR head already moved", async () => {
+  const storage = new MemStorage();
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  const existingItem = makeFeedbackItem({
+    decision: "accept",
+    decisionReason: "Recovery replay",
+    action: "Please rename this variable.",
+    status: "in_progress",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  await storage.upsertAgentRun({
+    id: "run-replay-2",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "running",
+    phase: "run.agent-running",
+    prompt: "REPLAY EXACT PROMPT",
+    initialHeadSha: "abc123",
+    metadata: { recoveryMode: true },
+    lastError: null,
+    createdAt: "2026-03-18T10:00:00.000Z",
+    updatedAt: "2026-03-18T10:01:00.000Z",
+  });
+
+  let applyCalled = false;
+  let feedbackFetchCount = 0;
+  const pullSummary = makePullSummary(pr, { headSha: "moved999" });
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Addressed in commit \`moved99\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>moved99</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    auditToken: "codefactory-feedback:gh-review-comment-2",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem];
+        }
+        return [{ ...existingItem, threadResolved: true }, followUp];
+      },
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => undefined,
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => undefined,
+      postPRComment: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "No new evaluation needed" }),
+      applyFixesWithAgent: async () => {
+        applyCalled = true;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      runCommand: makeGitRunCommand({ localHeadSha: "moved999", remoteHeadSha: "moved999" }),
+    },
+  );
+
+  await babysitter.resumeInterruptedRuns();
+
+  const run = await storage.getAgentRun("run-replay-2");
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(applyCalled, false);
+  assert.equal(run?.status, "completed");
+  assert.ok(logs.some((log) => log.phase === "run.replay" && log.message.includes("Skipping forced prompt replay")));
+
+  delete process.env.CODEFACTORY_HOME;
 });
 
 test("babysitPR resolves lingering review threads without reposting an existing audit trail", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import type { FeedbackItem, PR } from "@shared/schema";
+import type { AgentRun, FeedbackItem, PR } from "@shared/schema";
 import type { IStorage } from "./storage";
 import {
   applyFixesWithAgent,
@@ -500,6 +500,10 @@ async function ensureGitIdentity(worktreePath: string, run: typeof runCommand): 
   }
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class PRBabysitter {
   private readonly storage: IStorage;
   private readonly inProgress = new Set<string>();
@@ -514,6 +518,57 @@ export class PRBabysitter {
     this.storage = storage;
     this.github = github;
     this.runtime = runtime;
+  }
+
+  getActiveRunCount(): number {
+    return this.inProgress.size;
+  }
+
+  async waitForIdle(timeoutMs = 120000): Promise<boolean> {
+    const startedAt = Date.now();
+
+    while (this.inProgress.size > 0) {
+      if (Date.now() - startedAt >= timeoutMs) {
+        return false;
+      }
+      await wait(100);
+    }
+
+    return true;
+  }
+
+  async resumeInterruptedRuns(): Promise<void> {
+    const interruptedRuns = await this.storage.listAgentRuns({ status: "running" });
+    if (interruptedRuns.length === 0) {
+      return;
+    }
+
+    for (const run of interruptedRuns) {
+      const canReplay = Boolean(run.prompt && run.resolvedAgent && run.initialHeadSha);
+      if (!canReplay) {
+        const now = new Date().toISOString();
+        await this.storage.upsertAgentRun({
+          ...run,
+          status: "failed",
+          phase: "run.failed",
+          lastError: "Interrupted run missing replay context",
+          updatedAt: now,
+        });
+        await this.babysitPR(run.prId, run.preferredAgent, {
+          allowDuringDrain: true,
+        });
+        continue;
+      }
+
+      await this.babysitPR(run.prId, run.preferredAgent, {
+        runId: run.id,
+        recoveryMode: true,
+        forceAgentPrompt: run.prompt,
+        forceResolvedAgent: run.resolvedAgent,
+        replayInitialHeadSha: run.initialHeadSha,
+        allowDuringDrain: true,
+      });
+    }
   }
 
   async syncFeedbackForPR(
@@ -582,6 +637,11 @@ export class PRBabysitter {
   }
 
   async syncAndBabysitTrackedRepos(): Promise<void> {
+    const runtimeState = await this.storage.getRuntimeState();
+    if (runtimeState.drainMode) {
+      return;
+    }
+
     const config = await this.storage.getConfig();
     const octokit = await this.github.buildOctokit(config);
 
@@ -651,7 +711,29 @@ export class PRBabysitter {
     }
   }
 
-  async babysitPR(prId: string, preferredAgent: CodingAgent): Promise<void> {
+  async babysitPR(
+    prId: string,
+    preferredAgent: CodingAgent,
+    options?: {
+      runId?: string;
+      recoveryMode?: boolean;
+      forceAgentPrompt?: string | null;
+      forceResolvedAgent?: CodingAgent | null;
+      replayInitialHeadSha?: string | null;
+      allowDuringDrain?: boolean;
+    },
+  ): Promise<void> {
+    const runtimeState = await this.storage.getRuntimeState();
+    if (runtimeState.drainMode && !options?.allowDuringDrain) {
+      const pr = await this.storage.getPR(prId);
+      if (pr) {
+        await this.storage.addLog(pr.id, "warn", "Babysitter run skipped because drain mode is enabled", {
+          phase: "run",
+        });
+      }
+      return;
+    }
+
     if (this.inProgress.has(prId)) {
       const pr = await this.storage.getPR(prId);
       if (pr) {
@@ -663,9 +745,38 @@ export class PRBabysitter {
     }
 
     this.inProgress.add(prId);
-    const runId = randomUUID();
+    const runId = options?.runId || randomUUID();
     const auditWindowStartMs = Math.floor(Date.now() / 1000) * 1000 - 1000;
     let logQueue = Promise.resolve();
+    const runCreatedAt = new Date().toISOString();
+    let runRecord: AgentRun = (await this.storage.getAgentRun(runId)) || {
+      id: runId,
+      prId,
+      preferredAgent,
+      resolvedAgent: options?.forceResolvedAgent ?? null,
+      status: "running",
+      phase: "run.started",
+      prompt: options?.forceAgentPrompt ?? null,
+      initialHeadSha: options?.replayInitialHeadSha ?? null,
+      metadata: {
+        recoveryMode: Boolean(options?.recoveryMode),
+      },
+      lastError: null,
+      createdAt: runCreatedAt,
+      updatedAt: runCreatedAt,
+    };
+    await this.storage.upsertAgentRun(runRecord);
+
+    const updateRunRecord = async (
+      updates: Partial<Pick<AgentRun, "status" | "phase" | "resolvedAgent" | "prompt" | "initialHeadSha" | "metadata" | "lastError">>,
+    ) => {
+      runRecord = {
+        ...runRecord,
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+      await this.storage.upsertAgentRun(runRecord);
+    };
 
     const queueLog = (
       currentPrId: string,
@@ -784,16 +895,32 @@ export class PRBabysitter {
     };
 
     let followUpTasks: FeedbackItem[] = [];
+    const forcedFixPrompt = options?.forceAgentPrompt ?? null;
+    const forcedResolvedAgent = options?.forceResolvedAgent ?? null;
+    const replayInitialHeadSha = options?.replayInitialHeadSha ?? null;
+    const recoveryMode = Boolean(options?.recoveryMode);
+    let skipForcedReplay = false;
 
     try {
+      await updateRunRecord({
+        status: "running",
+        phase: "run.started",
+        metadata: {
+          ...(runRecord.metadata ?? {}),
+          recoveryMode,
+        },
+        lastError: null,
+      });
+
       await this.storage.updatePR(prId, {
         status: "processing",
         lastChecked: new Date().toISOString(),
       });
-      await queueLog(prId, "info", `Babysitter run started using preferred agent ${preferredAgent}`, {
+      await queueLog(prId, "info", `Babysitter run started using preferred agent ${preferredAgent}${recoveryMode ? " (recovery)" : ""}`, {
         phase: "run",
-        metadata: { preferredAgent },
+        metadata: { preferredAgent, recoveryMode },
       });
+      await updateRunRecord({ phase: "run.sync" });
 
       let pr = await this.syncFeedbackForPR(prId, {
         runId,
@@ -801,7 +928,10 @@ export class PRBabysitter {
         phase: "sync",
       });
       const config = await this.storage.getConfig();
-      const agent = await this.runtime.resolveAgent(preferredAgent);
+      const agent = forcedResolvedAgent || (await this.runtime.resolveAgent(preferredAgent));
+      await updateRunRecord({
+        resolvedAgent: agent,
+      });
       const parsedRepo = parseRepoSlug(pr.repo);
 
       if (!parsedRepo) {
@@ -820,6 +950,16 @@ export class PRBabysitter {
       };
 
       const pullSummary = await this.github.fetchPullSummary(octokit, parsedPr);
+      if (forcedFixPrompt && replayInitialHeadSha && pullSummary.headSha !== replayInitialHeadSha) {
+        skipForcedReplay = true;
+        await queueLog(pr.id, "warn", `Skipping forced prompt replay because PR head moved (${replayInitialHeadSha.slice(0, 7)} -> ${pullSummary.headSha.slice(0, 7)})`, {
+          phase: "run.replay",
+          metadata: {
+            replayInitialHeadSha,
+            currentHeadSha: pullSummary.headSha,
+          },
+        });
+      }
       const failingStatuses = await this.github.listFailingStatuses(octokit, parsedRepo, pullSummary.headSha);
 
       // Track status reply comments so we can update them with progress.
@@ -1014,16 +1154,30 @@ export class PRBabysitter {
       const commentTasks = pr.feedbackItems.filter(
         (item) => item.status === "queued" && item.decision === "accept",
       );
+      const replayCommentTasks = forcedFixPrompt
+        ? pr.feedbackItems.filter(
+            (item) => (item.status === "queued" || item.status === "in_progress") && item.decision === "accept",
+          )
+        : [];
+      const effectiveCommentTasks = replayCommentTasks.length > 0 ? replayCommentTasks : commentTasks;
       followUpTasks = collectGitHubFollowUpTasks(pr);
       const hasConflicts = pullSummary.mergeable === false;
+      const shouldRunForcedReplay = Boolean(forcedFixPrompt && !skipForcedReplay);
+      const disableAgentExecution = Boolean(forcedFixPrompt && skipForcedReplay);
+      const hasAgentWork = !disableAgentExecution && (effectiveCommentTasks.length > 0 || statusTasks.length > 0 || shouldRunForcedReplay);
 
-      if (commentTasks.length === 0 && statusTasks.length === 0 && followUpTasks.length === 0 && !hasConflicts) {
+      if (!hasAgentWork && followUpTasks.length === 0 && !hasConflicts) {
         await queueLog(pr.id, "info", `Babysitter checked PR #${pr.number}; no necessary fixes identified`, {
           phase: "run",
         });
         await this.storage.updatePR(pr.id, {
           status: "watching",
           lastChecked: new Date().toISOString(),
+        });
+        await updateRunRecord({
+          status: "completed",
+          phase: "run.completed",
+          lastError: null,
         });
         return;
       }
@@ -1040,18 +1194,19 @@ export class PRBabysitter {
         });
       }
 
-      if (commentTasks.length > 0 || statusTasks.length > 0 || hasConflicts) {
+      if (hasAgentWork || hasConflicts) {
         await queueLog(
           pr.id,
           "info",
-          `Babysitter preparing fix run with ${commentTasks.length} comment task(s), ${statusTasks.length} status task(s), and ${followUpTasks.length} GitHub follow-up task(s)${hasConflicts ? ", plus merge conflict resolution" : ""} using ${agent}`,
+          `Babysitter preparing fix run with ${effectiveCommentTasks.length} comment task(s), ${statusTasks.length} status task(s), and ${followUpTasks.length} GitHub follow-up task(s)${hasConflicts ? ", plus merge conflict resolution" : ""}${shouldRunForcedReplay ? ", with forced prompt replay" : ""} using ${agent}`,
           {
             phase: "run",
             metadata: {
-              commentTasks: commentTasks.length,
+              commentTasks: effectiveCommentTasks.length,
               statusTasks: statusTasks.length,
               followUpTasks: followUpTasks.length,
               hasConflicts,
+              shouldRunForcedReplay,
               agent,
             },
           },
@@ -1222,8 +1377,8 @@ export class PRBabysitter {
             }
           }
 
-          if (commentTasks.length > 0) {
-            const inProgressIds = new Set(commentTasks.map((item) => item.id));
+          if (effectiveCommentTasks.length > 0) {
+            const inProgressIds = new Set(effectiveCommentTasks.map((item) => item.id));
             const inProgressItems = pr.feedbackItems.map((item) =>
               inProgressIds.has(item.id) ? markInProgress(item) : item,
             );
@@ -1239,7 +1394,7 @@ export class PRBabysitter {
             }
           }
 
-          if (commentTasks.length > 0 || statusTasks.length > 0) {
+          if (shouldRunForcedReplay || effectiveCommentTasks.length > 0 || statusTasks.length > 0) {
             const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info");
             const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "warn");
             const githubToken = await this.github.resolveGitHubAuthToken(config);
@@ -1251,17 +1406,26 @@ export class PRBabysitter {
                 }
               : undefined;
 
-            const fixPrompt = buildAgentFixPrompt({
+            const fixPrompt = shouldRunForcedReplay && forcedFixPrompt ? forcedFixPrompt : buildAgentFixPrompt({
               pr,
               pullSummary,
               remoteName,
-              commentTasks,
+              commentTasks: effectiveCommentTasks,
               statusTasks,
+            });
+
+            await updateRunRecord({
+              phase: "run.prompt-prepared",
+              prompt: fixPrompt,
+              initialHeadSha: replayInitialHeadSha || pullSummary.headSha,
             });
 
             await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
               phase: "agent",
               metadata: { githubAuth: Boolean(githubToken), prompt: fixPrompt },
+            });
+            await updateRunRecord({
+              phase: "run.agent-running",
             });
 
             // Post agent command to GitHub PR as a comment for debugging visibility.
@@ -1269,7 +1433,7 @@ export class PRBabysitter {
 
             // Update status replies: agent is starting.
             const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
-            await Promise.all(commentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
+            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
 
             const applyResult = await this.runtime.applyFixesWithAgent({
               agent,
@@ -1284,12 +1448,12 @@ export class PRBabysitter {
 
             if (applyResult.code !== 0) {
               // Update status replies on failure.
-              await Promise.all(commentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed)));
+              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed)));
               throw new Error(`Agent apply failed (${applyResult.code}): ${applyResult.stderr || applyResult.stdout}`);
             }
 
             // Update status replies: agent succeeded.
-            await Promise.all(commentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
+            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
 
             // Extract per-feedback-item summaries from agent output.
             agentSummaries = extractAgentSummaries(applyResult.stdout);
@@ -1297,6 +1461,9 @@ export class PRBabysitter {
             await queueLog(pr.id, "info", `${agent} completed successfully`, {
               phase: "agent",
               metadata: { code: applyResult.code, extractedSummaries: agentSummaries.size },
+            });
+            await updateRunRecord({
+              phase: "run.agent-finished",
             });
           }
 
@@ -1422,6 +1589,10 @@ export class PRBabysitter {
         );
       }
 
+      await updateRunRecord({
+        phase: "run.reconcile",
+      });
+
       for (const item of followUpTasks) {
         const shouldPostFollowUp = !hasAuditTrail(item, pr.feedbackItems);
         const shouldResolveThread = item.replyKind === "review_thread" && !item.threadResolved;
@@ -1510,9 +1681,19 @@ export class PRBabysitter {
         phase: "run",
         metadata: { remoteName: remoteNameForLogs, branchMoved },
       });
+      await updateRunRecord({
+        status: "completed",
+        phase: "run.completed",
+        lastError: null,
+      });
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      await updateRunRecord({
+        status: "failed",
+        phase: "run.failed",
+        lastError: message,
+      });
       const currentPr = await this.storage.getPR(prId);
       if (currentPr) {
         await queueLog(currentPr.id, "error", `Babysitter error: ${message}`, {

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import type { PR, LogEntry, Config } from "@shared/schema";
+import type { AgentRun, AgentRunStatus, Config, LogEntry, PR, RuntimeState } from "@shared/schema";
 import type { IStorage } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
@@ -7,6 +7,12 @@ export class MemStorage implements IStorage {
   private prs: Map<string, PR> = new Map();
   private logs: LogEntry[] = [];
   private config: Config = { ...DEFAULT_CONFIG };
+  private runtimeState: RuntimeState = {
+    drainMode: false,
+    drainRequestedAt: null,
+    drainReason: null,
+  };
+  private agentRuns: Map<string, AgentRun> = new Map();
 
   async getPRs(): Promise<PR[]> {
     return Array.from(this.prs.values())
@@ -97,5 +103,40 @@ export class MemStorage implements IStorage {
   async updateConfig(updates: Partial<Config>): Promise<Config> {
     this.config = { ...this.config, ...updates };
     return { ...this.config };
+  }
+
+  async getRuntimeState(): Promise<RuntimeState> {
+    return { ...this.runtimeState };
+  }
+
+  async updateRuntimeState(updates: Partial<RuntimeState>): Promise<RuntimeState> {
+    this.runtimeState = {
+      ...this.runtimeState,
+      ...updates,
+    };
+
+    return { ...this.runtimeState };
+  }
+
+  async getAgentRun(id: string): Promise<AgentRun | undefined> {
+    const run = this.agentRuns.get(id);
+    return run ? { ...run } : undefined;
+  }
+
+  async listAgentRuns(filters?: { status?: AgentRunStatus; prId?: string }): Promise<AgentRun[]> {
+    const runs = Array.from(this.agentRuns.values())
+      .filter((run) => {
+        if (filters?.status && run.status !== filters.status) return false;
+        if (filters?.prId && run.prId !== filters.prId) return false;
+        return true;
+      })
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+    return runs.map((run) => ({ ...run }));
+  }
+
+  async upsertAgentRun(run: AgentRun): Promise<AgentRun> {
+    this.agentRuns.set(run.id, { ...run });
+    return { ...run };
   }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,6 +31,14 @@ export async function registerRoutes(
   );
   const runWatcher = watcherScheduler.run;
 
+  const getRuntimeSnapshot = async () => {
+    const state = await storage.getRuntimeState();
+    return {
+      ...state,
+      activeRuns: babysitter.getActiveRunCount(),
+    };
+  };
+
   const refreshWatcherSchedule = async () => {
     const config = await storage.getConfig();
     const interval = Math.max(10000, config.pollIntervalMs || 120000);
@@ -51,12 +59,57 @@ export async function registerRoutes(
   };
 
   await refreshWatcherSchedule();
+  void babysitter.resumeInterruptedRuns();
   void runWatcher();
 
   httpServer.on("close", () => {
     if (watcherTimer) {
       clearInterval(watcherTimer);
       watcherTimer = null;
+    }
+  });
+
+  app.get("/api/runtime", async (_req, res) => {
+    res.json(await getRuntimeSnapshot());
+  });
+
+  app.post("/api/runtime/drain", async (req, res) => {
+    try {
+      const payload = z.object({
+        enabled: z.boolean(),
+        reason: z.string().optional(),
+        waitForIdle: z.boolean().optional(),
+        timeoutMs: z.number().int().positive().max(600000).optional(),
+      }).parse(req.body);
+
+      const updated = await storage.updateRuntimeState({
+        drainMode: payload.enabled,
+        drainRequestedAt: payload.enabled ? new Date().toISOString() : null,
+        drainReason: payload.enabled ? payload.reason ?? null : null,
+      });
+
+      if (payload.enabled && payload.waitForIdle) {
+        const drained = await babysitter.waitForIdle(payload.timeoutMs ?? 120000);
+        const snapshot = await getRuntimeSnapshot();
+        return res.status(drained ? 200 : 202).json({
+          ...updated,
+          ...snapshot,
+          drained,
+        });
+      }
+
+      const snapshot = await getRuntimeSnapshot();
+      res.json({
+        ...updated,
+        ...snapshot,
+      });
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) {
+        return res.status(400).json({ error: err.errors[0].message });
+      }
+
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
     }
   });
 
@@ -105,6 +158,11 @@ export async function registerRoutes(
   });
 
   app.post("/api/repos/sync", async (_req, res) => {
+    const runtime = await storage.getRuntimeState();
+    if (runtime.drainMode) {
+      return res.status(409).json({ error: "Drain mode is enabled. Sync-triggered runs are blocked until drain mode is disabled." });
+    }
+
     try {
       await watcherScheduler.runAndReportErrors();
       res.json({ ok: true });
@@ -262,6 +320,10 @@ export async function registerRoutes(
   app.post("/api/prs/:id/apply", async (req, res) => {
     const pr = await storage.getPR(req.params.id);
     if (!pr) return res.status(404).json({ error: "PR not found" });
+    const runtime = await storage.getRuntimeState();
+    if (runtime.drainMode) {
+      return res.status(409).json({ error: "Drain mode is enabled. Manual runs are blocked until drain mode is disabled." });
+    }
 
     const config = await storage.getConfig();
     await storage.updatePR(pr.id, { status: "processing" });
@@ -280,6 +342,10 @@ export async function registerRoutes(
   app.post("/api/prs/:id/babysit", async (req, res) => {
     const pr = await storage.getPR(req.params.id);
     if (!pr) return res.status(404).json({ error: "PR not found" });
+    const runtime = await storage.getRuntimeState();
+    if (runtime.drainMode) {
+      return res.status(409).json({ error: "Drain mode is enabled. Manual runs are blocked until drain mode is disabled." });
+    }
 
     const config = await storage.getConfig();
     await storage.addLog(pr.id, "info", `Manual babysitter trigger using ${config.codingAgent}`);

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import { feedbackStatusEnum } from "@shared/schema";
-import type { Config, FeedbackItem, LogEntry, PR } from "@shared/schema";
+import type { AgentRun, AgentRunStatus, Config, FeedbackItem, LogEntry, PR, RuntimeState } from "@shared/schema";
 import type { IStorage } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
 import { DEFAULT_CONFIG } from "./defaultConfig";
@@ -71,6 +71,27 @@ type LogRow = {
   phase: string | null;
   message: string;
   metadata_json: string | null;
+};
+
+type RuntimeStateRow = {
+  drain_mode: number;
+  drain_requested_at: string | null;
+  drain_reason: string | null;
+};
+
+type AgentRunRow = {
+  id: string;
+  pr_id: string;
+  preferred_agent: Config["codingAgent"];
+  resolved_agent: Config["codingAgent"] | null;
+  status: AgentRunStatus;
+  phase: string;
+  prompt: string | null;
+  initial_head_sha: string | null;
+  metadata_json: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
 };
 
 export class SqliteStorage implements IStorage {
@@ -166,8 +187,32 @@ export class SqliteStorage implements IStorage {
         FOREIGN KEY(pr_id) REFERENCES prs(id) ON DELETE CASCADE
       );
 
+      CREATE TABLE IF NOT EXISTS runtime_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        drain_mode INTEGER NOT NULL DEFAULT 0,
+        drain_requested_at TEXT,
+        drain_reason TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_runs (
+        id TEXT PRIMARY KEY,
+        pr_id TEXT NOT NULL,
+        preferred_agent TEXT NOT NULL,
+        resolved_agent TEXT,
+        status TEXT NOT NULL,
+        phase TEXT NOT NULL,
+        prompt TEXT,
+        initial_head_sha TEXT,
+        metadata_json TEXT,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(pr_id) REFERENCES prs(id) ON DELETE CASCADE
+      );
+
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
       CREATE INDEX IF NOT EXISTS idx_logs_pr_id_timestamp ON logs(pr_id, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated_at ON agent_runs(status, updated_at);
     `);
 
     this.ensureColumn("feedback_items", "reply_kind", "TEXT NOT NULL DEFAULT 'general_comment'");
@@ -183,6 +228,16 @@ export class SqliteStorage implements IStorage {
     const configExists = this.db.prepare("SELECT 1 AS present FROM config WHERE id = 1").get() as { present: number } | undefined;
     if (!configExists) {
       this.writeConfig(DEFAULT_CONFIG);
+    }
+
+    const runtimeStateExists = this.db.prepare(
+      "SELECT 1 AS present FROM runtime_state WHERE id = 1",
+    ).get() as { present: number } | undefined;
+    if (!runtimeStateExists) {
+      this.db.prepare(`
+        INSERT INTO runtime_state (id, drain_mode, drain_requested_at, drain_reason)
+        VALUES (1, 0, NULL, NULL)
+      `).run();
     }
   }
 
@@ -277,6 +332,31 @@ export class SqliteStorage implements IStorage {
       lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
       lastChecked: row.last_checked,
       addedAt: row.added_at,
+    };
+  }
+
+  private parseRuntimeStateRow(row: RuntimeStateRow): RuntimeState {
+    return {
+      drainMode: Boolean(row.drain_mode),
+      drainRequestedAt: row.drain_requested_at,
+      drainReason: row.drain_reason,
+    };
+  }
+
+  private parseAgentRunRow(row: AgentRunRow): AgentRun {
+    return {
+      id: row.id,
+      prId: row.pr_id,
+      preferredAgent: row.preferred_agent,
+      resolvedAgent: row.resolved_agent,
+      status: row.status,
+      phase: row.phase,
+      prompt: row.prompt,
+      initialHeadSha: row.initial_head_sha,
+      metadata: row.metadata_json ? JSON.parse(row.metadata_json) : null,
+      lastError: row.last_error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
     };
   }
 
@@ -607,6 +687,117 @@ export class SqliteStorage implements IStorage {
 
     this.writeConfig(next);
     return next;
+  }
+
+  async getRuntimeState(): Promise<RuntimeState> {
+    const row = this.db.prepare(`
+      SELECT drain_mode, drain_requested_at, drain_reason
+      FROM runtime_state
+      WHERE id = 1
+    `).get() as RuntimeStateRow;
+
+    return this.parseRuntimeStateRow(row);
+  }
+
+  async updateRuntimeState(updates: Partial<RuntimeState>): Promise<RuntimeState> {
+    const current = await this.getRuntimeState();
+    const next: RuntimeState = {
+      ...current,
+      ...updates,
+    };
+
+    this.db.prepare(`
+      INSERT INTO runtime_state (id, drain_mode, drain_requested_at, drain_reason)
+      VALUES (1, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        drain_mode = excluded.drain_mode,
+        drain_requested_at = excluded.drain_requested_at,
+        drain_reason = excluded.drain_reason
+    `).run(
+      Number(next.drainMode),
+      next.drainRequestedAt,
+      next.drainReason,
+    );
+
+    return next;
+  }
+
+  async getAgentRun(id: string): Promise<AgentRun | undefined> {
+    const row = this.db.prepare(`
+      SELECT id, pr_id, preferred_agent, resolved_agent, status, phase, prompt, initial_head_sha,
+             metadata_json, last_error, created_at, updated_at
+      FROM agent_runs
+      WHERE id = ?
+    `).get(id) as AgentRunRow | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+
+    return this.parseAgentRunRow(row);
+  }
+
+  async listAgentRuns(filters?: { status?: AgentRunStatus; prId?: string }): Promise<AgentRun[]> {
+    const clauses: string[] = [];
+    const values: string[] = [];
+
+    if (filters?.status) {
+      clauses.push("status = ?");
+      values.push(filters.status);
+    }
+
+    if (filters?.prId) {
+      clauses.push("pr_id = ?");
+      values.push(filters.prId);
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+
+    const rows = this.db.prepare(`
+      SELECT id, pr_id, preferred_agent, resolved_agent, status, phase, prompt, initial_head_sha,
+             metadata_json, last_error, created_at, updated_at
+      FROM agent_runs
+      ${whereClause}
+      ORDER BY datetime(created_at) ASC
+    `).all(...values) as AgentRunRow[];
+
+    return rows.map((row) => this.parseAgentRunRow(row));
+  }
+
+  async upsertAgentRun(run: AgentRun): Promise<AgentRun> {
+    this.db.prepare(`
+      INSERT INTO agent_runs (
+        id, pr_id, preferred_agent, resolved_agent, status, phase, prompt, initial_head_sha,
+        metadata_json, last_error, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        pr_id = excluded.pr_id,
+        preferred_agent = excluded.preferred_agent,
+        resolved_agent = excluded.resolved_agent,
+        status = excluded.status,
+        phase = excluded.phase,
+        prompt = excluded.prompt,
+        initial_head_sha = excluded.initial_head_sha,
+        metadata_json = excluded.metadata_json,
+        last_error = excluded.last_error,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `).run(
+      run.id,
+      run.prId,
+      run.preferredAgent,
+      run.resolvedAgent,
+      run.status,
+      run.phase,
+      run.prompt,
+      run.initialHeadSha,
+      run.metadata ? JSON.stringify(run.metadata) : null,
+      run.lastError,
+      run.createdAt,
+      run.updatedAt,
+    );
+
+    return run;
   }
 
   close(): void {

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -12,6 +12,11 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     pollIntervalMs: 45000,
     watchedRepos: ["alex-morgan-o/lolodex"],
   });
+  await first.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-03-18T10:00:00.000Z",
+    drainReason: "planned update",
+  });
 
   const pr = await first.addPR({
     number: 106,
@@ -64,15 +69,35 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     phase: "agent",
     metadata: { attempt: 1 },
   });
+  await first.upsertAgentRun({
+    id: "run-1",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "running",
+    phase: "run.agent-running",
+    prompt: "Fix the accepted tasks and push",
+    initialHeadSha: "abc123",
+    metadata: { replay: true },
+    lastError: null,
+    createdAt: "2026-03-18T10:01:00.000Z",
+    updatedAt: "2026-03-18T10:02:00.000Z",
+  });
   first.close();
 
   const second = new SqliteStorage(root);
   const config = await second.getConfig();
+  const runtime = await second.getRuntimeState();
   const reloadedPr = await second.getPR(pr.id);
+  const run = await second.getAgentRun("run-1");
+  const runningRuns = await second.listAgentRuns({ status: "running" });
   const logs = await second.getLogs(pr.id);
 
   assert.equal(config.pollIntervalMs, 45000);
   assert.deepEqual(config.watchedRepos, ["alex-morgan-o/lolodex"]);
+  assert.equal(runtime.drainMode, true);
+  assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
+  assert.equal(runtime.drainReason, "planned update");
   assert.equal(reloadedPr?.repo, "alex-morgan-o/lolodex");
   assert.equal(reloadedPr?.feedbackItems.length, 1);
   assert.equal(reloadedPr?.feedbackItems[0]?.bodyHtml, "<p>Please fix <code>thing</code></p>");
@@ -82,6 +107,11 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(reloadedPr?.accepted, 1);
   assert.equal(reloadedPr?.feedbackItems[0]?.status, "resolved");
   assert.equal(reloadedPr?.feedbackItems[0]?.statusReason, "GitHub audit trail verified");
+  assert.equal(run?.status, "running");
+  assert.equal(run?.prompt, "Fix the accepted tasks and push");
+  assert.equal(run?.initialHeadSha, "abc123");
+  assert.equal(runningRuns.length, 1);
+  assert.equal(runningRuns[0]?.id, "run-1");
   assert.equal(logs.length, 1);
   assert.equal(logs[0]?.phase, "agent");
   assert.deepEqual(logs[0]?.metadata, { attempt: 1 });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import type { PR, LogEntry, Config } from "@shared/schema";
+import type { AgentRun, AgentRunStatus, Config, LogEntry, PR, RuntimeState } from "@shared/schema";
 export { MemStorage } from "./memoryStorage";
 import { SqliteStorage } from "./sqliteStorage";
 
@@ -29,6 +29,18 @@ export interface IStorage {
   // Config
   getConfig(): Promise<Config>;
   updateConfig(updates: Partial<Config>): Promise<Config>;
+
+  // Runtime lifecycle
+  getRuntimeState(): Promise<RuntimeState>;
+  updateRuntimeState(updates: Partial<RuntimeState>): Promise<RuntimeState>;
+
+  // Durable agent run journal
+  getAgentRun(id: string): Promise<AgentRun | undefined>;
+  listAgentRuns(filters?: {
+    status?: AgentRunStatus;
+    prId?: string;
+  }): Promise<AgentRun[]>;
+  upsertAgentRun(run: AgentRun): Promise<AgentRun>;
 }
 
 export const storage = new SqliteStorage();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -80,6 +80,32 @@ export const logEntrySchema = z.object({
 });
 export type LogEntry = z.infer<typeof logEntrySchema>;
 
+export const agentRunStatusEnum = z.enum(["running", "completed", "failed"]);
+export type AgentRunStatus = z.infer<typeof agentRunStatusEnum>;
+
+export const agentRunSchema = z.object({
+  id: z.string(),
+  prId: z.string(),
+  preferredAgent: z.enum(["codex", "claude"]),
+  resolvedAgent: z.enum(["codex", "claude"]).nullable(),
+  status: agentRunStatusEnum,
+  phase: z.string(),
+  prompt: z.string().nullable(),
+  initialHeadSha: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  lastError: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type AgentRun = z.infer<typeof agentRunSchema>;
+
+export const runtimeStateSchema = z.object({
+  drainMode: z.boolean(),
+  drainRequestedAt: z.string().nullable(),
+  drainReason: z.string().nullable(),
+});
+export type RuntimeState = z.infer<typeof runtimeStateSchema>;
+
 export const configSchema = z.object({
   githubToken: z.string(),
   codingAgent: z.enum(["codex", "claude"]),

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -122,3 +122,12 @@
   - Treat "push to a branch" and "open a PR" as separate requirements, and satisfy both.
   - If the current worktree contains unrelated changes, isolate the task in a fresh worktree before creating the PR.
   - Call out any explicit user instruction to skip PR creation in the final handoff.
+
+## 2026-03-18 - Never implement directly on local `main`
+- Pattern: I started implementation work while checked out on local `main`.
+- Rule: Before any non-trivial edit, verify branch context and move to a dedicated worktree branch if currently on `main`.
+- Prevention checklist:
+  - Run `git rev-parse --abbrev-ref HEAD` at task start.
+  - If on `main`, create a fresh worktree and `codex/*` branch before editing.
+  - Keep docs/planning and implementation changes in that isolated worktree.
+  - Do not proceed with code changes until branch/worktree isolation is confirmed.


### PR DESCRIPTION
## Summary
- add persisted runtime lifecycle state (runtime_state) and durable agent run journal (agent_runs)
- add drain-mode controls to block new watcher/manual runs while allowing active runs to finish
- add startup recovery for interrupted runs with exact prompt replay when PR head is unchanged
- skip replay when PR head already moved and continue reconciliation to avoid duplicate side effects
- add runtime APIs: GET /api/runtime and POST /api/runtime/drain
- add regression tests for storage persistence, drain gating, and replay/skip recovery paths

## Verification
- node --test --import tsx server/*.test.ts
- npm run check
