### PR TITLE
Add model selection support for Claude agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,14 @@ Use strict TypeScript, 2-space indentation, double quotes, and semicolons to mat
 ## Testing Guidelines
 Tests use the Node test runner with `tsx` and are currently colocated in `server/`. Add focused regression coverage for changes to storage, GitHub sync, repo workspace isolation, or babysitter flows. For filesystem behavior, prefer temp directories over repo-local fixtures so tests remain isolated and repeatable.
 
+## Agent Defaults
+When agents are used, default to the best available model (`opus`) with highest thinking enabled. The default coding agent is `claude`. These defaults are set in `server/defaultConfig.ts` and can be changed at runtime via the dashboard model selector or the `/api/config` endpoint.
+
 ## Commit & Pull Request Guidelines
 Recent commits favor short imperative summaries, usually with prefixes like `feat:`, `fix:`, and `docs:`. Keep PRs narrow, explain the behavior change, and list the commands you ran to verify it. Include screenshots for dashboard UI changes. Always start work in a git worktree created from a freshly updated `main`, then push to a branch instead of `main` unless the user explicitly asks for a direct push. Always open a PR when completed work is ready unless the user explicitly instructs otherwise.
+
+## Post-Merge Maintenance
+After every 5 PR merges, audit `AGENTS.md` for brevity: remove duplicate instructions, consolidate overlapping sections, and trim stale guidance. Submit the cleanup as its own PR so reviewers can approve the changes.
+
+## Pre-Commit Quality Check
+When creating a fresh PR with the `claude` agent available locally, run `/simplify` on all changed files before committing. This catches unnecessary complexity, code duplication, and quality issues early.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Use strict TypeScript, 2-space indentation, double quotes, and semicolons to mat
 Tests use the Node test runner with `tsx` and are currently colocated in `server/`. Add focused regression coverage for changes to storage, GitHub sync, repo workspace isolation, or babysitter flows. For filesystem behavior, prefer temp directories over repo-local fixtures so tests remain isolated and repeatable.
 
 ## Agent Defaults
