### PR TITLE
Add configurable auto-resolve for merge conflicts

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -722,6 +722,21 @@ export default function Dashboard() {
             <option value="sonnet">sonnet</option>
             <option value="haiku">haiku</option>
           </select>
+          <label className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={config?.autoResolveMergeConflicts ?? true}
+              onChange={(e) =>
+                updateConfigMutation.mutate({
+                  autoResolveMergeConflicts: e.target.checked,
+                })
+              }
+              disabled={updateConfigMutation.isPending}
+              data-testid="checkbox-auto-resolve-conflicts"
+              className="accent-foreground"
+            />
+            Auto-resolve conflicts
+          </label>
         </div>
       </header>
 

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -2139,3 +2139,83 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
 
   delete process.env.CODEFACTORY_HOME;
 });
+
+test("babysitPR skips conflict resolution when autoResolveMergeConflicts is disabled", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoResolveMergeConflicts: false });
+  const pr = await storage.addPR({
+    number: 107,
+    title: "Conflict skip PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/conflict-skip",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/107",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  let mergeAttempted = false;
+  let conflictAgentCalled = false;
+  const pullSummary = makePullSummary(pr, { mergeable: false });
+
+  const gitRunner = makeGitRunCommand({
+    localHeadSha: "skip123",
+    remoteHeadSha: "skip123",
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No fix needed",
+      }),
+      applyFixesWithAgent: async () => {
+        conflictAgentCalled = true;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      runCommand: async (command: string, args: string[], opts?: Record<string, unknown>) => {
+        if (command === "git" && args[0] === "merge") {
+          mergeAttempted = true;
+          return { code: 1, stdout: "", stderr: "CONFLICT" };
+        }
+        return gitRunner(command, args, opts);
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(mergeAttempted, false, "Should not attempt merge when auto-resolve is disabled");
+  assert.equal(conflictAgentCalled, false, "Should not invoke conflict agent when auto-resolve is disabled");
+  assert.equal(updated?.status, "watching");
+  assert.ok(logs.some((log) => log.phase === "conflict" && log.message.includes("auto-resolve is disabled")));
+
+  delete process.env.CODEFACTORY_HOME;
+});

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1341,7 +1341,15 @@ export class PRBabysitter {
         : [];
       const effectiveCommentTasks = replayCommentTasks.length > 0 ? replayCommentTasks : commentTasks;
       followUpTasks = collectGitHubFollowUpTasks(pr);
-      const hasConflicts = pullSummary.mergeable === false;
+      const prHasConflicts = pullSummary.mergeable === false;
+      const hasConflicts = prHasConflicts && config.autoResolveMergeConflicts;
+
+      if (prHasConflicts && !config.autoResolveMergeConflicts) {
+        await queueLog(pr.id, "warn", `PR #${pr.number} has merge conflicts but auto-resolve is disabled in settings`, {
+          phase: "conflict",
+          metadata: { baseRef: pullSummary.baseRef, mergeable: pullSummary.mergeable },
+        });
+      }
       const shouldRunForcedReplay = Boolean(forcedFixPrompt && !skipForcedReplay);
       const disableAgentExecution = Boolean(forcedFixPrompt && skipForcedReplay);
       const hasAgentWork = !disableAgentExecution && (effectiveCommentTasks.length > 0 || statusTasks.length > 0 || shouldRunForcedReplay);

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIG: Config = {
   batchWindowMs: 300000,
   pollIntervalMs: 120000,
   maxChangesPerRun: 20,
+  autoResolveMergeConflicts: true,
   watchedRepos: [],
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -16,6 +16,7 @@ type ConfigRow = {
   batch_window_ms: number;
   poll_interval_ms: number;
   max_changes_per_run: number;
+  auto_resolve_merge_conflicts: number;
   trusted_reviewers_json: string;
   ignored_bots_json: string;
 };
@@ -274,6 +275,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("feedback_items", "audit_token", "TEXT NOT NULL DEFAULT ''");
     this.ensureColumn("feedback_items", "status", "TEXT NOT NULL DEFAULT 'pending'");
     this.ensureColumn("feedback_items", "status_reason", "TEXT");
+    this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
 
     const configExists = this.db.prepare("SELECT 1 AS present FROM config WHERE id = 1").get() as { present: number } | undefined;
     if (!configExists) {
@@ -309,6 +311,7 @@ export class SqliteStorage implements IStorage {
       batchWindowMs: row.batch_window_ms,
       pollIntervalMs: row.poll_interval_ms,
       maxChangesPerRun: row.max_changes_per_run,
+      autoResolveMergeConflicts: Boolean(row.auto_resolve_merge_conflicts),
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
       ignoredBots: JSON.parse(row.ignored_bots_json),
@@ -326,9 +329,10 @@ export class SqliteStorage implements IStorage {
         batch_window_ms,
         poll_interval_ms,
         max_changes_per_run,
+        auto_resolve_merge_conflicts,
         trusted_reviewers_json,
         ignored_bots_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         github_token = excluded.github_token,
         coding_agent = excluded.coding_agent,
@@ -337,6 +341,7 @@ export class SqliteStorage implements IStorage {
         batch_window_ms = excluded.batch_window_ms,
         poll_interval_ms = excluded.poll_interval_ms,
         max_changes_per_run = excluded.max_changes_per_run,
+        auto_resolve_merge_conflicts = excluded.auto_resolve_merge_conflicts,
         trusted_reviewers_json = excluded.trusted_reviewers_json,
         ignored_bots_json = excluded.ignored_bots_json
     `).run(
@@ -348,6 +353,7 @@ export class SqliteStorage implements IStorage {
       config.batchWindowMs,
       config.pollIntervalMs,
       config.maxChangesPerRun,
+      Number(config.autoResolveMergeConflicts),
       JSON.stringify(config.trustedReviewers),
       JSON.stringify(config.ignoredBots),
     );
@@ -779,7 +785,8 @@ export class SqliteStorage implements IStorage {
   async getConfig(): Promise<Config> {
     const row = this.db.prepare(`
       SELECT github_token, coding_agent, model, max_turns, batch_window_ms,
-             poll_interval_ms, max_changes_per_run, trusted_reviewers_json, ignored_bots_json
+             poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts,
+             trusted_reviewers_json, ignored_bots_json
       FROM config
       WHERE id = 1
     `).get() as ConfigRow;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -159,6 +159,7 @@ export const configSchema = z.object({
   batchWindowMs: z.number(),
   pollIntervalMs: z.number(),
   maxChangesPerRun: z.number(),
+  autoResolveMergeConflicts: z.boolean(),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
   ignoredBots: z.array(z.string()),


### PR DESCRIPTION
## Summary
This PR adds a new configuration option to allow users to disable automatic merge conflict resolution. Previously, the system would always attempt to resolve merge conflicts when detected. Now users can opt out of this behavior through a dashboard setting.

## Key Changes
- **Schema & Config**: Added `autoResolveMergeConflicts` boolean field to the Config type with a default value of `true` to maintain backward compatibility
- **Database**: Added `auto_resolve_merge_conflicts` column to the SQLite config table with proper migration support
- **Dashboard UI**: Added a checkbox in the settings panel to toggle automatic conflict resolution on/off
- **Conflict Resolution Logic**: Modified the babysitter to check the config setting before attempting to resolve conflicts; if disabled, a warning log is recorded instead
- **Test Coverage**: Added comprehensive test case verifying that conflict resolution is properly skipped when the setting is disabled

## Implementation Details
- The feature defaults to `true` (enabled) to preserve existing behavior for current users
- When `autoResolveMergeConflicts` is `false` and conflicts are detected, the system logs a warning with phase "conflict" and metadata about the merge state, but does not attempt resolution
- The database migration uses `ensureColumn` to safely add the new column with a default value of 1 (true)
- The UI checkbox is disabled during mutation operations to prevent concurrent updates

https://claude.ai/code/session_01HXQ1Shqsc6Eq4q8hM2r8Zr