### PR TITLE
fix: compile markdown docs to HTML for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ server/public
 vite.config.ts.*
 *.tar.gz
 .worktrees
-docs/public/_site
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -700,11 +700,11 @@
             <span class="material-symbols-outlined">home</span>
             Introduction
           </a>
-          <a class="sidebar-link" href="./public/getting-started.md">
+          <a class="sidebar-link" href="./public/_site/getting-started.html">
             <span class="material-symbols-outlined">rocket_launch</span>
             Quickstart
           </a>
-          <a class="sidebar-link" href="./public/configuration.md">
+          <a class="sidebar-link" href="./public/_site/configuration.html">
             <span class="material-symbols-outlined">settings</span>
             Configuration
           </a>
@@ -712,15 +712,15 @@
 
         <div class="sidebar-section">
           <div class="sidebar-section-title">Core Concepts</div>
-          <a class="sidebar-link" href="./public/pr-babysitter.md">
+          <a class="sidebar-link" href="./public/_site/pr-babysitter.html">
             <span class="material-symbols-outlined">visibility</span>
             PR Babysitter
           </a>
-          <a class="sidebar-link" href="./public/agent-dispatch.md">
+          <a class="sidebar-link" href="./public/_site/agent-dispatch.html">
             <span class="material-symbols-outlined">smart_toy</span>
             Agent Dispatch
           </a>
-          <a class="sidebar-link" href="./public/pr-questions.md">
+          <a class="sidebar-link" href="./public/_site/pr-questions.html">
             <span class="material-symbols-outlined">chat_bubble</span>
             PR Q&amp;A
           </a>
@@ -803,7 +803,7 @@
           <span class="material-symbols-outlined">info</span>
           <p>
             CodeFactory runs entirely on your machine. Your code never leaves your environment.
-            Get started in under 2 minutes with our <a href="./public/getting-started.md">quickstart guide</a>.
+            Get started in under 2 minutes with our <a href="./public/_site/getting-started.html">quickstart guide</a>.
           </p>
         </div>
 
@@ -812,7 +812,7 @@
         <p class="section-subtext">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
 
         <div class="cards-grid">
-          <a class="doc-card" href="./public/getting-started.md">
+          <a class="doc-card" href="./public/_site/getting-started.html">
             <div class="doc-card-icon green">
               <span class="material-symbols-outlined">rocket_launch</span>
             </div>
@@ -823,7 +823,7 @@
             </div>
           </a>
 
-          <a class="doc-card" href="./public/configuration.md">
+          <a class="doc-card" href="./public/_site/configuration.html">
             <div class="doc-card-icon purple">
               <span class="material-symbols-outlined">settings</span>
             </div>
@@ -834,7 +834,7 @@
             </div>
           </a>
 
-          <a class="doc-card" href="./public/pr-babysitter.md">
+          <a class="doc-card" href="./public/_site/pr-babysitter.html">
             <div class="doc-card-icon accent">
               <span class="material-symbols-outlined">visibility</span>
             </div>
@@ -845,7 +845,7 @@
             </div>
           </a>
 
-          <a class="doc-card" href="./public/agent-dispatch.md">
+          <a class="doc-card" href="./public/_site/agent-dispatch.html">
             <div class="doc-card-icon orange">
               <span class="material-symbols-outlined">smart_toy</span>
             </div>
@@ -951,7 +951,7 @@
         <h2 class="section-heading">Explore</h2>
 
         <div class="cards-grid">
-          <a class="doc-card" href="./public/pr-questions.md">
+          <a class="doc-card" href="./public/_site/pr-questions.html">
             <div class="doc-card-icon pink">
               <span class="material-symbols-outlined">chat_bubble</span>
             </div>
@@ -977,7 +977,7 @@
         <!-- Footer Nav -->
         <div class="footer-nav">
           <div></div>
-          <a class="footer-nav-card next" href="./public/getting-started.md">
+          <a class="footer-nav-card next" href="./public/_site/getting-started.html">
             <div class="footer-nav-label">Next</div>
             <div class="footer-nav-title">Quickstart Guide &rarr;</div>
           </a>

