### PR TITLE
Handle missing review thread IDs gracefully with fallback

### DIFF
--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1704,7 +1704,11 @@ export class PRBabysitter {
           // yet (e.g. previous run posted the reply but failed before
           // resolving). Resolve it now to keep conversations tidy.
           if (!item.threadId) {
-            throw new Error(`Missing review thread metadata for ${item.id}`);
+            await queueLog(pr.id, "warn", `Cannot resolve review thread for ${item.id}: thread ID unavailable (skipping)`, {
+              phase: "github.followup",
+              metadata: { feedbackId: item.id },
+            });
+            continue;
           }
 
           await this.github.resolveReviewThread(octokit, parsedPr, item.threadId);

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -531,6 +531,77 @@ test("postFollowUpForFeedbackItem falls back to PR comment when review thread ID
   );
 });
 
+test("postStatusReplyForFeedbackItem falls back to PR comment when review thread ID is missing", async () => {
+  const comments: Array<Record<string, unknown>> = [];
+  const issueCommentUpdates: Array<Record<string, unknown>> = [];
+
+  const octokit = {
+    request: async () => {
+      throw new Error("should not call graphql when falling back");
+    },
+    pulls: {
+      updateReviewComment: async () => {
+        throw new Error("should not update review comments for fallback status replies");
+      },
+    },
+    issues: {
+      createComment: async (params: Record<string, unknown>) => {
+        comments.push(params);
+        return { data: { id: 222 } };
+      },
+      updateComment: async (params: Record<string, unknown>) => {
+        issueCommentUpdates.push(params);
+        return { data: { ok: true } };
+      },
+    },
+  };
+
+  const ref = await postStatusReplyForFeedbackItem(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    makeFeedbackItem({
+      threadId: null,
+      sourceUrl: "https://github.com/octo/example/pull/42#discussion_r1",
+    }),
+    "Queued for processing",
+  );
+
+  assert.deepEqual(ref, {
+    commentDatabaseId: 222,
+    replyKind: "general_comment",
+    body: `> _Could not post this status update in the review thread directly ([original comment](https://github.com/octo/example/pull/42#discussion_r1))._\n\nQueued for processing`,
+  });
+  assert.equal(comments.length, 1);
+  assert.ok(
+    String(comments[0]?.body).includes("Queued for processing"),
+    "fallback comment should contain original status body",
+  );
+  assert.ok(
+    String(comments[0]?.body).includes("original comment"),
+    "fallback comment should link to original review comment",
+  );
+
+  if (!ref) {
+    throw new Error("expected a status reply reference");
+  }
+
+  await updateStatusReply(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    ref,
+    "Queued for processing\nVerifying changes",
+  );
+
+  assert.deepEqual(issueCommentUpdates, [
+    {
+      owner: "octo",
+      repo: "example",
+      comment_id: 222,
+      body: "Queued for processing\nVerifying changes",
+    },
+  ]);
+});
+
 test("postStatusReplyForFeedbackItem validates review-thread replies and updateStatusReply mutates the local ref", async () => {
   const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
   const updatedReviewComments: Array<Record<string, unknown>> = [];

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -493,6 +493,44 @@ test("postFollowUpForFeedbackItem routes review and general comments to PR comme
   ]);
 });
 
+test("postFollowUpForFeedbackItem falls back to PR comment when review thread ID is missing", async () => {
+  const comments: Array<Record<string, unknown>> = [];
+
+  const octokit = {
+    request: async () => {
+      throw new Error("should not call graphql when falling back");
+    },
+    issues: {
+      createComment: async (params: Record<string, unknown>) => {
+        comments.push(params);
+        return { data: { id: 999 } };
+      },
+    },
+  };
+
+  await postFollowUpForFeedbackItem(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 42 },
+    makeFeedbackItem({
+      threadId: null,
+      sourceUrl: "https://github.com/octo/example/pull/42#discussion_r1",
+    }),
+    "Addressed this feedback.",
+  );
+
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0]?.owner, "octo");
+  assert.equal(comments[0]?.issue_number, 42);
+  assert.ok(
+    String(comments[0]?.body).includes("Addressed this feedback."),
+    "fallback comment should contain original body",
+  );
+  assert.ok(
+    String(comments[0]?.body).includes("original comment"),
+    "fallback comment should link to original review comment",
+  );
+});
+
 test("postStatusReplyForFeedbackItem validates review-thread replies and updateStatusReply mutates the local ref", async () => {
   const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
   const updatedReviewComments: Array<Record<string, unknown>> = [];

--- a/server/github.ts
+++ b/server/github.ts
@@ -579,10 +579,13 @@ export async function postFollowUpForFeedbackItem(
 ): Promise<void> {
   if (item.replyKind === "review_thread") {
     if (!item.threadId) {
-      throw new GitHubIntegrationError(
-        `GitHub could not determine the review thread for feedback item ${item.id} on ${formatGitHubTarget(parsed)}.`,
-        502,
-      );
+      // Thread lookup failed (e.g. GraphQL pagination gap or timing issue).
+      // Fall back to a top-level PR comment so the audit trail is still visible.
+      const fallbackBody = item.sourceUrl
+        ? `> _Could not reply in the review thread directly ([original comment](${item.sourceUrl}))._\n\n${body}`
+        : body;
+      await replyToIssueComment(octokit, parsed, fallbackBody);
+      return;
     }
 
     await replyToReviewThread(octokit, parsed, item.threadId, body);

--- a/server/github.ts
+++ b/server/github.ts
@@ -807,7 +807,26 @@ export async function postStatusReplyForFeedbackItem(
   body: string,
 ): Promise<StatusReplyRef | null> {
   if (item.replyKind === "review_thread") {
-    if (!item.threadId) return null;
+    if (!item.threadId) {
+      const fallbackBody = item.sourceUrl
+        ? `> _Could not post this status update in the review thread directly ([original comment](${item.sourceUrl}))._\n\n${body}`
+        : body;
+
+      const fallbackResult = await withGitHubErrorHandling("status reply fallback", parsed, () =>
+        octokit.issues.createComment({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          issue_number: parsed.number,
+          body: fallbackBody,
+        }),
+      );
+
+      return {
+        commentDatabaseId: fallbackResult.data.id,
+        replyKind: "general_comment",
+        body: fallbackBody,
+      };
+    }
 
     const result = await withGitHubErrorHandling("status reply in review thread", parsed, () =>
       octokit.request("POST /graphql", {


### PR DESCRIPTION
## Summary
This change improves error handling when GitHub review thread IDs are unavailable by falling back to top-level PR comments instead of throwing errors. This ensures feedback responses remain visible in the audit trail even when thread metadata lookup fails.

## Key Changes
- **github.ts**: Modified `postFollowUpForFeedbackItem()` to fall back to posting a top-level PR comment when `threadId` is missing, rather than throwing a 502 error. The fallback comment includes a link to the original review comment for context.
- **babysitter.ts**: Updated review thread resolution logic to log a warning and skip resolution when thread ID is unavailable, instead of throwing an error. This prevents the entire feedback processing from failing.
- **github.test.ts**: Added test case verifying the fallback behavior when `threadId` is null, ensuring the comment is posted to the PR with appropriate context linking to the original comment.

## Implementation Details
- The fallback comment includes a note indicating it couldn't reply in the review thread directly, with a link to the original comment via `sourceUrl`
- This gracefully handles edge cases like GraphQL pagination gaps or timing issues that might cause thread ID lookup to fail
- The solution maintains visibility of feedback responses while acknowledging the limitation to users

https://claude.ai/code/session_01EBnozpH6GYcNfywezbyb4t