### PR TITLE
Add dynamic agent model discovery and selection

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,12 +5,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Dashboard from "@/pages/dashboard";
+import Settings from "@/pages/settings";
 import NotFound from "@/pages/not-found";
 
 function AppRouter() {
   return (
     <Switch>
       <Route path="/" component={Dashboard} />
+      <Route path="/settings" component={Settings} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
-import { AGENT_MODELS, DEFAULT_AGENT_MODEL } from "@shared/schema";
+import { FALLBACK_AGENT_MODELS, DEFAULT_AGENT_MODEL } from "@shared/schema";
 import type { Config, FeedbackItem, LogEntry, PR, PRQuestion } from "@shared/schema";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
@@ -570,6 +570,11 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
+  const { data: agentModels } = useQuery<Record<string, string[]>>({
+    queryKey: ["/api/agent-models"],
+    refetchInterval: 60000,
+  });
+
   const { data: repos = [] } = useQuery<string[]>({
     queryKey: ["/api/repos"],
     refetchInterval: 5000,
@@ -689,7 +694,7 @@ export default function Dashboard() {
             value={config?.codingAgent ?? "codex"}
             onChange={(e) => {
               const newAgent = e.target.value as Config["codingAgent"];
-              const models = AGENT_MODELS[newAgent];
+              const models = agentModels?.[newAgent] ?? FALLBACK_AGENT_MODELS[newAgent];
               const currentModel = config?.model;
               const model = currentModel && models.includes(currentModel)
                 ? currentModel
@@ -718,7 +723,7 @@ export default function Dashboard() {
             data-testid="select-model"
             className="border border-border bg-transparent px-2 py-0.5 text-[11px] focus:border-foreground focus:outline-none disabled:opacity-50"
           >
-            {(AGENT_MODELS[(config?.codingAgent ?? "codex") as keyof typeof AGENT_MODELS] ?? AGENT_MODELS.codex).map(
+            {(agentModels?.[config?.codingAgent ?? "codex"] ?? FALLBACK_AGENT_MODELS[config?.codingAgent ?? "codex"]).map(
               (m) => (
                 <option key={m} value={m}>
                   {m}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
@@ -582,6 +582,15 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
+  const getModelsForAgent = (agent: Config["codingAgent"]) =>
+    agentModels?.[agent] ?? FALLBACK_AGENT_MODELS[agent];
+
+  const currentAgent = config?.codingAgent ?? "codex";
+  const modelsForCurrentAgent = useMemo(
+    () => getModelsForAgent(currentAgent),
+    [agentModels, currentAgent],
+  );
+
   const displayedPRs = viewMode === "active" ? prs : archivedPRs;
   const isArchived = viewMode === "archived";
 
@@ -702,7 +711,7 @@ export default function Dashboard() {
             value={config?.codingAgent ?? "codex"}
             onChange={(e) => {
               const newAgent = e.target.value as Config["codingAgent"];
-              const models = agentModels?.[newAgent] ?? FALLBACK_AGENT_MODELS[newAgent];
+              const models = getModelsForAgent(newAgent);
               const currentModel = config?.model;
               const model = currentModel && models.includes(currentModel)
                 ? currentModel
@@ -731,13 +740,11 @@ export default function Dashboard() {
             data-testid="select-model"
             className="border border-border bg-transparent px-2 py-0.5 text-[11px] focus:border-foreground focus:outline-none disabled:opacity-50"
           >
-            {(agentModels?.[config?.codingAgent ?? "codex"] ?? FALLBACK_AGENT_MODELS[config?.codingAgent ?? "codex"]).map(
-              (m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ),
-            )}
+            {modelsForCurrentAgent.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
           </select>
           <Link
             href="/settings"

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
+import { AGENT_MODELS, DEFAULT_AGENT_MODEL } from "@shared/schema";
 import type { Config, FeedbackItem, LogEntry, PR, PRQuestion } from "@shared/schema";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
@@ -686,11 +687,18 @@ export default function Dashboard() {
           <label className="text-[11px] uppercase tracking-wider text-muted-foreground">Agent</label>
           <select
             value={config?.codingAgent ?? "codex"}
-            onChange={(e) =>
+            onChange={(e) => {
+              const newAgent = e.target.value as Config["codingAgent"];
+              const models = AGENT_MODELS[newAgent];
+              const currentModel = config?.model;
+              const model = currentModel && models.includes(currentModel)
+                ? currentModel
+                : DEFAULT_AGENT_MODEL[newAgent];
               updateConfigMutation.mutate({
-                codingAgent: e.target.value as Config["codingAgent"],
-              })
-            }
+                codingAgent: newAgent,
+                model,
+              });
+            }}
             disabled={updateConfigMutation.isPending}
             data-testid="select-coding-agent"
             className="border border-border bg-transparent px-2 py-0.5 text-[11px] focus:border-foreground focus:outline-none disabled:opacity-50"
@@ -710,9 +718,13 @@ export default function Dashboard() {
             data-testid="select-model"
             className="border border-border bg-transparent px-2 py-0.5 text-[11px] focus:border-foreground focus:outline-none disabled:opacity-50"
           >
-            <option value="opus">opus</option>
-            <option value="sonnet">sonnet</option>
-            <option value="haiku">haiku</option>
+            {(AGENT_MODELS[(config?.codingAgent ?? "codex") as keyof typeof AGENT_MODELS] ?? AGENT_MODELS.codex).map(
+              (m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ),
+            )}
           </select>
         </div>
       </header>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
+import { Link } from "wouter";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
 import { FALLBACK_AGENT_MODELS, DEFAULT_AGENT_MODEL } from "@shared/schema";
@@ -731,6 +732,12 @@ export default function Dashboard() {
               ),
             )}
           </select>
+          <Link
+            href="/settings"
+            className="border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            settings
+          </Link>
         </div>
       </header>
 

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,0 +1,330 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { queryClient, apiRequest } from "@/lib/queryClient";
+import { FALLBACK_AGENT_MODELS, DEFAULT_AGENT_MODEL } from "@shared/schema";
+import type { Config } from "@shared/schema";
+import { toast } from "@/hooks/use-toast";
+import { Link } from "wouter";
+
+export default function Settings() {
+  const { data: config } = useQuery<Config>({
+    queryKey: ["/api/config"],
+  });
+
+  const { data: agentModels } = useQuery<Record<string, string[]>>({
+    queryKey: ["/api/agent-models"],
+  });
+
+  const [githubToken, setGithubToken] = useState("");
+  const [showTokenInput, setShowTokenInput] = useState(false);
+
+  const updateConfigMutation = useMutation({
+    mutationFn: async (updates: Partial<Config>) => {
+      const res = await apiRequest("PATCH", "/api/config", updates);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      toast({ description: "Settings saved." });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Failed to save: ${error.message}` });
+    },
+  });
+
+  const refreshModelsMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("POST", "/api/agent-models/refresh");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/agent-models"] });
+      toast({ description: "Models refreshed from CLI agents." });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Refresh failed: ${error.message}` });
+    },
+  });
+
+  const codexModels = agentModels?.codex ?? FALLBACK_AGENT_MODELS.codex;
+  const claudeModels = agentModels?.claude ?? FALLBACK_AGENT_MODELS.claude;
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <Link href="/" className="text-[11px] text-muted-foreground hover:text-foreground">
+            &larr; back
+          </Link>
+          <span className="text-sm font-medium tracking-tight">settings</span>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto flex max-w-2xl flex-col gap-8">
+
+          {/* Agent & Model */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Agent &amp; Model
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm">Coding Agent</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    CLI agent used to apply fixes
+                  </div>
+                </div>
+                <select
+                  value={config?.codingAgent ?? "codex"}
+                  onChange={(e) => {
+                    const newAgent = e.target.value as Config["codingAgent"];
+                    const models = agentModels?.[newAgent] ?? FALLBACK_AGENT_MODELS[newAgent];
+                    const currentModel = config?.model;
+                    const model =
+                      currentModel && models.includes(currentModel)
+                        ? currentModel
+                        : DEFAULT_AGENT_MODEL[newAgent];
+                    updateConfigMutation.mutate({ codingAgent: newAgent, model });
+                  }}
+                  disabled={updateConfigMutation.isPending}
+                  className="border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
+                >
+                  <option value="codex">codex</option>
+                  <option value="claude">claude</option>
+                </select>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm">Model</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Model used by the selected agent
+                  </div>
+                </div>
+                <select
+                  value={config?.model}
+                  onChange={(e) => {
+                    if (e.target.value !== config?.model) {
+                      updateConfigMutation.mutate({ model: e.target.value });
+                    }
+                  }}
+                  disabled={updateConfigMutation.isPending}
+                  className="border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
+                >
+                  {(agentModels?.[config?.codingAgent ?? "codex"] ??
+                    FALLBACK_AGENT_MODELS[config?.codingAgent ?? "codex"]
+                  ).map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </section>
+
+          {/* Model Discovery */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Model Discovery
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <div className="text-[11px] text-muted-foreground">
+                Available models are auto-detected from installed CLI agents every 3 days.
+                You can trigger a manual refresh below.
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:gap-6">
+                <div className="flex-1">
+                  <div className="mb-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    Codex models
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {codexModels.map((m) => (
+                      <span
+                        key={m}
+                        className="rounded border border-border px-1.5 py-0.5 text-[11px]"
+                      >
+                        {m}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex-1">
+                  <div className="mb-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    Claude models
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {claudeModels.map((m) => (
+                      <span
+                        key={m}
+                        className="rounded border border-border px-1.5 py-0.5 text-[11px]"
+                      >
+                        {m}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={() => refreshModelsMutation.mutate()}
+                disabled={refreshModelsMutation.isPending}
+                className="self-start border border-border px-3 py-1 text-xs hover:bg-muted disabled:opacity-50"
+              >
+                {refreshModelsMutation.isPending ? "refreshing..." : "refresh models"}
+              </button>
+            </div>
+          </section>
+
+          {/* Tuning */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Tuning
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <SettingRow
+                label="Max turns"
+                description="Maximum agent turns per feedback item"
+                value={config?.maxTurns ?? 15}
+                onChange={(v) => updateConfigMutation.mutate({ maxTurns: v })}
+                disabled={updateConfigMutation.isPending}
+              />
+              <SettingRow
+                label="Poll interval (ms)"
+                description="How often to check for new feedback"
+                value={config?.pollIntervalMs ?? 120000}
+                onChange={(v) => updateConfigMutation.mutate({ pollIntervalMs: v })}
+                disabled={updateConfigMutation.isPending}
+              />
+              <SettingRow
+                label="Batch window (ms)"
+                description="Time to batch feedback before processing"
+                value={config?.batchWindowMs ?? 300000}
+                onChange={(v) => updateConfigMutation.mutate({ batchWindowMs: v })}
+                disabled={updateConfigMutation.isPending}
+              />
+              <SettingRow
+                label="Max changes per run"
+                description="Limit on concurrent changes"
+                value={config?.maxChangesPerRun ?? 20}
+                onChange={(v) => updateConfigMutation.mutate({ maxChangesPerRun: v })}
+                disabled={updateConfigMutation.isPending}
+              />
+            </div>
+          </section>
+
+          {/* GitHub Token */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              GitHub
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm">Token</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    {config?.githubToken || "not set"}
+                  </div>
+                </div>
+                {showTokenInput ? (
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="password"
+                      value={githubToken}
+                      onChange={(e) => setGithubToken(e.target.value)}
+                      placeholder="ghp_..."
+                      className="border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none"
+                    />
+                    <button
+                      onClick={() => {
+                        if (githubToken) {
+                          updateConfigMutation.mutate({ githubToken });
+                          setGithubToken("");
+                          setShowTokenInput(false);
+                        }
+                      }}
+                      disabled={!githubToken || updateConfigMutation.isPending}
+                      className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                    >
+                      save
+                    </button>
+                    <button
+                      onClick={() => {
+                        setShowTokenInput(false);
+                        setGithubToken("");
+                      }}
+                      className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setShowTokenInput(true)}
+                    className="border border-border px-2 py-1 text-xs hover:bg-muted"
+                  >
+                    update
+                  </button>
+                )}
+              </div>
+
+              <div>
+                <div className="text-sm">Trusted reviewers</div>
+                <div className="text-[11px] text-muted-foreground">
+                  {config?.trustedReviewers?.length
+                    ? config.trustedReviewers.join(", ")
+                    : "none configured"}
+                </div>
+              </div>
+
+              <div>
+                <div className="text-sm">Ignored bots</div>
+                <div className="text-[11px] text-muted-foreground">
+                  {config?.ignoredBots?.length
+                    ? config.ignoredBots.join(", ")
+                    : "none configured"}
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingRow({
+  label,
+  description,
+  value,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  description: string;
+  value: number;
+  onChange: (v: number) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <div className="text-sm">{label}</div>
+        <div className="text-[11px] text-muted-foreground">{description}</div>
+      </div>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => {
+          const n = parseInt(e.target.value, 10);
+          if (!isNaN(n)) onChange(n);
+        }}
+        disabled={disabled}
+        className="w-28 border border-border bg-transparent px-2 py-1 text-right text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
+      />
+    </div>
+  );
+}

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -3,7 +3,7 @@ import type { Config } from "@shared/schema";
 export const DEFAULT_CONFIG: Config = {
   githubToken: "",
   codingAgent: "claude",
-  model: "opus",
+  model: "claude-sonnet-4-6",
   maxTurns: 15,
   batchWindowMs: 300000,
   pollIntervalMs: 120000,

--- a/server/modelDiscovery.ts
+++ b/server/modelDiscovery.ts
@@ -30,56 +30,54 @@ export async function discoverModels(): Promise<AgentModels> {
 }
 
 async function discoverCodexModels(): Promise<string[]> {
-  if (!(await commandExists("codex"))) {
-    return FALLBACK_AGENT_MODELS.codex;
-  }
-
   try {
-    // `codex --help` lists supported model names
-    const result = await runCommand("codex", ["--help"], { timeoutMs: 10000 });
-    if (result.code !== 0) {
-      return FALLBACK_AGENT_MODELS.codex;
+    if (await commandExists("codex")) {
+      // `codex --help` lists supported model names
+      const result = await runCommand("codex", ["--help"], { timeoutMs: 10000 });
+      if (result.code === 0) {
+        const models = parseModelsFromHelp(result.stdout, "codex");
+        if (models.length > 0) {
+          return models;
+        }
+      }
     }
-
-    const models = parseModelsFromHelp(result.stdout, "codex");
-    return models.length > 0 ? models : FALLBACK_AGENT_MODELS.codex;
-  } catch {
-    return FALLBACK_AGENT_MODELS.codex;
+  } catch (err) {
+    console.error("Codex model discovery failed:", err);
   }
+
+  return FALLBACK_AGENT_MODELS.codex;
 }
 
 async function discoverClaudeModels(): Promise<string[]> {
-  if (!(await commandExists("claude"))) {
-    return FALLBACK_AGENT_MODELS.claude;
-  }
-
   try {
-    // Try `claude model list` first (added in newer versions)
-    const listResult = await runCommand("claude", ["model", "list"], {
-      timeoutMs: 15000,
-    });
-    if (listResult.code === 0 && listResult.stdout.trim()) {
-      const models = parseModelListOutput(listResult.stdout);
-      if (models.length > 0) {
-        return models;
+    if (await commandExists("claude")) {
+      // Try `claude model list` first (added in newer versions)
+      const listResult = await runCommand("claude", ["model", "list"], {
+        timeoutMs: 15000,
+      });
+      if (listResult.code === 0 && listResult.stdout.trim()) {
+        const models = parseModelListOutput(listResult.stdout);
+        if (models.length > 0) {
+          return models;
+        }
+      }
+
+      // Fallback: parse `claude --help` for model references
+      const helpResult = await runCommand("claude", ["--help"], {
+        timeoutMs: 10000,
+      });
+      if (helpResult.code === 0) {
+        const models = parseModelsFromHelp(helpResult.stdout, "claude");
+        if (models.length > 0) {
+          return models;
+        }
       }
     }
-
-    // Fallback: parse `claude --help` for model references
-    const helpResult = await runCommand("claude", ["--help"], {
-      timeoutMs: 10000,
-    });
-    if (helpResult.code === 0) {
-      const models = parseModelsFromHelp(helpResult.stdout, "claude");
-      if (models.length > 0) {
-        return models;
-      }
-    }
-
-    return FALLBACK_AGENT_MODELS.claude;
-  } catch {
-    return FALLBACK_AGENT_MODELS.claude;
+  } catch (err) {
+    console.error("Claude model discovery failed:", err);
   }
+
+  return FALLBACK_AGENT_MODELS.claude;
 }
 
 /**
@@ -119,15 +117,17 @@ export function startModelDiscoveryJob(): void {
     return;
   }
 
+  const runDiscovery = (context: "Initial" | "Periodic") => {
+    void discoverModels().catch((err) => {
+      console.error(`${context} model discovery failed:`, err);
+    });
+  };
+
   // Run discovery immediately (non-blocking)
-  void discoverModels().catch((err) => {
-    console.error("Initial model discovery failed:", err);
-  });
+  runDiscovery("Initial");
 
   discoveryTimer = setInterval(() => {
-    void discoverModels().catch((err) => {
-      console.error("Periodic model discovery failed:", err);
-    });
+    runDiscovery("Periodic");
   }, THREE_DAYS_MS);
 }
 

--- a/server/modelDiscovery.ts
+++ b/server/modelDiscovery.ts
@@ -1,0 +1,142 @@
+import { FALLBACK_AGENT_MODELS } from "@shared/schema";
+import { runCommand, commandExists } from "./agentRunner";
+
+export type AgentModels = Record<"codex" | "claude", string[]>;
+
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+
+let cachedModels: AgentModels = { ...FALLBACK_AGENT_MODELS };
+let discoveryTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Return the currently known models for each agent.
+ */
+export function getAgentModels(): AgentModels {
+  return cachedModels;
+}
+
+/**
+ * Discover available models by asking each CLI, then cache the results.
+ * Falls back to hardcoded lists when a CLI is missing or fails.
+ */
+export async function discoverModels(): Promise<AgentModels> {
+  const [codexModels, claudeModels] = await Promise.all([
+    discoverCodexModels(),
+    discoverClaudeModels(),
+  ]);
+
+  cachedModels = { codex: codexModels, claude: claudeModels };
+  return cachedModels;
+}
+
+async function discoverCodexModels(): Promise<string[]> {
+  if (!(await commandExists("codex"))) {
+    return FALLBACK_AGENT_MODELS.codex;
+  }
+
+  try {
+    // `codex --help` lists supported model names
+    const result = await runCommand("codex", ["--help"], { timeoutMs: 10000 });
+    if (result.code !== 0) {
+      return FALLBACK_AGENT_MODELS.codex;
+    }
+
+    const models = parseModelsFromHelp(result.stdout, "codex");
+    return models.length > 0 ? models : FALLBACK_AGENT_MODELS.codex;
+  } catch {
+    return FALLBACK_AGENT_MODELS.codex;
+  }
+}
+
+async function discoverClaudeModels(): Promise<string[]> {
+  if (!(await commandExists("claude"))) {
+    return FALLBACK_AGENT_MODELS.claude;
+  }
+
+  try {
+    // Try `claude model list` first (added in newer versions)
+    const listResult = await runCommand("claude", ["model", "list"], {
+      timeoutMs: 15000,
+    });
+    if (listResult.code === 0 && listResult.stdout.trim()) {
+      const models = parseModelListOutput(listResult.stdout);
+      if (models.length > 0) {
+        return models;
+      }
+    }
+
+    // Fallback: parse `claude --help` for model references
+    const helpResult = await runCommand("claude", ["--help"], {
+      timeoutMs: 10000,
+    });
+    if (helpResult.code === 0) {
+      const models = parseModelsFromHelp(helpResult.stdout, "claude");
+      if (models.length > 0) {
+        return models;
+      }
+    }
+
+    return FALLBACK_AGENT_MODELS.claude;
+  } catch {
+    return FALLBACK_AGENT_MODELS.claude;
+  }
+}
+
+/**
+ * Parse a line-oriented model list (one model per line).
+ */
+function parseModelListOutput(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("Available"));
+}
+
+/**
+ * Parse model names from CLI --help output.
+ * Looks for patterns like model identifiers in the text.
+ */
+function parseModelsFromHelp(output: string, agent: "codex" | "claude"): string[] {
+  const pattern =
+    agent === "codex"
+      ? /\b(gpt-[\w.-]+|o[34][\w-]*|codex-[\w.-]+)\b/g
+      : /\b(claude-[\w.-]+)\b/g;
+
+  const matches = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(output)) !== null) {
+    matches.add(m[1]);
+  }
+  return Array.from(matches);
+}
+
+/**
+ * Start the periodic model discovery background job.
+ * Runs immediately on start, then every 3 days.
+ */
+export function startModelDiscoveryJob(): void {
+  if (discoveryTimer) {
+    return;
+  }
+
+  // Run discovery immediately (non-blocking)
+  void discoverModels().catch((err) => {
+    console.error("Initial model discovery failed:", err);
+  });
+
+  discoveryTimer = setInterval(() => {
+    void discoverModels().catch((err) => {
+      console.error("Periodic model discovery failed:", err);
+    });
+  }, THREE_DAYS_MS);
+}
+
+/**
+ * Stop the periodic model discovery job.
+ */
+export function stopModelDiscoveryJob(): void {
+  if (discoveryTimer) {
+    clearInterval(discoveryTimer);
+    discoveryTimer = null;
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import {
   parsePRUrl,
   parseRepoSlug,
 } from "./github";
+import { getAgentModels, startModelDiscoveryJob, stopModelDiscoveryJob } from "./modelDiscovery";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -62,12 +63,14 @@ export async function registerRoutes(
   await refreshWatcherSchedule();
   void babysitter.resumeInterruptedRuns();
   void runWatcher();
+  startModelDiscoveryJob();
 
   httpServer.on("close", () => {
     if (watcherTimer) {
       clearInterval(watcherTimer);
       watcherTimer = null;
     }
+    stopModelDiscoveryJob();
   });
 
   app.get("/api/runtime", async (_req, res) => {
@@ -448,6 +451,12 @@ export async function registerRoutes(
     const prId = req.query.prId as string | undefined;
     const logs = await storage.getLogs(prId);
     res.json(logs);
+  });
+
+  // ── Agent Models ─────────────────────────────────────────────
+
+  app.get("/api/agent-models", (_req, res) => {
+    res.json(getAgentModels());
   });
 
   // ── Config ─────────────────────────────────────────────────

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,7 +15,7 @@ import {
   parsePRUrl,
   parseRepoSlug,
 } from "./github";
-import { getAgentModels, startModelDiscoveryJob, stopModelDiscoveryJob } from "./modelDiscovery";
+import { getAgentModels, discoverModels, startModelDiscoveryJob, stopModelDiscoveryJob } from "./modelDiscovery";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -457,6 +457,16 @@ export async function registerRoutes(
 
   app.get("/api/agent-models", (_req, res) => {
     res.json(getAgentModels());
+  });
+
+  app.post("/api/agent-models/refresh", async (_req, res) => {
+    try {
+      const models = await discoverModels();
+      res.json(models);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
   });
 
   // ── Config ─────────────────────────────────────────────────

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -126,14 +126,14 @@ export const askQuestionSchema = z.object({
   question: z.string().min(1).max(2000),
 });
 
-export const AGENT_MODELS: Record<"codex" | "claude", string[]> = {
-  codex: ["o3", "o4-mini", "gpt-4.1"],
-  claude: ["opus", "sonnet", "haiku"],
+export const FALLBACK_AGENT_MODELS: Record<"codex" | "claude", string[]> = {
+  codex: ["codex-mini-latest", "gpt-4.1", "o3", "o4-mini"],
+  claude: ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5-20251001"],
 };
 
 export const DEFAULT_AGENT_MODEL: Record<"codex" | "claude", string> = {
-  codex: "o3",
-  claude: "opus",
+  codex: "codex-mini-latest",
+  claude: "claude-sonnet-4-6",
 };
 
 export const configSchema = z.object({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -126,6 +126,16 @@ export const askQuestionSchema = z.object({
   question: z.string().min(1).max(2000),
 });
 
+export const AGENT_MODELS: Record<"codex" | "claude", string[]> = {
+  codex: ["o3", "o4-mini", "gpt-4.1"],
+  claude: ["opus", "sonnet", "haiku"],
+};
+
+export const DEFAULT_AGENT_MODEL: Record<"codex" | "claude", string> = {
+  codex: "o3",
+  claude: "opus",
+};
+
 export const configSchema = z.object({
   githubToken: z.string(),
   codingAgent: z.enum(["codex", "claude"]),


### PR DESCRIPTION
## Summary
This PR implements dynamic discovery of available AI models from installed CLI tools (codex and claude) and updates the UI to allow users to select from the discovered models instead of hardcoded options.

## Key Changes

- **New model discovery system** (`server/modelDiscovery.ts`):
  - Queries `codex --help` and `claude model list` / `claude --help` to discover available models
  - Caches results and refreshes every 3 days via a background job
  - Falls back to hardcoded model lists when CLIs are unavailable or fail
  - Exports `getAgentModels()`, `discoverModels()`, `startModelDiscoveryJob()`, and `stopModelDiscoveryJob()`

- **Updated schema** (`shared/schema.ts`):
  - Added `FALLBACK_AGENT_MODELS` constant with default model lists for codex and claude
  - Added `DEFAULT_AGENT_MODEL` constant to specify the default model per agent

- **Enhanced dashboard UI** (`client/src/pages/dashboard.tsx`):
  - Fetches available models from `/api/agent-models` endpoint
  - Dynamically populates model dropdown based on selected agent
  - Auto-selects appropriate default model when switching agents
  - Falls back to hardcoded models if API data is unavailable

- **New API endpoint** (`server/routes.ts`):
  - Added `GET /api/agent-models` to expose discovered models to the client
  - Integrated model discovery job lifecycle with server startup/shutdown

- **Updated default config** (`server/defaultConfig.ts`):
  - Changed default model from `"opus"` to `"claude-sonnet-4-6"` to match actual Claude model naming

## Implementation Details

- Model discovery runs immediately on server startup and then every 3 days
- Parsing logic handles different CLI output formats (line-oriented lists and help text patterns)
- Regex patterns are agent-specific to match their respective model naming conventions
- UI gracefully handles missing or stale model data by using fallback lists
- Agent switching automatically validates and updates the selected model if it's not available for the new agent

https://claude.ai/code/session_01XQxkwtkNw8vHvv76SJGjsx