--- a/docs/public/_site/agent-dispatch.html
+++ b/docs/public/_site/agent-dispatch.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — Agent Dispatch" />
+  <title>Agent Dispatch | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,96 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
     </div>
-  `;
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
+      <article class="prose">
+        <h1>Agent Dispatch</h1>
+<p>CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
+<h2>Supported Agents</h2>
+<table>
+<thead>
+<tr>
+<th>Agent</th>
+<th>CLI Tool</th>
+<th>Best For</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Claude Code</strong></td>
+<td><code>claude</code></td>
+<td>Complex reasoning, multi-file refactors, architectural changes</td>
+</tr>
+<tr>
+<td><strong>OpenAI Codex</strong></td>
+<td><code>codex</code></td>
+<td>Quick fixes, single-file edits, style corrections</td>
+</tr>
+</tbody></table>
+<p>CodeFactory automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.</p>
+<h2>How Dispatch Works</h2>
+<h3>1. Worktree Isolation</h3>
+<p>Before an agent runs, CodeFactory creates a <strong>temporary git worktree</strong>:</p>
+<pre><code>/tmp/pr-babysitter/&lt;repo&gt;/&lt;pr-number&gt;/
+</code></pre>
+<p>This ensures:</p>
+<ul>
+<li>The agent works on an <strong>isolated copy</strong> of the branch.</li>
+<li>Your local working directory is <strong>never touched</strong>.</li>
+<li>Multiple agents can run <strong>in parallel</strong> on different PRs.</li>
+</ul>
+<h3>2. Agent Execution</h3>
+<p>The agent receives:</p>
+<ul>
+<li>The <strong>review feedback</strong> to address.</li>
+<li>The <strong>file context</strong> (relevant source files).</li>
+<li>The <strong>PR description</strong> for broader understanding.</li>
+<li>Any <strong>previous agent attempts</strong> (to avoid repeating failed approaches).</li>
+</ul>
+<h3>3. Validation</h3>
+<p>After the agent completes:</p>
+<ul>
+<li>Changes are <strong>diffed</strong> against the original branch.</li>
+<li>If configured, <strong>tests are run</strong> to validate the fix.</li>
+<li>The diff is <strong>logged</strong> for human review in the dashboard.</li>
+</ul>
+<h3>4. Commit &amp; Push</h3>
+<p>If validation passes, CodeFactory:</p>
+<ul>
+<li>Creates a <strong>descriptive commit message</strong> explaining what was fixed.</li>
+<li>Pushes the commit to the <strong>PR branch</strong> on GitHub.</li>
+<li>Updates the <strong>feedback status</strong> to resolved.</li>
+</ul>
+<h2>Agent Runs in the Dashboard</h2>
+<p>Every agent run is tracked in the CodeFactory dashboard:</p>
+<ul>
+<li><strong>Status</strong> — Running, succeeded, or failed.</li>
+<li><strong>Duration</strong> — How long the agent took.</li>
+<li><strong>Diff</strong> — Exact changes the agent made.</li>
+<li><strong>Logs</strong> — Full agent output for debugging.</li>
+</ul>
+<h2>Model Discovery</h2>
+<p>CodeFactory discovers available models from your local CLI installations. You can view and refresh available models from the <strong>Settings</strong> page in the dashboard.</p>
+<h2>Customization</h2>
+<p>Override the default agent per repository or globally:</p>
+<ul>
+<li>Set <code>CODEFACTORY_AGENT=claude</code> or <code>CODEFACTORY_AGENT=codex</code> as an environment variable.</li>
+<li>Configure per-repo preferences in the dashboard under repository settings.</li>
+</ul>
+<p>See <a href="./configuration.html">Configuration</a> for all options.</p>
 
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — Configuration" />
+  <title>Configuration | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,103 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
     </div>
-  `;
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
+      <article class="prose">
+        <h1>Configuration</h1>
+<p>CodeFactory is configured through environment variables and the dashboard settings page.</p>
+<h2>Environment Variables</h2>
+<table>
+<thead>
+<tr>
+<th>Variable</th>
+<th>Default</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>PORT</code></td>
+<td><code>5001</code></td>
+<td>HTTP server port</td>
+</tr>
+<tr>
+<td><code>CODEFACTORY_HOME</code></td>
+<td><code>~/.codefactory</code></td>
+<td>Data directory for state and logs</td>
+</tr>
+<tr>
+<td><code>PR_BABYSITTER_ROOT</code></td>
+<td><code>/tmp/pr-babysitter</code></td>
+<td>Root directory for agent worktrees</td>
+</tr>
+<tr>
+<td><code>CODEFACTORY_AGENT</code></td>
+<td>(auto)</td>
+<td>Preferred agent: <code>claude</code> or <code>codex</code></td>
+</tr>
+<tr>
+<td><code>DATABASE_URL</code></td>
+<td>(SQLite)</td>
+<td>PostgreSQL connection string (optional)</td>
+</tr>
+<tr>
+<td><code>GITHUB_TOKEN</code></td>
+<td>—</td>
+<td>Default GitHub personal access token</td>
+</tr>
+</tbody></table>
+<h2>Storage</h2>
+<h3>SQLite (Default)</h3>
+<p>By default, CodeFactory stores all state in a local SQLite database:</p>
+<pre><code>~/.codefactory/state.sqlite
+</code></pre>
+<p>No external database is required. This is ideal for single-user setups.</p>
+<h3>PostgreSQL</h3>
+<p>For team deployments, configure a PostgreSQL connection:</p>
+<pre><code class="language-bash">DATABASE_URL=postgresql://user:pass@localhost:5432/codefactory
+</code></pre>
+<p>Then push the schema:</p>
+<pre><code class="language-bash">npm run db:push
+</code></pre>
+<h2>Activity Logs</h2>
+<p>CodeFactory writes daily activity logs to:</p>
+<pre><code>~/.codefactory/log/
+</code></pre>
+<p>These logs mirror the dashboard activity feed and are useful for debugging or auditing agent behavior.</p>
+<h2>Dashboard Settings</h2>
+<p>The settings page in the dashboard provides a UI for:</p>
+<ul>
+<li><strong>GitHub Token management</strong> — Add, update, or rotate tokens.</li>
+<li><strong>Repository preferences</strong> — Per-repo agent and poll interval settings.</li>
+<li><strong>Model discovery</strong> — View and refresh available AI models.</li>
+<li><strong>Theme</strong> — Toggle between light and dark mode.</li>
+</ul>
+<h2>Build &amp; Deploy</h2>
+<h3>Development</h3>
+<pre><code class="language-bash">npm run dev          # Start dev server with hot reload
+</code></pre>
+<h3>Production</h3>
+<pre><code class="language-bash">npm run build        # Bundle client and server
+npm run start        # Run production server
+</code></pre>
+<h3>Desktop App</h3>
+<pre><code class="language-bash">npm run tauri:dev    # Tauri dev build
+npm run tauri:build  # Tauri production build
+</code></pre>
 
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — Getting Started" />
+  <title>Getting Started | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,68 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
     </div>
