### PR TITLE
Fix GraphQL variable passing in GitHub API requests

### DIFF
--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -360,7 +360,7 @@ test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThr
   assert.equal(requests.length, 2);
   assert.equal(requests[0]?.route, "POST /graphql");
   assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  const vars0 = requests[0]?.params.variables as Record<string, unknown> | undefined;
+  const vars0 = requests[0]?.params.variables as { threadId?: string; body?: string } | undefined;
   assert.equal(vars0?.threadId, "THREAD_node_123");
   assert.equal(
     vars0?.body,
@@ -368,7 +368,7 @@ test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThr
   );
   assert.equal(requests[1]?.route, "POST /graphql");
   assert.match(String(requests[1]?.params.query || ""), /resolveReviewThread/);
-  const vars1 = requests[1]?.params.variables as Record<string, unknown> | undefined;
+  const vars1 = requests[1]?.params.variables as { threadId?: string } | undefined;
   assert.equal(vars1?.threadId, "THREAD_node_123");
 });
 
@@ -479,7 +479,7 @@ test("postStatusReplyForFeedbackItem validates review-thread replies and updateS
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.route, "POST /graphql");
   assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  const statusVars = requests[0]?.params.variables as Record<string, unknown> | undefined;
+  const statusVars = requests[0]?.params.variables as { threadId?: string; body?: string } | undefined;
   assert.equal(statusVars?.threadId, "THREAD_node_123");
   assert.equal(statusVars?.body, "Queued for processing");
   assert.deepEqual(ref, {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -230,11 +230,11 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
 
       throw new Error("Unexpected paginate call");
     },
-    request: async (_route: string, params: { query: string; threadId?: string; cursor?: string | null }) => {
+    request: async (_route: string, params: { query: string; variables?: { threadId?: string; cursor?: string | null } }) => {
       graphqlCalls.push({
         query: params.query,
-        threadId: params.threadId,
-        cursor: params.cursor ?? null,
+        threadId: params.variables?.threadId,
+        cursor: params.variables?.cursor ?? null,
       });
 
       if (params.query.includes("CodeFactoryReviewThreads")) {
@@ -269,8 +269,8 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
         };
       }
 
-      assert.equal(params.threadId, "THREAD_node_999");
-      assert.equal(params.cursor, "cursor-100");
+      assert.equal(params.variables?.threadId, "THREAD_node_999");
+      assert.equal(params.variables?.cursor, "cursor-100");
 
       return {
         data: {
@@ -360,14 +360,16 @@ test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThr
   assert.equal(requests.length, 2);
   assert.equal(requests[0]?.route, "POST /graphql");
   assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  assert.equal(requests[0]?.params.threadId, "THREAD_node_123");
+  const vars0 = requests[0]?.params.variables as Record<string, unknown> | undefined;
+  assert.equal(vars0?.threadId, "THREAD_node_123");
   assert.equal(
-    requests[0]?.params.body,
+    vars0?.body,
     "Addressed in the latest babysitter update.\n\ncodefactory-feedback:gh-review-comment-1",
   );
   assert.equal(requests[1]?.route, "POST /graphql");
   assert.match(String(requests[1]?.params.query || ""), /resolveReviewThread/);
-  assert.equal(requests[1]?.params.threadId, "THREAD_node_123");
+  const vars1 = requests[1]?.params.variables as Record<string, unknown> | undefined;
+  assert.equal(vars1?.threadId, "THREAD_node_123");
 });
 
 test("postFollowUpForFeedbackItem routes review and general comments to PR comments", async () => {
@@ -477,8 +479,9 @@ test("postStatusReplyForFeedbackItem validates review-thread replies and updateS
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.route, "POST /graphql");
   assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  assert.equal(requests[0]?.params.threadId, "THREAD_node_123");
-  assert.equal(requests[0]?.params.body, "Queued for processing");
+  const statusVars = requests[0]?.params.variables as Record<string, unknown> | undefined;
+  assert.equal(statusVars?.threadId, "THREAD_node_123");
+  assert.equal(statusVars?.body, "Queued for processing");
   assert.deepEqual(ref, {
     commentDatabaseId: 456,
     replyKind: "review_thread",

--- a/server/github.ts
+++ b/server/github.ts
@@ -406,8 +406,10 @@ async function appendPaginatedReviewThreadComments(
     const response = await withGitHubErrorHandling("review thread comments", parsed, () =>
       octokit.request("POST /graphql", {
         query: REVIEW_THREAD_COMMENTS_QUERY,
-        threadId: thread.id,
-        cursor,
+        variables: {
+          threadId: thread.id,
+          cursor,
+        },
       }),
     );
 
@@ -448,10 +450,12 @@ async function fetchReviewThreadLookup(
     const response = await withGitHubErrorHandling("review threads", parsed, () =>
       octokit.request("POST /graphql", {
         query: REVIEW_THREADS_QUERY,
-        owner: parsed.owner,
-        repo: parsed.repo,
-        number: parsed.number,
-        cursor,
+        variables: {
+          owner: parsed.owner,
+          repo: parsed.repo,
+          number: parsed.number,
+          cursor,
+        },
       }),
     );
 
@@ -498,8 +502,10 @@ export async function replyToReviewThread(
   await withGitHubErrorHandling("review thread reply", parsed, () =>
     octokit.request("POST /graphql", {
       query: REVIEW_THREAD_REPLY_MUTATION,
-      threadId,
-      body,
+      variables: {
+        threadId,
+        body,
+      },
     }),
   );
 }
@@ -512,7 +518,9 @@ export async function resolveReviewThread(
   await withGitHubErrorHandling("review thread resolution", parsed, () =>
     octokit.request("POST /graphql", {
       query: RESOLVE_REVIEW_THREAD_MUTATION,
-      threadId,
+      variables: {
+        threadId,
+      },
     }),
   );
 }
@@ -796,8 +804,10 @@ export async function postStatusReplyForFeedbackItem(
     const result = await withGitHubErrorHandling("status reply in review thread", parsed, () =>
       octokit.request("POST /graphql", {
         query: REVIEW_THREAD_REPLY_MUTATION,
-        threadId: item.threadId,
-        body,
+        variables: {
+          threadId: item.threadId,
+          body,
+        },
       }),
     );
 


### PR DESCRIPTION
## Summary
This PR fixes how GraphQL variables are passed to the GitHub API in several review thread operations. Previously, variables were being passed as top-level parameters to the `octokit.request()` call, but they should be nested under a `variables` object according to the GraphQL request specification.

## Key Changes
- **appendPaginatedReviewThreadComments**: Wrapped `threadId` and `cursor` parameters in a `variables` object
- **fetchReviewThreadLookup**: Wrapped `owner`, `repo`, `number`, and `cursor` parameters in a `variables` object
- **replyToReviewThread**: Wrapped `threadId` and `body` parameters in a `variables` object
- **resolveReviewThread**: Wrapped `threadId` parameter in a `variables` object
- **postStatusReplyForFeedbackItem**: Wrapped `threadId` and `body` parameters in a `variables` object
- **Test updates**: Updated test assertions to access variables from the nested `variables` object instead of top-level parameters

## Implementation Details
The changes ensure that all GraphQL mutations and queries properly structure their variables according to the GraphQL specification. This is a correctness fix that aligns the code with how the Octokit library expects GraphQL requests to be formatted when using `octokit.request("POST /graphql", ...)`.

https://claude.ai/code/session_01GCCcnnELtGnZFSFBhFtvzm