### PR TITLE
Fix Tauri desktop app crash on launch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -3085,6 +3086,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,6 +3881,46 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-single-instance = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,25 +1,93 @@
+use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Mutex;
 use tauri::Manager;
 
 struct ServerProcess(Mutex<Option<Child>>);
 
-fn start_server(resource_dir: std::path::PathBuf, port: u16) -> std::io::Result<Child> {
+/// Find the node binary by checking common install locations.
+/// GUI apps on macOS don't inherit the shell PATH, so `node` alone won't resolve
+/// for nvm, Homebrew, fnm, Volta, or other version managers.
+fn find_node() -> Option<PathBuf> {
+    // First, try the bare command (works if node is in the system PATH)
+    if Command::new("node")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return Some(PathBuf::from("node"));
+    }
+
+    let home = std::env::var("HOME").ok()?;
+    let candidates = [
+        // nvm (most common on macOS)
+        format!("{}/.nvm/versions/node", home),
+        // fnm
+        format!("{}/.local/share/fnm/node-versions", home),
+        format!("{}/Library/Application Support/fnm/node-versions", home),
+        // Volta
+        format!("{}/.volta/tools/image/node", home),
+    ];
+
+    for base in &candidates {
+        let base_path = PathBuf::from(base);
+        if !base_path.is_dir() {
+            continue;
+        }
+        // Pick the highest semver directory
+        if let Ok(entries) = std::fs::read_dir(&base_path) {
+            let mut versions: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.is_dir())
+                .collect();
+            versions.sort();
+            if let Some(latest) = versions.last() {
+                let node_bin = latest.join("bin").join("node");
+                if node_bin.exists() {
+                    return Some(node_bin);
+                }
+            }
+        }
+    }
+
+    // Homebrew paths
+    let brew_paths = [
+        "/opt/homebrew/bin/node",  // Apple Silicon
+        "/usr/local/bin/node",     // Intel Mac / Linux Homebrew
+    ];
+    for path in &brew_paths {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    None
+}
+
+fn start_server(resource_dir: PathBuf, port: u16) -> Result<Child, String> {
     let server_script = resource_dir.join("dist").join("index.cjs");
 
     if !server_script.exists() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Server bundle not found at {:?}", server_script),
+        return Err(format!(
+            "Server bundle not found at {}",
+            server_script.display()
         ));
     }
 
-    Command::new("node")
+    let node = find_node().ok_or_else(|| {
+        "Node.js not found. Please install Node.js (https://nodejs.org) and restart the app."
+            .to_string()
+    })?;
+
+    Command::new(&node)
         .arg(&server_script)
         .env("NODE_ENV", "production")
         .env("PORT", port.to_string())
         .current_dir(&resource_dir)
         .spawn()
+        .map_err(|e| format!("Failed to start server with {}: {}", node.display(), e))
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -32,7 +100,6 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            // When a second instance is launched, focus the existing window
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_focus();
                 let _ = window.unminimize();