-  `;
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
+      <article class="prose">
+        <h1>Getting Started</h1>
+<p>Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
+<h2>Prerequisites</h2>
+<ul>
+<li><strong>Node.js 22+</strong> — <a href="https://nodejs.org/">Download</a></li>
+<li><strong>Git</strong> — installed and configured</li>
+<li><strong>GitHub Personal Access Token</strong> — with <code>repo</code> scope (<a href="https://github.com/settings/tokens">create one</a>)</li>
+</ul>
+<h2>Installation</h2>
+<p>Clone the repository and install dependencies:</p>
+<pre><code class="language-bash">git clone https://github.com/yungookim/codefactory.git
+cd codefactory
+npm install
+</code></pre>
+<h2>Quick Start</h2>
+<h3>1. Start the development server</h3>
+<pre><code class="language-bash">npm run dev
+</code></pre>
+<p>This launches the dashboard at <a href="http://localhost:5001">http://localhost:5001</a>.</p>
+<h3>2. Connect a GitHub repository</h3>
+<ol>
+<li>Open the dashboard in your browser.</li>
+<li>Click <strong>Add Repository</strong> and paste the URL of a GitHub repository you manage.</li>
+<li>Enter your GitHub Personal Access Token when prompted.</li>
+</ol>
+<h3>3. Watch CodeFactory work</h3>
+<p>Once connected, CodeFactory will:</p>
+<ul>
+<li><strong>Monitor</strong> open pull requests in real time.</li>
+<li><strong>Sync</strong> review comments and change requests.</li>
+<li><strong>Triage</strong> feedback into actionable tasks.</li>
+<li><strong>Dispatch</strong> AI agents (Claude Code or OpenAI Codex) to fix issues.</li>
+<li><strong>Push</strong> the fixes back to the PR branch.</li>
+</ul>
+<h2>Desktop App</h2>
+<p>CodeFactory is also available as a native desktop application powered by Tauri:</p>
+<pre><code class="language-bash">npm run tauri:dev    # Development
+npm run tauri:build  # Production build
+</code></pre>
+<h2>Next Steps</h2>
+<ul>
+<li><a href="./pr-babysitter.html">PR Babysitter</a> — Learn how autonomous PR monitoring works.</li>
+<li><a href="./agent-dispatch.html">Agent Dispatch</a> — Understand how AI agents are dispatched to fix code.</li>
+<li><a href="./configuration.html">Configuration</a> — Customize CodeFactory for your workflow.</li>
+</ul>
 
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/public/_site/index.html
+++ b/docs/public/_site/index.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — Documentation" />
+  <title>Documentation | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,53 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
+    </div>
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="../../index.html" class="nav-back">← Back to CodeFactory</a></div>
+      <article class="prose">
+        
     <h1>Documentation</h1>
     <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
     <div class="doc-grid">
-      ${cards}
+      
+      <a href="./getting-started.html" class="doc-card">
+        <h3>Getting Started</h3>
+        <p>Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
+      </a>
+
+      <a href="./agent-dispatch.html" class="doc-card">
+        <h3>Agent Dispatch</h3>
+        <p>CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
+      </a>
+
+      <a href="./configuration.html" class="doc-card">
+        <h3>Configuration</h3>
+        <p>CodeFactory is configured through environment variables and the dashboard settings page.</p>
+      </a>
+
+      <a href="./pr-babysitter.html" class="doc-card">
+        <h3>PR Babysitter</h3>
+        <p>The PR Babysitter is CodeFactory's core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
+      </a>
+
+      <a href="./pr-questions.html" class="doc-card">
+        <h3>PR Q&A</h3>
+        <p>CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
+      </a>
     </div>
-  `;
-
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+  
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — PR Babysitter" />
+  <title>PR Babysitter | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,107 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
     </div>
