### PR TITLE
Add conflict resolution step to workflow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ All of this happens locally on your machine. No hosted service, no data leaving 
                                                                       │
                                                                       ▼
                                                                ┌──────────────┐
+                                                               │  Conflict    │
+                                                               │  Resolution  │
+                                                               └──────┬───────┘
+                                                                      │
+                                                                      ▼
+                                                               ┌──────────────┐
                                                                │ Commit & Push│
                                                                │ to PR branch │
                                                                └──────────────┘

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ All of this happens locally on your machine. No hosted service, no data leaving 
 3. Open PRs and their review feedback are fetched, normalized, and stored.
 4. The babysitter triages what needs action and what can be ignored.
 5. An agent run happens inside an isolated git worktree — your working copy stays untouched.
-6. Verification, commit, push, and detailed logs are recorded for the dashboard.
+6. If merge conflicts appear, the babysitter attempts conflict resolution in that worktree.
+7. Verification, commit, push, and detailed logs are recorded for the dashboard.
 
 ## Features
 


### PR DESCRIPTION
## Summary
Updated the README workflow diagram to include an explicit conflict resolution step in the process flow.

## Changes
- Added a new "Conflict Resolution" step to the workflow diagram that appears after the main processing stage and before the "Commit & Push to PR branch" step
- This clarifies that conflict resolution is a distinct phase in the workflow that users should be aware of

## Details
The diagram now visually represents the complete workflow including the conflict resolution phase, making it clearer to users what steps are involved in the overall process.

https://claude.ai/code/session_01KHr4sXmTev8NTRebgpVUy2