@@ -41,16 +108,26 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
         .setup(move |app| {
-            // In production, start the bundled Express server
             if !cfg!(debug_assertions) {
                 let resource_dir = app
                     .path()
                     .resource_dir()
-                    .expect("Failed to resolve resource directory");
+                    .map_err(|e| format!("Failed to resolve resource directory: {}", e))?;
 
-                let child = start_server(resource_dir, port)
-                    .expect("Failed to start server. Is Node.js installed?");
-                app.manage(ServerProcess(Mutex::new(Some(child))));
+                match start_server(resource_dir, port) {
+                    Ok(child) => {
+                        app.manage(ServerProcess(Mutex::new(Some(child))));
+                    }
+                    Err(msg) => {
+                        eprintln!("Server error: {}", msg);
+                        // Show a native dialog so the user knows what went wrong
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.set_title(&format!("Code Factory — Error: {}", msg));
+                        }
+                        app.manage(ServerProcess(Mutex::new(None)));
+                        return Err(msg.into());
+                    }
+                }
 
                 // Give the server time to initialize
                 std::thread::sleep(std::time::Duration::from_millis(2000));
@@ -58,10 +135,11 @@ pub fn run() {
                 app.manage(ServerProcess(Mutex::new(None)));
             }
 
-            // Point the webview at the Express server
             let server_url = format!("http://localhost:{}", port);
             if let Some(window) = app.get_webview_window("main") {
-                let url: tauri::Url = server_url.parse().expect("Invalid URL");
+                let url: tauri::Url = server_url
+                    .parse()
+                    .map_err(|e| format!("Invalid URL: {}", e))?;
                 let _ = window.navigate(url);
             }
 
@@ -69,7 +147,6 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {
-                // Kill the server process when the app is closed
                 if let Some(state) = window.try_state::<ServerProcess>() {
                     if let Ok(mut guard) = state.0.lock() {
                         if let Some(ref mut child) = *guard {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,29 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::sync::Mutex;
 use tauri::Manager;
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 
 struct ServerProcess(Mutex<Option<Child>>);
+
+fn version_sort_key(path: &Path) -> Vec<u32> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("")
+        .trim_start_matches('v')
+        .split('.')
+        .filter_map(|part| part.parse::<u32>().ok())
+        .collect()
+}
+
+fn node_binary_for_version(version_dir: &Path) -> Option<PathBuf> {
+    [
+        version_dir.join("bin").join("node"),
+        version_dir.join("installation").join("bin").join("node"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
 
 /// Find the node binary by checking common install locations.
 /// GUI apps on macOS don't inherit the shell PATH, so `node` alone won't resolve
@@ -41,20 +61,21 @@ fn find_node() -> Option<PathBuf> {
                 .map(|e| e.path())
                 .filter(|p| p.is_dir())
                 .collect();
-            versions.sort();
-            if let Some(latest) = versions.last() {
-                let node_bin = latest.join("bin").join("node");
-                if node_bin.exists() {
-                    return Some(node_bin);
-                }
+            versions.sort_by_key(|path| version_sort_key(path));
+            if let Some(node_bin) = versions
+                .iter()
+                .rev()
+                .find_map(|version| node_binary_for_version(version))
+            {
+                return Some(node_bin);
             }
         }
     }
 
     // Homebrew paths
     let brew_paths = [
-        "/opt/homebrew/bin/node",  // Apple Silicon
-        "/usr/local/bin/node",     // Intel Mac / Linux Homebrew
+        "/opt/homebrew/bin/node", // Apple Silicon
+        "/usr/local/bin/node",    // Intel Mac / Linux Homebrew
     ];
     for path in &brew_paths {
         let p = PathBuf::from(path);
@@ -105,6 +126,7 @@ pub fn run() {
                 let _ = window.unminimize();
             }
         }))
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
         .setup(move |app| {
@@ -122,7 +144,12 @@ pub fn run() {
                         eprintln!("Server error: {}", msg);
                         // Show a native dialog so the user knows what went wrong
                         if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.set_title(&format!("Code Factory — Error: {}", msg));
+                            window
+                                .dialog()
+                                .message(msg.clone())
+                                .title("Code Factory — Error")
+                                .kind(MessageDialogKind::Error)
+                                .show(|_| {});
                         }
                         app.manage(ServerProcess(Mutex::new(None)));
                         return Err(msg.into());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,9 +37,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": [
-      "../dist"
-    ],
+    "resources": {
+      "../dist": "dist/"
+    },
     "externalBin": []
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Fix Node.js discovery for macOS GUI apps that don't inherit shell PATH (nvm, Homebrew, fnm, Volta)
- Fix bundled resource path mapping so `dist/` lands at the correct location in the app bundle
- Replace `.expect()` panics with proper error propagation for better error reporting

## Context
The Tauri desktop app crashed with SIGABRT immediately on startup. Two root causes:
1. `Command::new("node")` fails because Finder apps get a minimal system PATH
2. `"resources": ["../dist"]` in tauri.conf.json creates `_up_/dist/` in the bundle instead of `dist/`

## Test plan
- [ ] Build with `npx tauri build --target aarch64-apple-darwin`
- [ ] Install the .app or .dmg and launch from Finder (not terminal)
- [ ] Verify the app starts and shows the Code Factory UI
- [ ] Test on a machine with Node installed via nvm, Homebrew, or system package

🤖 Generated with [Claude Code](https://claude.com/claude-code)