-  `;
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
+      <article class="prose">
+        <h1>PR Babysitter</h1>
+<p>The PR Babysitter is CodeFactory&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
+<h2>How It Works</h2>
+<h3>1. Repository Watching</h3>
+<p>When you add a repository to CodeFactory, the babysitter begins polling for open pull requests. It tracks:</p>
+<ul>
+<li>New PRs opened against the repository.</li>
+<li>Review comments and change requests on existing PRs.</li>
+<li>Status changes (approvals, dismissals, re-requests).</li>
+</ul>
+<h3>2. Review Sync</h3>
+<p>Every review comment is captured and stored locally. CodeFactory understands GitHub&#39;s threaded review model:</p>
+<ul>
+<li><strong>Top-level review comments</strong> — general feedback on the PR.</li>
+<li><strong>Inline comments</strong> — feedback attached to specific lines of code.</li>
+<li><strong>Review threads</strong> — multi-message conversations about a specific change.</li>
+</ul>
+<h3>3. Feedback Triage</h3>
+<p>Not all feedback is equal. CodeFactory classifies each piece of feedback:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Description</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Blocking</strong></td>
+<td>Must be fixed before merge</td>
+<td>Agent dispatched immediately</td>
+</tr>
+<tr>
+<td><strong>Suggestion</strong></td>
+<td>Improvement that should be considered</td>
+<td>Queued for agent review</td>
+</tr>
+<tr>
+<td><strong>Nitpick</strong></td>
+<td>Style or preference issue</td>
+<td>Logged but deprioritized</td>
+</tr>
+<tr>
+<td><strong>Question</strong></td>
+<td>Reviewer needs clarification</td>
+<td>Flagged for human response</td>
+</tr>
+</tbody></table>
+<h3>4. Automated Resolution</h3>
+<p>For actionable feedback, CodeFactory:</p>
+<ol>
+<li>Creates an <strong>isolated worktree</strong> — a clean copy of the branch.</li>
+<li>Dispatches an <strong>AI agent</strong> (Claude Code or OpenAI Codex) with the feedback context.</li>
+<li>The agent makes changes, runs tests, and validates the fix.</li>
+<li>Changes are <strong>committed and pushed</strong> back to the PR branch.</li>
+</ol>
+<h2>Feedback Lifecycle</h2>
+<p>Each feedback item moves through a defined state machine:</p>
+<pre><code>pending → triaged → dispatched → resolved
+                  ↘ skipped
+</code></pre>
+<ul>
+<li><strong>pending</strong> — Feedback just synced from GitHub.</li>
+<li><strong>triaged</strong> — Classified by category and priority.</li>
+<li><strong>dispatched</strong> — An agent is actively working on it.</li>
+<li><strong>resolved</strong> — The agent successfully addressed the feedback.</li>
+<li><strong>skipped</strong> — Determined to not need automated action.</li>
+</ul>
+<h2>Merge Conflict Resolution</h2>
+<p>When a PR branch falls behind the base branch, CodeFactory can automatically:</p>
+<ol>
+<li>Detect the conflict.</li>
+<li>Rebase the branch.</li>
+<li>Use an AI agent to resolve non-trivial merge conflicts.</li>
+<li>Push the resolved branch.</li>
+</ol>
+<h2>Configuration</h2>
+<p>You can control babysitter behavior per repository:</p>
+<ul>
+<li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
+<li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
+<li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let CodeFactory decide.</li>
+</ul>
+<p>See <a href="./configuration.html">Configuration</a> for details.</p>
 
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/public/_site/pr-questions.html
+++ b/docs/public/_site/pr-questions.html
@@ -1,58 +1,13 @@
-/**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
- *
- * Usage: npx tsx script/build-public-docs.ts
- */
-
-import fs from "node:fs";
-import path from "node:path";
-import { marked } from "marked";
-
-const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
-const OUT_DIR = path.join(DOCS_DIR, "_site");
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
+  <meta name="description" content="CodeFactory Documentation — PR Q&A" />
+  <title>PR Q&A | CodeFactory Docs</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <style>${getStyles()}</style>
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
-
-function getStyles(): string {
-  return `
+  <style>
     :root {
       --bg: #0e0e0e;
       --bg-elevated: #1a1919;
@@ -287,116 +242,72 @@ function getStyles(): string {
       .prose h2 { font-size: 1.25rem; }
       .doc-grid { grid-template-columns: 1fr; }
     }
-  `;
-}
-
-interface DocMeta {
-  slug: string;
-  title: string;
-  description: string;
-  htmlFile: string;
-}
-
-/** Extract the first H1 and first paragraph from markdown as title and description */
-function extractMeta(markdown: string, filename: string): { title: string; description: string } {
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
-
-  // Get first paragraph after the title
-  const lines = markdown.split("\n");
-  let description = "";
-  let pastTitle = false;
-  for (const line of lines) {
-    if (!pastTitle) {
-      if (titleMatch && line.startsWith("# ")) {
-        pastTitle = true;
-      }
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
-    description = trimmed;
-    break;
-  }
-
-  return { title, description };
-}
-
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="nav-inner">
+      <a href="../../index.html" class="brand">CodeFactory</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-section">Documentation</span>
     </div>
-  `;
+  </nav>
+  <div class="layout">
+    <main class="content">
+      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
+      <article class="prose">
+        <h1>PR Q&amp;A</h1>
+<p>CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
+<h2>Overview</h2>
+<p>Instead of manually reading through large diffs, you can ask questions like:</p>
+<ul>
+<li>&quot;What does this PR change?&quot;</li>
+<li>&quot;Why did the tests fail?&quot;</li>
+<li>&quot;What are the architectural implications of this change?&quot;</li>
+<li>&quot;Does this PR introduce any security concerns?&quot;</li>
+</ul>
+<p>CodeFactory uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.</p>
+<h2>How to Use</h2>
+<ol>
+<li>Open a PR in the CodeFactory dashboard.</li>
+<li>Navigate to the <strong>Q&amp;A</strong> tab.</li>
+<li>Type your question and press Enter.</li>
+</ol>
+<p>The agent will analyze the PR context and return a detailed answer within seconds.</p>
+<h2>What the Agent Sees</h2>
+<p>When answering a question, the agent has access to:</p>
+<ul>
+<li>The <strong>full diff</strong> of the PR.</li>
+<li>All <strong>review comments</strong> and threads.</li>
+<li>The <strong>PR description</strong> and title.</li>
+<li>The <strong>commit history</strong> on the branch.</li>
+<li>The <strong>surrounding code context</strong> in affected files.</li>
+</ul>
+<h2>Use Cases</h2>
+<h3>Code Review Assistance</h3>
+<p>Ask the agent to summarize changes before you start reviewing:</p>
+<blockquote>
+<p>&quot;Summarize the key changes in this PR and flag anything that needs careful review.&quot;</p>
+</blockquote>
+<h3>Debugging Failed Checks</h3>
+<p>When CI fails, ask the agent to diagnose:</p>
+<blockquote>
+<p>&quot;The lint check is failing — what&#39;s causing it and how should it be fixed?&quot;</p>
+</blockquote>
+<h3>Architecture Review</h3>
+<p>For larger PRs, get a high-level understanding:</p>
+<blockquote>
+<p>&quot;Does this PR change any public API surfaces? What are the breaking changes?&quot;</p>
+</blockquote>
+<h2>Limitations</h2>
+<ul>
+<li>The agent only sees the PR context — it does not have access to external documentation or issue trackers.</li>
+<li>Answers are generated by AI and should be verified for critical decisions.</li>
+<li>Very large PRs (1000+ changed files) may exceed context limits.</li>
+</ul>
 
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
-function rewriteLinks(html: string): string {
-  return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
-}
-
-async function main() {
-  // Clean output directory
-  if (fs.existsSync(OUT_DIR)) {
-    fs.rmSync(OUT_DIR, { recursive: true });
-  }
-  fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
-
-  if (files.length === 0) {
-    console.log("No markdown files found in docs/public/");
-    return;
-  }
-
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
-  const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
-
-  for (const file of orderedFiles) {
-    const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
-    const { title, description } = extractMeta(markdown, file);
-    const slug = file.replace(/\.md$/, "");
-    const htmlFile = `${slug}.html`;
-
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
-
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
-  }
-
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
-
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
-}
-
-main().catch((err) => {
-  console.error("Failed to build public docs:", err);
-  process.exit(1);
-});
+      </article>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Built all 5 markdown docs under `docs/public/` into styled HTML pages** in `docs/public/_site/` using the existing `build-public-docs.ts` script
- **Updated all links in `docs/index.html`** from `./public/*.md` to `./public/_site/*.html` so sidebar and card navigation renders properly on GitHub Pages
- **Fixed back-navigation paths** in the build script (`../index.html` → `../../index.html`) to account for the `_site/` subdirectory
- **Removed `docs/public/_site` from `.gitignore`** so built HTML files are committed and served by GitHub Pages

## Test plan

- [ ] Visit https://yungookim.github.io/codefactory/ and click each sidebar link (Quickstart, Configuration, PR Babysitter, Agent Dispatch, PR Q&A) — should render styled HTML, not raw markdown
- [ ] Click each card on the landing page — same verification
- [ ] On any doc page, click "CodeFactory" brand link and "← All Documentation" / "← Back to CodeFactory" — should navigate correctly back
- [ ] Verify the docs index page at `public/_site/index.html` lists all 5 documents

https://claude.ai/code/session_01A74pjQGqe5UTNMSKA6Quax