-When agents are used, default to the best available model (`opus`) with highest thinking enabled. The default coding agent is `claude`. These defaults are set in `server/defaultConfig.ts` and can be changed at runtime via the dashboard model selector or the `/api/config` endpoint.
+When agents are used, default to `codingAgent: "claude"` and `model: "opus"`. There is no separate "thinking"/reasoning-effort configuration flag in this app today; agent reasoning behavior follows the selected model/runtime defaults. These defaults are set in `server/defaultConfig.ts` and can be changed at runtime via the dashboard model selector or the `/api/config` endpoint.
 
 ## Commit & Pull Request Guidelines
 Recent commits favor short imperative summaries, usually with prefixes like `feat:`, `fix:`, and `docs:`. Keep PRs narrow, explain the behavior change, and list the commands you ran to verify it. Include screenshots for dashboard UI changes. Always start work in a git worktree created from a freshly updated `main`, then push to a branch instead of `main` unless the user explicitly asks for a direct push. Always open a PR when completed work is ready unless the user explicitly instructs otherwise.

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -698,6 +698,22 @@ export default function Dashboard() {
             <option value="codex">codex</option>
             <option value="claude">claude</option>
           </select>
+          <label className="text-[11px] uppercase tracking-wider text-muted-foreground">Model</label>
+          <select
+            value={config?.model}
+            onChange={(e) => {
+              if (e.target.value !== config?.model) {
+                updateConfigMutation.mutate({ model: e.target.value });
+              }
+            }}
+            disabled={updateConfigMutation.isPending}
+            data-testid="select-model"
+            className="border border-border bg-transparent px-2 py-0.5 text-[11px] focus:border-foreground focus:outline-none disabled:opacity-50"
+          >
+            <option value="opus">opus</option>
+            <option value="sonnet">sonnet</option>
+            <option value="haiku">haiku</option>
+          </select>
         </div>
       </header>
 

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -20,6 +20,10 @@ export type CommandResult = {
 
 const AGENTS: CodingAgent[] = ["codex", "claude"];
 
+function modelArgs(model?: string): string[] {
+  return model ? ["--model", model] : [];
+}
+
 export async function commandExists(command: string): Promise<boolean> {
   const result = await runCommand("which", [command], {
     timeoutMs: 4000,
@@ -49,8 +53,9 @@ export async function evaluateFixNecessityWithAgent(params: {
   agent: CodingAgent;
   cwd: string;
   prompt: string;
+  model?: string;
 }): Promise<EvaluationResult> {
-  const { agent, cwd, prompt } = params;
+  const { agent, cwd, prompt, model } = params;
 
   const extractionPrompt = [
     "Respond with ONLY valid JSON and nothing else.",
@@ -100,14 +105,17 @@ export async function evaluateFixNecessityWithAgent(params: {
     }
   }
 
+  const claudeArgs = [
+    "-p",
+    "--output-format",
+    "text",
+    ...modelArgs(model),
+    extractionPrompt,
+  ];
+
   const result = await runCommand(
     "claude",
-    [
-      "-p",
-      "--output-format",
-      "text",
-      extractionPrompt,
-    ],
+    claudeArgs,
     { cwd, timeoutMs: 180000 },
   );
 
@@ -122,11 +130,12 @@ export async function applyFixesWithAgent(params: {
   agent: CodingAgent;
   cwd: string;
   prompt: string;
+  model?: string;
   env?: NodeJS.ProcessEnv;
   onStdoutChunk?: (chunk: string) => void;
   onStderrChunk?: (chunk: string) => void;
 }): Promise<CommandResult> {
-  const { agent, cwd, prompt, env, onStdoutChunk, onStderrChunk } = params;
+  const { agent, cwd, prompt, model, env, onStdoutChunk, onStderrChunk } = params;
 
   if (agent === "codex") {
     const result = await runCommand(
@@ -151,6 +160,7 @@ export async function applyFixesWithAgent(params: {
       "-p",
       "--permission-mode",
       "auto",
+      ...modelArgs(model),
       prompt,
     ],
     { cwd, env, timeoutMs: 900000, onStdoutChunk, onStderrChunk },

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1138,6 +1138,7 @@ export class PRBabysitter {
           agent,
           cwd: process.cwd(),
           prompt: evalPrompt,
+          model: config.model,
         });
 
         const updated = applyEvaluationDecision(item, evaluation.needsFix, evaluation.reason);
@@ -1208,6 +1209,7 @@ export class PRBabysitter {
           agent,
           cwd: process.cwd(),
           prompt: statusEvalPrompt,
+          model: config.model,
         });
 
         if (evaluation.needsFix) {
@@ -1420,6 +1422,7 @@ export class PRBabysitter {
                 agent,
                 cwd: worktreePath,
                 prompt: conflictPrompt,
+                model: config.model,
                 env: conflictAgentEnv,
                 onStdoutChunk: conflictStdout.onChunk,
                 onStderrChunk: conflictStderr.onChunk,
@@ -1529,6 +1532,7 @@ export class PRBabysitter {
               agent,
               cwd: worktreePath,
               prompt: fixPrompt,
+              model: config.model,
               env: agentEnv,
               onStdoutChunk: agentStdout.onChunk,
               onStderrChunk: agentStderr.onChunk,

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -2,8 +2,8 @@ import type { Config } from "@shared/schema";
 
 export const DEFAULT_CONFIG: Config = {
   githubToken: "",
-  codingAgent: "codex",
-  model: "sonnet",
+  codingAgent: "claude",
+  model: "opus",
   maxTurns: 15,
   batchWindowMs: 300000,
   pollIntervalMs: 120000,

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -12,8 +12,8 @@ import {
 
 const config: Config = {
   githubToken: "",
-  codingAgent: "codex",
-  model: "sonnet",
+  codingAgent: "claude",
+  model: "opus",
   maxTurns: 15,
   batchWindowMs: 300000,
   pollIntervalMs: 120000,


### PR DESCRIPTION
## Summary
This PR adds support for selecting different Claude models (opus, sonnet, haiku) at runtime, with opus as the new default. The model selection is exposed through the dashboard UI and passed through to agent invocations.

## Key Changes
- **Agent function updates**: Added `model` parameter to `evaluateFixNecessityWithAgent()` and `applyFixesWithAgent()` functions, with a new `modelArgs()` helper to conditionally include model flags
- **Dashboard UI**: Added a model selector dropdown in the configuration panel allowing users to choose between opus, sonnet, and haiku models
- **Default configuration**: Changed default coding agent from "codex" to "claude" and default model from "sonnet" to "opus"
- **Agent invocations**: Updated all calls to agent functions in `babysitter.ts` to pass the configured model
- **Documentation**: Updated `AGENTS.md` with agent defaults guidance and added post-merge maintenance and pre-commit quality check sections
- **Test fixtures**: Updated test config to match new defaults (claude agent, opus model)

## Implementation Details
- The `modelArgs()` helper returns `["--model", model]` when a model is specified, or an empty array otherwise, keeping the command construction clean
- Model selection is integrated into the existing config mutation flow on the dashboard
- All agent execution paths (evaluation, status checking, conflict resolution, and fix application) now respect the configured model

https://claude.ai/code/session_018XZuVMNc8QQcGMtQc9PuYQ