### PR TITLE
Prevent merge indicator when agent is actively processing

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -135,7 +135,8 @@ function AgentIndicator({ pr }: { pr: PR }) {
 
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
-  const readyToMerge = isPRReadyToMerge(pr.feedbackItems);
+  const agentActive = pr.status === "processing" || countActiveFeedbackStatuses(pr.feedbackItems).inProgress > 0;
+  const readyToMerge = !agentActive && isPRReadyToMerge(pr.feedbackItems);
 
   return (
     <div
@@ -894,7 +895,7 @@ export default function Dashboard() {
                     </button>
                   )}
                 </div>
-                {isPRReadyToMerge(selectedPR.feedbackItems) && (
+                {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
                   <ReadyToMergeIndicator
                     href={selectedPR.url}
                     testId="detail-ready-to-merge"


### PR DESCRIPTION
## Summary
Updated the "Ready to Merge" indicator logic to account for active agent processing, preventing the merge button from appearing while the agent is still working on feedback items.

## Key Changes
- Added `agentActive` state that checks if PR status is "processing" or if there are in-progress feedback items
- Modified `readyToMerge` calculation to require `!agentActive` in addition to the existing `isPRReadyToMerge()` check
- Updated the merge indicator display condition to explicitly check for both processing status and active feedback items

## Implementation Details
The change ensures that the "Ready to Merge" indicator is only shown when:
1. The PR status is not "processing"
2. There are no in-progress feedback items
3. The PR passes the existing `isPRReadyToMerge()` validation

This prevents users from attempting to merge while the agent is actively processing feedback, improving the UX by making the merge state more accurate.

https://claude.ai/code/session_01DbFifgcAGKmSDcLyB88xuo