### PR TITLE
Add Tauri app build workflow for merged pull requests

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,0 +1,76 @@
+name: Build Tauri App
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build-tauri:
+    if: github.event.pull_request.merged == true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ matrix.target }}-cargo-
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            javascriptcoregtk-4.1 \
+            libayatana-appindicator3-dev
+
+      - run: npm ci
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: v${{ github.event.pull_request.merge_commit_sha }}
+          releaseName: "Code Factory v__VERSION__"
+          releaseBody: "Built from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically builds and releases the Tauri application whenever a pull request is merged into the main branch.

## Key Changes
- **New workflow file**: `.github/workflows/tauri-build.yml`
  - Triggers on merged pull requests
  - Builds for multiple platforms: Linux (x86_64), macOS (ARM64 and x86_64), and Windows (x86_64)
  - Sets up Node.js 24 with npm caching
  - Installs Rust stable toolchain with platform-specific targets
  - Caches Rust dependencies to improve build times
  - Installs required Linux development dependencies (GTK, WebKit2, etc.)
  - Creates draft releases with build artifacts from each platform
  - Uses the merge commit SHA for release tagging

## Notable Implementation Details
- The workflow only runs when `github.event.pull_request.merged == true`, ensuring builds only happen for successfully merged PRs
- Uses matrix strategy for cross-platform builds with fail-fast disabled to build all platforms even if one fails
- Includes comprehensive Linux dependency installation for Tauri's GTK-based requirements
- Generates draft releases (not auto-published) with PR context in the release body
- Leverages GitHub Actions caching for both npm and Rust dependencies to optimize build performance

https://claude.ai/code/session_017NVcwzmrrDE7HzMcsp8RyV