### PR TITLE
fix: update MemStorage sort test to respect immutable addedAt

### DIFF
--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -84,11 +84,11 @@ describe("MemStorage", () => {
       assert.equal(prs[0].title, "Active");
     });
 
-    it("sorts by addedAt descending", async () => {
-      // addedAt is immutable via updatePR, so we add PRs with a small delay
-      // to ensure they get distinct timestamps for deterministic ordering.
+    it("sorts by addedAt descending", async (t) => {
+      t.mock.timers.enable({ apis: ["Date"], now: new Date("2024-01-01T00:00:00.000Z") });
+
       await storage.addPR(makePRInput({ title: "First" }));
-      await new Promise((resolve) => setTimeout(resolve, 15));
+      t.mock.timers.tick(100);
       await storage.addPR(makePRInput({ title: "Second" }));
 
       const prs = await storage.getPRs();

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -85,11 +85,11 @@ describe("MemStorage", () => {
     });
 
     it("sorts by addedAt descending", async () => {
-      const pr1 = await storage.addPR(makePRInput({ title: "First" }));
-      // Force a later addedAt on the second PR
-      await storage.updatePR(pr1.id, { addedAt: "2020-01-01T00:00:00.000Z" });
-      const pr2 = await storage.addPR(makePRInput({ title: "Second" }));
-      await storage.updatePR(pr2.id, { addedAt: "2025-01-01T00:00:00.000Z" });
+      // addedAt is immutable via updatePR, so we add PRs with a small delay
+      // to ensure they get distinct timestamps for deterministic ordering.
+      await storage.addPR(makePRInput({ title: "First" }));
+      await new Promise((r) => setTimeout(r, 2));
+      await storage.addPR(makePRInput({ title: "Second" }));
 
       const prs = await storage.getPRs();
       // Most recent first


### PR DESCRIPTION
## Summary
- Fixes the failing `lint-and-test` CI check on PR #59
- The `MemStorage` "sorts by addedAt descending" test was mutating `addedAt` via `updatePR`, but the new `applyPRUpdate` function correctly treats `addedAt` as immutable — so the update was silently ignored, both PRs got identical timestamps, and the sort order became non-deterministic
- Uses a small delay between `addPR` calls instead to produce distinct timestamps

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (152/152)

https://claude.ai/code/session_0158QGSmADc5v9TJpD8pbM46