### PR TITLE
docs: unify docs site styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,990 +1,348 @@
 <!DOCTYPE html>
 <html class="dark" lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <meta
-      name="description"
-      content="CodeFactory documentation — the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches agents to fix code."
-    />
-    <title>CodeFactory Docs</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
-      rel="stylesheet"
-    />
-    <style>
-      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-      :root {
-        --bg: #000000;
-        --bg-secondary: #0c0c0c;
-        --bg-tertiary: #121212;
-        --bg-elevated: #1a1a1a;
-        --bg-hover: #181818;
-        --border: #1e1e1e;
-        --border-hover: #2a2a2a;
-        --text-primary: #ffffff;
-        --text-secondary: #b5b5b5;
-        --text-tertiary: #525252;
-        --accent: #e0e0e0;
-        --accent-dim: #8f8f8f;
-        --accent-bg: rgba(255, 255, 255, 0.04);
-        --accent-bg-hover: rgba(255, 255, 255, 0.08);
-        --accent-border: rgba(255, 255, 255, 0.12);
-        --tone-1: #f0f0f0;
-        --tone-1-bg: rgba(255, 255, 255, 0.05);
-        --tone-2: #cecece;
-        --tone-2-bg: rgba(255, 255, 255, 0.04);
-        --tone-3: #9a9a9a;
-        --tone-3-bg: rgba(255, 255, 255, 0.03);
-        --tone-4: #767676;
-        --tone-4-bg: rgba(255, 255, 255, 0.025);
-        --sidebar-w: 260px;
-        --header-h: 56px;
-      }
-
-      html { scroll-behavior: smooth; }
-
-      body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-        background: var(--bg);
-        color: var(--text-primary);
-        line-height: 1.6;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
-
-      a { color: inherit; text-decoration: none; }
-
-      /* ── Header ── */
-      .doc-header {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: var(--header-h);
-        background: rgba(0, 0, 0, 0.85);
-        backdrop-filter: blur(16px);
-        border-bottom: 1px solid var(--border);
-        z-index: 100;
-        display: flex;
-        align-items: center;
-        padding: 0 24px;
-      }
-
-      .header-left {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-        width: var(--sidebar-w);
-        flex-shrink: 0;
-      }
-
-      .header-logo {
-        font-size: 15px;
-        font-weight: 700;
-        color: var(--text-primary);
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        letter-spacing: -0.02em;
-      }
-
-      .header-logo .logo-icon {
-        width: 24px;
-        height: 24px;
-        background: linear-gradient(135deg, #1a1a1a, #050505);
-        border-radius: 6px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .header-logo .logo-icon span {
-        font-size: 14px;
-        color: #fff;
-      }
-
-      .header-badge {
-        font-size: 10px;
-        font-weight: 600;
-        color: var(--accent);
-        background: var(--accent-bg);
-        border: 1px solid var(--accent-border);
-        padding: 2px 8px;
-        border-radius: 9999px;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }
-
-      .header-center {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0 24px;
-      }
-
-      .search-trigger {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        width: 100%;
-        max-width: 480px;
-        padding: 7px 12px;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-radius: 8px;
-        color: var(--text-tertiary);
-        font-size: 13px;
-        cursor: pointer;
-        transition: border-color 0.15s, background 0.15s;
-      }
-
-      .search-trigger:hover {
-        border-color: var(--border-hover);
-        background: var(--bg-tertiary);
-      }
-
-      .search-trigger .material-symbols-outlined {
-        font-size: 16px;
-      }
-
-      .search-trigger .shortcut {
-        margin-left: auto;
-        display: flex;
-        gap: 4px;
-      }
-
-      .search-trigger .shortcut kbd {
-        font-family: 'Inter', sans-serif;
-        font-size: 11px;
-        font-weight: 500;
-        background: var(--bg-tertiary);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        padding: 1px 5px;
-        color: var(--text-tertiary);
-      }
-
-      .header-right {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .header-link {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 12px;
-        border-radius: 6px;
-        font-size: 13px;
-        font-weight: 500;
-        color: var(--text-secondary);
-        transition: color 0.15s, background 0.15s;
-      }
-
-      .header-link:hover {
-        color: var(--text-primary);
-        background: var(--bg-hover);
-      }
-
-      .header-link .material-symbols-outlined {
-        font-size: 18px;
-      }
-
-      /* ── Sidebar ── */
-      .doc-sidebar {
-        position: fixed;
-        top: var(--header-h);
-        left: 0;
-        bottom: 0;
-        width: var(--sidebar-w);
-        background: var(--bg);
-        border-right: 1px solid var(--border);
-        overflow-y: auto;
-        padding: 16px 12px 32px;
-        z-index: 50;
-      }
-
-      .doc-sidebar::-webkit-scrollbar { width: 4px; }
-      .doc-sidebar::-webkit-scrollbar-track { background: transparent; }
-      .doc-sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
-
-      .sidebar-section {
-        margin-bottom: 24px;
-      }
-
-      .sidebar-section-title {
-        font-size: 11px;
-        font-weight: 600;
-        color: var(--text-tertiary);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        padding: 0 12px;
-        margin-bottom: 6px;
-      }
-
-      .sidebar-link {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 7px 12px;
-        border-radius: 6px;
-        font-size: 13px;
-        font-weight: 450;
-        color: var(--text-secondary);
-        transition: all 0.12s;
-        line-height: 1.4;
-      }
-
-      .sidebar-link:hover {
-        color: var(--text-primary);
-        background: var(--bg-hover);
-      }
-
-      .sidebar-link.active {
-        color: var(--accent);
-        background: var(--accent-bg);
-      }
-
-      .sidebar-link .material-symbols-outlined {
-        font-size: 18px;
-        font-variation-settings: 'FILL' 0, 'wght' 300;
-        opacity: 0.7;
-      }
-
-      .sidebar-link.active .material-symbols-outlined {
-        opacity: 1;
-      }
-
-      /* ── Main Content ── */
-      .doc-main {
-        margin-left: var(--sidebar-w);
-        margin-top: var(--header-h);
-        min-height: calc(100vh - var(--header-h));
-      }
-
-      .doc-content {
-        max-width: 860px;
-        margin: 0 auto;
-        padding: 48px 48px 96px;
-      }
-
-      /* ── Hero Section ── */
-      .doc-hero {
-        margin-bottom: 48px;
-      }
-
-      .doc-hero-overline {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 12px;
-        font-weight: 600;
-        color: var(--accent);
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        margin-bottom: 12px;
-      }
-
-      .doc-hero-overline .material-symbols-outlined {
-        font-size: 16px;
-      }
-
-      .doc-hero h1 {
-        font-size: 36px;
-        font-weight: 700;
-        letter-spacing: -0.03em;
-        line-height: 1.2;
-        color: var(--text-primary);
-        margin-bottom: 12px;
-      }
-
-      .doc-hero p {
-        font-size: 16px;
-        color: var(--text-secondary);
-        max-width: 600px;
-        line-height: 1.7;
-      }
-
-      /* ── Quick Start Cards ── */
-      .cards-grid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 16px;
-        margin-bottom: 48px;
-      }
-
-      .doc-card {
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 24px;
-        background: var(--bg);
-        transition: all 0.2s;
-        cursor: pointer;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-      }
-
-      .doc-card:hover {
-        border-color: var(--border-hover);
-        background: var(--bg-secondary);
-        transform: translateY(-1px);
-      }
-
-      .doc-card-icon {
-        width: 36px;
-        height: 36px;
-        border-radius: 8px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .doc-card-icon .material-symbols-outlined {
-        font-size: 20px;
-      }
-
-      .doc-card-icon.tone-1 { background: var(--tone-1-bg); color: var(--tone-1); }
-      .doc-card-icon.tone-2 { background: var(--tone-2-bg); color: var(--tone-2); }
-      .doc-card-icon.accent { background: var(--accent-bg); color: var(--accent); }
-      .doc-card-icon.tone-3 { background: var(--tone-3-bg); color: var(--tone-3); }
-      .doc-card-icon.tone-4 { background: var(--tone-4-bg); color: var(--tone-4); }
-
-      .doc-card h3 {
-        font-size: 15px;
-        font-weight: 600;
-        color: var(--text-primary);
-        letter-spacing: -0.01em;
-      }
-
-      .doc-card p {
-        font-size: 13px;
-        color: var(--text-secondary);
-        line-height: 1.6;
-      }
-
-      .doc-card-arrow {
-        margin-top: auto;
-        font-size: 13px;
-        font-weight: 500;
-        color: var(--accent);
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        opacity: 0;
-        transform: translateX(-4px);
-        transition: all 0.2s;
-      }
-
-      .doc-card:hover .doc-card-arrow {
-        opacity: 1;
-        transform: translateX(0);
-      }
-
-      .doc-card-arrow .material-symbols-outlined {
-        font-size: 16px;
-      }
-
-      /* ── Section Headings ── */
-      .section-heading {
-        font-size: 22px;
-        font-weight: 650;
-        color: var(--text-primary);
-        letter-spacing: -0.02em;
-        margin-bottom: 16px;
-        padding-bottom: 12px;
-        border-bottom: 1px solid var(--border);
-      }
-
-      .section-subtext {
-        font-size: 14px;
-        color: var(--text-secondary);
-        margin-bottom: 20px;
-        line-height: 1.7;
-      }
-
-      /* ── Code Block ── */
-      .code-block {
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        overflow: hidden;
-        margin-bottom: 32px;
-      }
-
-      .code-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 10px 16px;
-        border-bottom: 1px solid var(--border);
-        background: var(--bg-tertiary);
-      }
-
-      .code-header-left {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .code-header .dot { width: 8px; height: 8px; border-radius: 50%; }
-      .code-header .dot.dot-dark { background: #525252; opacity: 0.6; }
-      .code-header .dot.dot-medium { background: #8a8a8a; opacity: 0.6; }
-      .code-header .dot.dot-light { background: #d9d9d9; opacity: 0.6; }
-
-      .code-lang {
-        font-family: 'JetBrains Mono', monospace;
-        font-size: 11px;
-        color: var(--text-tertiary);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-
-      .code-copy {
-        background: none;
-        border: 1px solid var(--border);
-        border-radius: 5px;
-        color: var(--text-tertiary);
-        font-size: 12px;
-        padding: 3px 10px;
-        cursor: pointer;
-        font-family: 'Inter', sans-serif;
-        transition: all 0.15s;
-      }
-
-      .code-copy:hover {
-        color: var(--text-secondary);
-        border-color: var(--border-hover);
-        background: var(--bg-hover);
-      }
-
-      .code-body {
-        padding: 16px 20px;
-        font-family: 'JetBrains Mono', monospace;
-        font-size: 13px;
-        line-height: 1.7;
-        color: var(--text-secondary);
-        overflow-x: auto;
-      }
-
-      .code-body .comment { color: var(--text-tertiary); }
-      .code-body .command { color: var(--tone-1); }
-      .code-body .arg { color: var(--accent); }
-      .code-body .url { color: var(--tone-3); }
-
-      /* ── Feature List ── */
-      .feature-list {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        margin-bottom: 48px;
-      }
-
-      .feature-item {
-        display: flex;
-        align-items: flex-start;
-        gap: 12px;
-        padding: 14px 16px;
-        border-radius: 8px;
-        transition: background 0.15s;
-      }
-
-      .feature-item:hover {
-        background: var(--bg-secondary);
-      }
-
-      .feature-icon {
-        width: 28px;
-        height: 28px;
-        border-radius: 6px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
-        margin-top: 1px;
-      }
-
-      .feature-icon .material-symbols-outlined {
-        font-size: 16px;
-      }
-
-      .feature-text h4 {
-        font-size: 14px;
-        font-weight: 600;
-        color: var(--text-primary);
-        margin-bottom: 2px;
-      }
-
-      .feature-text p {
-        font-size: 13px;
-        color: var(--text-secondary);
-        line-height: 1.5;
-      }
-
-      /* ── Divider ── */
-      .doc-divider {
-        border: none;
-        border-top: 1px solid var(--border);
-        margin: 40px 0;
-      }
-
-      /* ── Footer Nav ── */
-      .footer-nav {
-        display: flex;
-        justify-content: space-between;
-        gap: 16px;
-        margin-top: 48px;
-        padding-top: 32px;
-        border-top: 1px solid var(--border);
-      }
-
-      .footer-nav-card {
-        flex: 1;
-        padding: 16px 20px;
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        transition: all 0.15s;
-      }
-
-      .footer-nav-card:hover {
-        border-color: var(--border-hover);
-        background: var(--bg-secondary);
-      }
-
-      .footer-nav-card.next {
-        text-align: right;
-      }
-
-      .footer-nav-label {
-        font-size: 11px;
-        font-weight: 500;
-        color: var(--text-tertiary);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        margin-bottom: 4px;
-      }
-
-      .footer-nav-title {
-        font-size: 14px;
-        font-weight: 600;
-        color: var(--accent);
-      }
-
-      /* ── Info Callout ── */
-      .callout {
-        display: flex;
-        gap: 12px;
-        padding: 16px;
-        border-radius: 10px;
-        border: 1px solid var(--accent-border);
-        background: var(--accent-bg);
-        margin-bottom: 32px;
-      }
-
-      .callout .material-symbols-outlined {
-        font-size: 18px;
-        color: var(--accent);
-        flex-shrink: 0;
-        margin-top: 1px;
-      }
-
-      .callout p {
-        font-size: 13px;
-        color: var(--text-secondary);
-        line-height: 1.6;
-      }
-
-      .callout a {
-        color: var(--accent);
-        text-decoration: underline;
-        text-underline-offset: 2px;
-      }
-
-      /* ── Tech Stack Badge ── */
-      .tech-badges {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        margin-bottom: 32px;
-      }
-
-      .tech-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 5px 12px;
-        border-radius: 6px;
-        font-size: 12px;
-        font-weight: 500;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        color: var(--text-secondary);
-      }
-
-      /* ── Responsive ── */
-      @media (max-width: 900px) {
-        .doc-sidebar { display: none; }
-        .doc-main { margin-left: 0; }
-        .header-left { width: auto; }
-        .cards-grid { grid-template-columns: 1fr; }
-      }
-
-      @media (max-width: 600px) {
-        .doc-content { padding: 32px 20px 64px; }
-        .doc-hero h1 { font-size: 28px; }
-        .header-center { display: none; }
-        .footer-nav { flex-direction: column; }
-      }
-
-      /* ── Material Symbols ── */
-      .material-symbols-outlined {
-        font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 24;
-      }
-
-      /* ── Scrollbar (global) ── */
-      ::-webkit-scrollbar { width: 6px; height: 6px; }
-      ::-webkit-scrollbar-track { background: transparent; }
-      ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-      ::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
-    </style>
-  </head>
-  <body>
-
-    <!-- ── Header ── -->
-    <header class="doc-header">
-      <div class="header-left">
-        <a href="./index.html" class="header-logo">
-          <div class="logo-icon">
-            <span class="material-symbols-outlined" style="font-size:14px;font-variation-settings:'FILL' 1,'wght' 600">bolt</span>
-          </div>
-          CodeFactory
-        </a>
-        <span class="header-badge">Docs</span>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
+  <title>CodeFactory Documentation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
+  <link rel="stylesheet" href="./public/styles.css" />
+</head>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./index.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./public/_site/getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./public/_site/configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./public/_site/pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./public/_site/agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./public/_site/pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
+    </div>
+  </nav>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="./index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12">
+  <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v6m0 0v6m0-6h6m-6 0H6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Welcome to CodeFactory</span>
+  </div>
+  <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
+  <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
+    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+  </p>
+
+  <div class="mb-8 flex flex-wrap gap-3">
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+      <span>Open Source (MIT)</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M5 12a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2M5 12a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2m-2-4h.01M17 16h.01" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <span>Runs Locally</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <span>Claude Code &amp; OpenAI Codex</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-green-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+      <span>Node.js 22+</span>
+    </span>
+  </div>
+
+  <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
+    <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"></path></svg>
+    <p class="text-sm leading-relaxed text-blue-100/80">
+      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      <a class="text-blue-400 hover:underline" href="./public/_site/getting-started.html">quickstart guide</a>.
+    </p>
+  </div>
+</header>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
+  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/getting-started.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Quickstart</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/configuration.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Configuration</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Environment variables, storage options, database setup, and activity logging.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/pr-babysitter.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">PR Babysitter</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Autonomous monitoring, review sync, and feedback triage for your pull requests.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/agent-dispatch.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Agent Dispatch</h3>
+  <p class="text-sm leading-relaxed text-gray-400">How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
+</a>
+  </div>
+</section>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Installation</h2>
+  <div class="overflow-hidden rounded-xl border border-dark-700 bg-dark-800">
+    <div class="flex items-center gap-2 border-b border-dark-700 bg-dark-800 px-4 py-2">
+      <div class="flex gap-1.5">
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
       </div>
+    </div>
+    <div class="overflow-x-auto p-6">
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
+<span class="text-white">git clone https://github.com/yungookim/codefactory.git</span>
+<span class="text-white">cd codefactory</span>
+<span class="text-white">npm install</span>
 
-      <div class="header-center">
-        <div class="search-trigger" tabindex="0" role="button">
-          <span class="material-symbols-outlined">search</span>
-          <span>Search documentation...</span>
-          <span class="shortcut">
-            <kbd>Ctrl</kbd>
-            <kbd>K</kbd>
-          </span>
-        </div>
+<span class="text-gray-500"># Start the dashboard</span>
+<span class="text-white">npm run dev</span></code></pre>
+    </div>
+  </div>
+</section>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
+  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <div class="space-y-0">
+    <div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">1.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Watch Repositories</h3>
+        <p class="text-gray-400">Add any GitHub repository. CodeFactory polls for open PRs and new review activity.</p>
       </div>
-
-      <div class="header-right">
-        <a class="header-link" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-          <span>GitHub</span>
-        </a>
-        <a class="header-link" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
-          <span class="material-symbols-outlined">forum</span>
-          <span>Community</span>
-        </a>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">2.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Sync Reviews</h3>
+        <p class="text-gray-400">Review comments, inline feedback, and threaded conversations are captured and stored locally.</p>
       </div>
-    </header>
-
-    <!-- ── Sidebar ── -->
-    <aside class="doc-sidebar">
-      <nav>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Getting Started</div>
-          <a class="sidebar-link active" href="./index.html">
-            <span class="material-symbols-outlined">home</span>
-            Introduction
-          </a>
-          <a class="sidebar-link" href="./public/_site/getting-started.html">
-            <span class="material-symbols-outlined">rocket_launch</span>
-            Quickstart
-          </a>
-          <a class="sidebar-link" href="./public/_site/configuration.html">
-            <span class="material-symbols-outlined">settings</span>
-            Configuration
-          </a>
-        </div>
-
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Core Concepts</div>
-          <a class="sidebar-link" href="./public/_site/pr-babysitter.html">
-            <span class="material-symbols-outlined">visibility</span>
-            PR Babysitter
-          </a>
-          <a class="sidebar-link" href="./public/_site/agent-dispatch.html">
-            <span class="material-symbols-outlined">smart_toy</span>
-            Agent Dispatch
-          </a>
-          <a class="sidebar-link" href="./public/_site/pr-questions.html">
-            <span class="material-symbols-outlined">chat_bubble</span>
-            PR Q&amp;A
-          </a>
-        </div>
-
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Guides</div>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank">
-            <span class="material-symbols-outlined">handshake</span>
-            Contributing
-          </a>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank">
-            <span class="material-symbols-outlined">api</span>
-            API Reference
-          </a>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank">
-            <span class="material-symbols-outlined">tune</span>
-            Agent Config
-          </a>
-        </div>
-
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Resources</div>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory/releases" target="_blank">
-            <span class="material-symbols-outlined">new_releases</span>
-            Changelog
-          </a>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory/issues" target="_blank">
-            <span class="material-symbols-outlined">bug_report</span>
-            Report an Issue
-          </a>
-          <a class="sidebar-link" href="https://github.com/yungookim/codefactory" target="_blank">
-            <span class="material-symbols-outlined">code</span>
-            Source Code
-          </a>
-        </div>
-      </nav>
-    </aside>
-
-    <!-- ── Main ── -->
-    <main class="doc-main">
-      <div class="doc-content">
-
-        <!-- Hero -->
-        <div class="doc-hero">
-          <div class="doc-hero-overline">
-            <span class="material-symbols-outlined">auto_awesome</span>
-            Welcome to CodeFactory
-          </div>
-          <h1>The Autonomous PR Babysitter</h1>
-          <p>
-            CodeFactory watches your GitHub repositories, triages review feedback,
-            and dispatches local AI agents to fix code — so you can focus on
-            building, not babysitting pull requests.
-          </p>
-        </div>
-
-        <!-- Tech Badges -->
-        <div class="tech-badges">
-          <span class="tech-badge">
-            <span class="material-symbols-outlined" style="font-size:14px;color:var(--tone-1)">check_circle</span>
-            Open Source (MIT)
-          </span>
-          <span class="tech-badge">
-            <span class="material-symbols-outlined" style="font-size:14px;color:var(--accent)">terminal</span>
-            Runs Locally
-          </span>
-          <span class="tech-badge">
-            <span class="material-symbols-outlined" style="font-size:14px;color:var(--tone-2)">smart_toy</span>
-            Claude Code &amp; OpenAI Codex
-          </span>
-          <span class="tech-badge">
-            <span class="material-symbols-outlined" style="font-size:14px;color:var(--tone-3)">bolt</span>
-            Node.js 22+
-          </span>
-        </div>
-
-        <!-- Callout -->
-        <div class="callout">
-          <span class="material-symbols-outlined">info</span>
-          <p>
-            CodeFactory runs entirely on your machine. Your code never leaves your environment.
-            Get started in under 2 minutes with our <a href="./public/_site/getting-started.html">quickstart guide</a>.
-          </p>
-        </div>
-
-        <!-- Quick Start Cards -->
-        <h2 class="section-heading">Get Started</h2>
-        <p class="section-subtext">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
-
-        <div class="cards-grid">
-          <a class="doc-card" href="./public/_site/getting-started.html">
-            <div class="doc-card-icon tone-1">
-              <span class="material-symbols-outlined">rocket_launch</span>
-            </div>
-            <h3>Quickstart</h3>
-            <p>Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.</p>
-            <div class="doc-card-arrow">
-              Get started <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-
-          <a class="doc-card" href="./public/_site/configuration.html">
-            <div class="doc-card-icon tone-2">
-              <span class="material-symbols-outlined">settings</span>
-            </div>
-            <h3>Configuration</h3>
-            <p>Environment variables, storage options, database setup, and activity logging.</p>
-            <div class="doc-card-arrow">
-              Configure <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-
-          <a class="doc-card" href="./public/_site/pr-babysitter.html">
-            <div class="doc-card-icon accent">
-              <span class="material-symbols-outlined">visibility</span>
-            </div>
-            <h3>PR Babysitter</h3>
-            <p>Autonomous monitoring, review sync, and feedback triage for your pull requests.</p>
-            <div class="doc-card-arrow">
-              Learn more <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-
-          <a class="doc-card" href="./public/_site/agent-dispatch.html">
-            <div class="doc-card-icon tone-3">
-              <span class="material-symbols-outlined">smart_toy</span>
-            </div>
-            <h3>Agent Dispatch</h3>
-            <p>How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
-            <div class="doc-card-arrow">
-              Explore <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-        </div>
-
-        <!-- Install -->
-        <h2 class="section-heading">Installation</h2>
-
-        <div class="code-block">
-          <div class="code-header">
-            <div class="code-header-left">
-              <span class="dot dot-dark"></span>
-              <span class="dot dot-medium"></span>
-              <span class="dot dot-light"></span>
-              <span class="code-lang">bash</span>
-            </div>
-            <button class="code-copy" onclick="navigator.clipboard.writeText('git clone https://github.com/yungookim/codefactory.git\ncd codefactory\nnpm install\nnpm run dev')">Copy</button>
-          </div>
-          <div class="code-body">
-            <div><span class="comment"># Clone and install</span></div>
-            <div><span class="command">git clone</span> <span class="url">https://github.com/yungookim/codefactory.git</span></div>
-            <div><span class="command">cd</span> <span class="arg">codefactory</span></div>
-            <div><span class="command">npm install</span></div>
-            <div style="height:8px"></div>
-            <div><span class="comment"># Start the dashboard</span></div>
-            <div><span class="command">npm run</span> <span class="arg">dev</span></div>
-          </div>
-        </div>
-
-        <!-- How It Works -->
-        <h2 class="section-heading">How It Works</h2>
-        <p class="section-subtext">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
-
-        <div class="feature-list">
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--accent-bg)">
-              <span class="material-symbols-outlined" style="color:var(--accent)">visibility</span>
-            </div>
-            <div class="feature-text">
-              <h4>1. Watch Repositories</h4>
-              <p>Add any GitHub repository. CodeFactory polls for open PRs and new review activity.</p>
-            </div>
-          </div>
-
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--tone-2-bg)">
-              <span class="material-symbols-outlined" style="color:var(--tone-2)">sync_alt</span>
-            </div>
-            <div class="feature-text">
-              <h4>2. Sync Reviews</h4>
-              <p>Review comments, inline feedback, and threaded conversations are captured and stored locally.</p>
-            </div>
-          </div>
-
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--tone-1-bg)">
-              <span class="material-symbols-outlined" style="color:var(--tone-1)">assignment_turned_in</span>
-            </div>
-            <div class="feature-text">
-              <h4>3. Triage Feedback</h4>
-              <p>Feedback is classified into blocking, suggestions, and nitpicks for prioritized action.</p>
-            </div>
-          </div>
-
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--tone-3-bg)">
-              <span class="material-symbols-outlined" style="color:var(--tone-3)">smart_toy</span>
-            </div>
-            <div class="feature-text">
-              <h4>4. Dispatch Agents</h4>
-              <p>Local AI agents (Claude Code or OpenAI Codex) work in isolated git worktrees to fix issues.</p>
-            </div>
-          </div>
-
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--tone-4-bg)">
-              <span class="material-symbols-outlined" style="color:var(--tone-4)">call_merge</span>
-            </div>
-            <div class="feature-text">
-              <h4>5. Resolve Conflicts</h4>
-              <p>Automated merge conflict handling and rebase to keep branches clean.</p>
-            </div>
-          </div>
-
-          <div class="feature-item">
-            <div class="feature-icon" style="background:var(--tone-1-bg)">
-              <span class="material-symbols-outlined" style="color:var(--tone-1)">publish</span>
-            </div>
-            <div class="feature-text">
-              <h4>6. Commit &amp; Push</h4>
-              <p>Signed commits are pushed back to the PR branch automatically.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Explore More -->
-        <h2 class="section-heading">Explore</h2>
-
-        <div class="cards-grid">
-          <a class="doc-card" href="./public/_site/pr-questions.html">
-            <div class="doc-card-icon tone-4">
-              <span class="material-symbols-outlined">chat_bubble</span>
-            </div>
-            <h3>PR Q&amp;A</h3>
-            <p>Ask natural-language questions about any pull request and get AI-powered answers.</p>
-            <div class="doc-card-arrow">
-              Learn more <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-
-          <a class="doc-card" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank">
-            <div class="doc-card-icon accent">
-              <span class="material-symbols-outlined">api</span>
-            </div>
-            <h3>API Reference</h3>
-            <p>Full REST API documentation for programmatic control of CodeFactory.</p>
-            <div class="doc-card-arrow">
-              View API <span class="material-symbols-outlined">arrow_forward</span>
-            </div>
-          </a>
-        </div>
-
-        <!-- Footer Nav -->
-        <div class="footer-nav">
-          <div></div>
-          <a class="footer-nav-card next" href="./public/_site/getting-started.html">
-            <div class="footer-nav-label">Next</div>
-            <div class="footer-nav-title">Quickstart Guide &rarr;</div>
-          </a>
-        </div>
-
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">3.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Triage Feedback</h3>
+        <p class="text-gray-400">Feedback is classified into blocking, suggestions, and nitpicks for prioritized action.</p>
       </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">4.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Dispatch Agents</h3>
+        <p class="text-gray-400">Local AI agents work in isolated git worktrees to fix issues without touching your active checkout.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">5.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Resolve Conflicts</h3>
+        <p class="text-gray-400">Automated merge handling keeps agent branches clean before fixes are pushed back upstream.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">6.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Commit &amp; Push</h3>
+        <p class="text-gray-400">Validated fixes are committed and pushed back to the PR branch automatically.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="mb-8">
+  <h2 class="mb-4 text-2xl font-bold text-white">Explore</h2>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/pr-questions.html">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">PR Q&amp;A</h3>
+      <p class="text-sm leading-relaxed text-gray-400">Ask natural-language questions about any pull request and get AI-powered answers.</p>
+    </a>
+
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+    </a>
+  </div>
+</section>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./public/_site/getting-started.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      Quickstart Guide
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
-
-  </body>
+  </div>
+</body>
 </html>

--- a/docs/public/_site/agent-dispatch.html
+++ b/docs/public/_site/agent-dispatch.html
@@ -1,29 +1,188 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — Agent Dispatch" />
+  <meta name="description" content="Agent Dispatch - CodeFactory documentation" />
   <title>Agent Dispatch | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
-      <article class="prose">
-        <h1>Agent Dispatch</h1>
-<p>CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
-<h2>Supported Agents</h2>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="./index.html">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Agent Dispatch</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
+</header>
+
+<article class="doc-prose">
+  <h2>Supported Agents</h2>
 <table>
 <thead>
 <tr>
@@ -95,7 +254,17 @@
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for all options.</p>
 
-      </article>
+</article>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-questions.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      PR Q&amp;A
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -1,29 +1,188 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — Configuration" />
+  <meta name="description" content="Configuration - CodeFactory documentation" />
   <title>Configuration | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
-      <article class="prose">
-        <h1>Configuration</h1>
-<p>CodeFactory is configured through environment variables and the dashboard settings page.</p>
-<h2>Environment Variables</h2>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="./index.html">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Configuration</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory is configured through environment variables and the dashboard settings page.</p>
+</header>
+
+<article class="doc-prose">
+  <h2>Environment Variables</h2>
 <table>
 <thead>
 <tr>
@@ -102,7 +261,17 @@ npm run start        # Run production server
 npm run tauri:build  # Tauri production build
 </code></pre>
 
-      </article>
+</article>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-babysitter.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      PR Babysitter
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -1,29 +1,188 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — Getting Started" />
+  <meta name="description" content="Getting Started - CodeFactory documentation" />
   <title>Getting Started | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
-      <article class="prose">
-        <h1>Getting Started</h1>
-<p>Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
-<h2>Prerequisites</h2>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="./index.html">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Getting Started</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
+</header>
+
+<article class="doc-prose">
+  <h2>Prerequisites</h2>
 <ul>
 <li><strong>Node.js 22+</strong> — <a href="https://nodejs.org/">Download</a></li>
 <li><strong>Git</strong> — installed and configured</li>
@@ -67,7 +226,17 @@ npm run tauri:build  # Production build
 <li><a href="./configuration.html">Configuration</a> — Customize CodeFactory for your workflow.</li>
 </ul>
 
-      </article>
+</article>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./configuration.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      Configuration
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/index.html
+++ b/docs/public/_site/index.html
@@ -1,58 +1,347 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — Documentation" />
-  <title>Documentation | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <meta name="description" content="CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
+  <title>CodeFactory Documentation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="../../index.html" class="nav-back">← Back to CodeFactory</a></div>
-      <article class="prose">
-        
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      
-      <a href="./getting-started.html" class="doc-card">
-        <h3>Getting Started</h3>
-        <p>Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
-      </a>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12">
+  <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v6m0 0v6m0-6h6m-6 0H6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Welcome to CodeFactory</span>
+  </div>
+  <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
+  <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
+    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+  </p>
 
-      <a href="./agent-dispatch.html" class="doc-card">
-        <h3>Agent Dispatch</h3>
-        <p>CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
-      </a>
+  <div class="mb-8 flex flex-wrap gap-3">
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+      <span>Open Source (MIT)</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M5 12a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2M5 12a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2m-2-4h.01M17 16h.01" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <span>Runs Locally</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <span>Claude Code &amp; OpenAI Codex</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      <svg class="h-4 w-4 text-green-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+      <span>Node.js 22+</span>
+    </span>
+  </div>
 
-      <a href="./configuration.html" class="doc-card">
-        <h3>Configuration</h3>
-        <p>CodeFactory is configured through environment variables and the dashboard settings page.</p>
-      </a>
+  <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
+    <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"></path></svg>
+    <p class="text-sm leading-relaxed text-blue-100/80">
+      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      <a class="text-blue-400 hover:underline" href="./getting-started.html">quickstart guide</a>.
+    </p>
+  </div>
+</header>
 
-      <a href="./pr-babysitter.html" class="doc-card">
-        <h3>PR Babysitter</h3>
-        <p>The PR Babysitter is CodeFactory's core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
-      </a>
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
+  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./getting-started.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Quickstart</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./configuration.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Configuration</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Environment variables, storage options, database setup, and activity logging.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./pr-babysitter.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">PR Babysitter</h3>
+  <p class="text-sm leading-relaxed text-gray-400">Autonomous monitoring, review sync, and feedback triage for your pull requests.</p>
+</a>
+<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./agent-dispatch.html">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">Agent Dispatch</h3>
+  <p class="text-sm leading-relaxed text-gray-400">How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
+</a>
+  </div>
+</section>
 
-      <a href="./pr-questions.html" class="doc-card">
-        <h3>PR Q&A</h3>
-        <p>CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
-      </a>
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Installation</h2>
+  <div class="overflow-hidden rounded-xl border border-dark-700 bg-dark-800">
+    <div class="flex items-center gap-2 border-b border-dark-700 bg-dark-800 px-4 py-2">
+      <div class="flex gap-1.5">
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+      </div>
     </div>
-  
-      </article>
+    <div class="overflow-x-auto p-6">
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
+<span class="text-white">git clone https://github.com/yungookim/codefactory.git</span>
+<span class="text-white">cd codefactory</span>
+<span class="text-white">npm install</span>
+
+<span class="text-gray-500"># Start the dashboard</span>
+<span class="text-white">npm run dev</span></code></pre>
+    </div>
+  </div>
+</section>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
+  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <div class="space-y-0">
+    <div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">1.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Watch Repositories</h3>
+        <p class="text-gray-400">Add any GitHub repository. CodeFactory polls for open PRs and new review activity.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">2.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Sync Reviews</h3>
+        <p class="text-gray-400">Review comments, inline feedback, and threaded conversations are captured and stored locally.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">3.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Triage Feedback</h3>
+        <p class="text-gray-400">Feedback is classified into blocking, suggestions, and nitpicks for prioritized action.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">4.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Dispatch Agents</h3>
+        <p class="text-gray-400">Local AI agents work in isolated git worktrees to fix issues without touching your active checkout.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">5.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Resolve Conflicts</h3>
+        <p class="text-gray-400">Automated merge handling keeps agent branches clean before fixes are pushed back upstream.</p>
+      </div>
+    </div>
+<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">6.</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">Commit &amp; Push</h3>
+        <p class="text-gray-400">Validated fixes are committed and pushed back to the PR branch automatically.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="mb-8">
+  <h2 class="mb-4 text-2xl font-bold text-white">Explore</h2>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./pr-questions.html">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">PR Q&amp;A</h3>
+      <p class="text-sm leading-relaxed text-gray-400">Ask natural-language questions about any pull request and get AI-powered answers.</p>
+    </a>
+
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+    </a>
+  </div>
+</section>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./getting-started.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      Quickstart Guide
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -1,29 +1,188 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — PR Babysitter" />
+  <meta name="description" content="PR Babysitter - CodeFactory documentation" />
   <title>PR Babysitter | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
-      <article class="prose">
-        <h1>PR Babysitter</h1>
-<p>The PR Babysitter is CodeFactory&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
-<h2>How It Works</h2>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="./index.html">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">PR Babysitter</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">The PR Babysitter is CodeFactory&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
+</header>
+
+<article class="doc-prose">
+  <h2>How It Works</h2>
 <h3>1. Repository Watching</h3>
 <p>When you add a repository to CodeFactory, the babysitter begins polling for open pull requests. It tracks:</p>
 <ul>
@@ -106,7 +265,17 @@
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for details.</p>
 
-      </article>
+</article>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./agent-dispatch.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      Agent Dispatch
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/pr-questions.html
+++ b/docs/public/_site/pr-questions.html
@@ -1,29 +1,188 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="dark" lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — PR Q&A" />
-  <title>PR Q&A | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <meta name="description" content="PR Q&amp;A - CodeFactory documentation" />
+  <title>PR Q&amp;A | CodeFactory Docs</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="https://github.com/yungookim/codefactory/discussions" target="_blank" rel="noreferrer">
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="../../index.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Introduction</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./getting-started.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Quickstart</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./configuration.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Configuration</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./pr-babysitter.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Babysitter</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="./agent-dispatch.html">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Dispatch</span>
+  </a>
+</li>
+<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors bg-dark-800 text-white" href="./pr-questions.html">
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>PR Q&amp;A</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Contributing</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>API Reference</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/blob/main/AGENTS.md" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Agent Config</span>
+  </a>
+</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/releases" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Changelog</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory/issues" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Report an Issue</span>
+  </a>
+</li>
+        <li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors text-slate-400 hover:bg-dark-800 hover:text-slate-200" href="https://github.com/yungookim/codefactory" target="_blank" rel="noreferrer">
+    <svg class="h-4 w-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Source Code</span>
+  </a>
+</li>
+      </ul>
     </div>
   </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb"><a href="./index.html" class="nav-back">← All Documentation</a></div>
-      <article class="prose">
-        <h1>PR Q&amp;A</h1>
-<p>CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
-<h2>Overview</h2>
+</aside>
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="../../index.html">
+    <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>
+        <header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="./index.html">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">PR Q&amp;A</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
+</header>
+
+<article class="doc-prose">
+  <h2>Overview</h2>
 <p>Instead of manually reading through large diffs, you can ask questions like:</p>
 <ul>
 <li>&quot;What does this PR change?&quot;</li>
@@ -71,7 +230,17 @@
 <li>Very large PRs (1000+ changed files) may exceed context limits.</li>
 </ul>
 
-      </article>
+</article>
+      </div>
+      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="../../index.html">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Overview</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      Documentation Overview
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>
     </main>
   </div>
 </body>

--- a/docs/public/_site/styles.css
+++ b/docs/public/_site/styles.css
@@ -1,235 +1,223 @@
+:root {
+  color-scheme: dark;
+}
 
-    :root {
-      --bg: #000000;
-      --bg-elevated: #111111;
-      --bg-card: #1a1a1a;
-      --bg-code: #121212;
-      --text: #ffffff;
-      --text-secondary: #b5b5b5;
-      --text-muted: #525252;
-      --primary: #e0e0e0;
-      --primary-dim: #8f8f8f;
-      --border: #1f1f1f;
-      --border-subtle: rgba(255, 255, 255, 0.1);
-      --accent-gradient: linear-gradient(135deg, #ffffff 0%, #8f8f8f 100%);
-    }
+html {
+  scroll-behavior: smooth;
+}
 
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  margin: 0;
+  background-color: #0f1115;
+  color: #94a3b8;
+}
 
-    body {
-      font-family: "Inter", system-ui, -apple-system, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.7;
-      -webkit-font-smoothing: antialiased;
-    }
+a {
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
 
-    .top-nav {
-      position: sticky;
-      top: 0;
-      z-index: 50;
-      background: rgba(0, 0, 0, 0.85);
-      backdrop-filter: blur(16px);
-      border-bottom: 1px solid var(--border-subtle);
-      padding: 0.875rem 2rem;
-    }
+::selection {
+  background: rgba(59, 130, 246, 0.28);
+  color: #eff6ff;
+}
 
-    .nav-inner {
-      max-width: 56rem;
-      margin: 0 auto;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
 
-    .brand {
-      font-weight: 800;
-      font-size: 1.1rem;
-      color: var(--primary);
-      text-decoration: none;
-      letter-spacing: -0.02em;
-    }
+::-webkit-scrollbar-track {
+  background: transparent;
+}
 
-    .nav-separator { color: var(--text-muted); }
-    .nav-section { color: var(--text-secondary); font-size: 0.875rem; }
+::-webkit-scrollbar-thumb {
+  background: #2c313c;
+  border-radius: 999px;
+}
 
-    .layout {
-      max-width: 56rem;
-      margin: 0 auto;
-      padding: 2rem;
-    }
+::-webkit-scrollbar-thumb:hover {
+  background: #475569;
+}
 
-    .breadcrumb { margin-bottom: 2rem; }
+.doc-prose {
+  color: #94a3b8;
+  font-size: 0.975rem;
+  line-height: 1.8;
+}
 
-    .nav-back {
-      color: var(--primary);
-      text-decoration: none;
-      font-size: 0.875rem;
-      font-weight: 500;
-      transition: opacity 0.15s;
-    }
-    .nav-back:hover { opacity: 0.8; }
+.doc-prose > * + * {
+  margin-top: 1.15rem;
+}
 
-    /* Prose styles */
-    .prose h1 {
-      font-size: 2.5rem;
-      font-weight: 900;
-      letter-spacing: -0.03em;
-      line-height: 1.15;
-      margin-bottom: 1.5rem;
-      background: linear-gradient(to bottom, #fff 0%, #8f8f8f 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-    }
+.doc-prose h2,
+.doc-prose h3,
+.doc-prose h4,
+.doc-prose h5,
+.doc-prose h6 {
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
 
-    .prose h2 {
-      font-size: 1.5rem;
-      font-weight: 800;
-      letter-spacing: -0.02em;
-      margin-top: 3rem;
-      margin-bottom: 1rem;
-      padding-bottom: 0.5rem;
-      border-bottom: 1px solid var(--border-subtle);
-    }
+.doc-prose h2 {
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  font-size: 1.75rem;
+}
 
-    .prose h3 {
-      font-size: 1.2rem;
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      margin-top: 2rem;
-      margin-bottom: 0.75rem;
-      color: var(--primary);
-    }
+.doc-prose h3 {
+  margin-top: 2.2rem;
+  margin-bottom: 0.85rem;
+  font-size: 1.3rem;
+}
 
-    .prose p {
-      margin-bottom: 1rem;
-      color: var(--text-secondary);
-    }
+.doc-prose h4 {
+  margin-top: 1.8rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+}
 
-    .prose strong { color: var(--text); font-weight: 600; }
+.doc-prose p {
+  color: #94a3b8;
+}
 
-    .prose a {
-      color: var(--primary);
-      text-decoration: none;
-      border-bottom: 1px solid transparent;
-      transition: border-color 0.15s;
-    }
-    .prose a:hover { border-bottom-color: var(--primary); }
+.doc-prose strong {
+  color: #f8fafc;
+  font-weight: 600;
+}
 
-    .prose ul, .prose ol {
-      margin-bottom: 1rem;
-      padding-left: 1.5rem;
-      color: var(--text-secondary);
-    }
-    .prose li { margin-bottom: 0.35rem; }
-    .prose li strong { color: var(--text); }
+.doc-prose em {
+  color: #cbd5e1;
+}
 
-    .prose code {
-      font-family: "JetBrains Mono", monospace;
-      font-size: 0.85em;
-      background: var(--bg-code);
-      border: 1px solid var(--border-subtle);
-      border-radius: 4px;
-      padding: 0.15em 0.4em;
-      color: var(--primary);
-    }
+.doc-prose a {
+  color: #60a5fa;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(96, 165, 250, 0.35);
+}
 
-    .prose pre {
-      background: var(--bg-code);
-      border: 1px solid var(--border-subtle);
-      border-radius: 8px;
-      padding: 1.25rem;
-      margin-bottom: 1.5rem;
-      overflow-x: auto;
-    }
+.doc-prose a:hover {
+  color: #93c5fd;
+  border-bottom-color: rgba(147, 197, 253, 0.75);
+}
 
-    .prose pre code {
-      background: none;
-      border: none;
-      padding: 0;
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
+.doc-prose ul,
+.doc-prose ol {
+  padding-left: 1.5rem;
+}
 
-    .prose blockquote {
-      border-left: 3px solid var(--primary-dim);
-      margin: 1.5rem 0;
-      padding: 0.75rem 1.25rem;
-      background: rgba(255, 255, 255, 0.04);
-      border-radius: 0 8px 8px 0;
-    }
-    .prose blockquote p { color: var(--text-secondary); margin-bottom: 0; }
+.doc-prose li {
+  margin: 0.45rem 0;
+}
 
-    .prose table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-bottom: 1.5rem;
-      font-size: 0.9rem;
-    }
+.doc-prose li::marker {
+  color: #60a5fa;
+}
 
-    .prose th {
-      text-align: left;
-      padding: 0.75rem 1rem;
-      background: var(--bg-elevated);
-      border-bottom: 2px solid var(--border);
-      font-weight: 700;
-      font-size: 0.8rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--primary);
-    }
+.doc-prose hr {
+  margin: 3rem 0;
+  border: 0;
+  border-top: 1px solid rgba(71, 85, 105, 0.5);
+}
 
-    .prose td {
-      padding: 0.65rem 1rem;
-      border-bottom: 1px solid var(--border-subtle);
-      color: var(--text-secondary);
-    }
+.doc-prose blockquote {
+  margin: 1.75rem 0;
+  border-left: 3px solid rgba(59, 130, 246, 0.8);
+  border-radius: 0 1rem 1rem 0;
+  background: rgba(37, 99, 235, 0.12);
+  padding: 1rem 1.2rem;
+  color: #cbd5e1;
+}
 
-    .prose tr:last-child td { border-bottom: none; }
+.doc-prose code {
+  font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+  background: rgba(30, 33, 40, 0.92);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 0.45rem;
+  padding: 0.14rem 0.4rem;
+}
 
-    .prose hr {
-      border: none;
-      border-top: 1px solid var(--border-subtle);
-      margin: 2rem 0;
-    }
+.doc-prose pre {
+  overflow-x: auto;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+  background: rgba(30, 33, 40, 0.95);
+  padding: 1.25rem 1.35rem;
+}
 
-    /* Index page doc cards */
-    .doc-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-      gap: 1rem;
-      margin-top: 1.5rem;
-    }
+.doc-prose pre code {
+  display: block;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #e2e8f0;
+  line-height: 1.75;
+}
 
-    .doc-card {
-      display: block;
-      background: var(--bg-elevated);
-      border: 1px solid var(--border-subtle);
-      border-radius: 12px;
-      padding: 1.5rem;
-      text-decoration: none;
-      transition: border-color 0.2s, transform 0.15s;
-    }
-    .doc-card:hover {
-      border-color: var(--primary);
-      transform: translateY(-2px);
-    }
-    .doc-card h3 {
-      color: var(--text);
-      font-size: 1.1rem;
-      font-weight: 700;
-      margin-bottom: 0.5rem;
-    }
-    .doc-card p {
-      color: var(--text-muted);
-      font-size: 0.875rem;
-      line-height: 1.5;
-    }
+.doc-prose table {
+  width: 100%;
+  margin: 1.75rem 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+}
 
-    @media (max-width: 640px) {
-      .layout { padding: 1rem; }
-      .prose h1 { font-size: 1.75rem; }
-      .prose h2 { font-size: 1.25rem; }
-      .doc-grid { grid-template-columns: 1fr; }
-    }
+.doc-prose thead th {
+  background: rgba(30, 33, 40, 0.96);
+  color: #e2e8f0;
+  text-align: left;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.85rem 1rem;
+}
+
+.doc-prose tbody td {
+  padding: 0.85rem 1rem;
+  border-top: 1px solid rgba(71, 85, 105, 0.35);
+}
+
+.doc-prose img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 2rem auto;
+  border-radius: 1rem;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+}
+
+.doc-prose iframe {
+  width: 100%;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+  background: rgba(30, 33, 40, 0.92);
+}
+
+@media (max-width: 640px) {
+  .doc-prose {
+    font-size: 0.95rem;
+  }
+
+  .doc-prose h2 {
+    font-size: 1.45rem;
+  }
+
+  .doc-prose h3 {
+    font-size: 1.15rem;
+  }
+
+  .doc-prose table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}

--- a/docs/public/styles.css
+++ b/docs/public/styles.css
@@ -1,235 +1,223 @@
+:root {
+  color-scheme: dark;
+}
 
-    :root {
-      --bg: #000000;
-      --bg-elevated: #111111;
-      --bg-card: #1a1a1a;
-      --bg-code: #121212;
-      --text: #ffffff;
-      --text-secondary: #b5b5b5;
-      --text-muted: #525252;
-      --primary: #e0e0e0;
-      --primary-dim: #8f8f8f;
-      --border: #1f1f1f;
-      --border-subtle: rgba(255, 255, 255, 0.1);
-      --accent-gradient: linear-gradient(135deg, #ffffff 0%, #8f8f8f 100%);
-    }
+html {
+  scroll-behavior: smooth;
+}
 
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  margin: 0;
+  background-color: #0f1115;
+  color: #94a3b8;
+}
 
-    body {
-      font-family: "Inter", system-ui, -apple-system, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.7;
-      -webkit-font-smoothing: antialiased;
-    }
+a {
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
 
-    .top-nav {
-      position: sticky;
-      top: 0;
-      z-index: 50;
-      background: rgba(0, 0, 0, 0.85);
-      backdrop-filter: blur(16px);
-      border-bottom: 1px solid var(--border-subtle);
-      padding: 0.875rem 2rem;
-    }
+::selection {
+  background: rgba(59, 130, 246, 0.28);
+  color: #eff6ff;
+}
 
-    .nav-inner {
-      max-width: 56rem;
-      margin: 0 auto;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
 
-    .brand {
-      font-weight: 800;
-      font-size: 1.1rem;
-      color: var(--primary);
-      text-decoration: none;
-      letter-spacing: -0.02em;
-    }
+::-webkit-scrollbar-track {
+  background: transparent;
+}
 
-    .nav-separator { color: var(--text-muted); }
-    .nav-section { color: var(--text-secondary); font-size: 0.875rem; }
+::-webkit-scrollbar-thumb {
+  background: #2c313c;
+  border-radius: 999px;
+}
 
-    .layout {
-      max-width: 56rem;
-      margin: 0 auto;
-      padding: 2rem;
-    }
+::-webkit-scrollbar-thumb:hover {
+  background: #475569;
+}
 
-    .breadcrumb { margin-bottom: 2rem; }
+.doc-prose {
+  color: #94a3b8;
+  font-size: 0.975rem;
+  line-height: 1.8;
+}
 
-    .nav-back {
-      color: var(--primary);
-      text-decoration: none;
-      font-size: 0.875rem;
-      font-weight: 500;
-      transition: opacity 0.15s;
-    }
-    .nav-back:hover { opacity: 0.8; }
+.doc-prose > * + * {
+  margin-top: 1.15rem;
+}
 
-    /* Prose styles */
-    .prose h1 {
-      font-size: 2.5rem;
-      font-weight: 900;
-      letter-spacing: -0.03em;
-      line-height: 1.15;
-      margin-bottom: 1.5rem;
-      background: linear-gradient(to bottom, #fff 0%, #8f8f8f 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-    }
+.doc-prose h2,
+.doc-prose h3,
+.doc-prose h4,
+.doc-prose h5,
+.doc-prose h6 {
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
 
-    .prose h2 {
-      font-size: 1.5rem;
-      font-weight: 800;
-      letter-spacing: -0.02em;
-      margin-top: 3rem;
-      margin-bottom: 1rem;
-      padding-bottom: 0.5rem;
-      border-bottom: 1px solid var(--border-subtle);
-    }
+.doc-prose h2 {
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  font-size: 1.75rem;
+}
 
-    .prose h3 {
-      font-size: 1.2rem;
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      margin-top: 2rem;
-      margin-bottom: 0.75rem;
-      color: var(--primary);
-    }
+.doc-prose h3 {
+  margin-top: 2.2rem;
+  margin-bottom: 0.85rem;
+  font-size: 1.3rem;
+}
 
-    .prose p {
-      margin-bottom: 1rem;
-      color: var(--text-secondary);
-    }
+.doc-prose h4 {
+  margin-top: 1.8rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+}
 
-    .prose strong { color: var(--text); font-weight: 600; }
+.doc-prose p {
+  color: #94a3b8;
+}
 
-    .prose a {
-      color: var(--primary);
-      text-decoration: none;
-      border-bottom: 1px solid transparent;
-      transition: border-color 0.15s;
-    }
-    .prose a:hover { border-bottom-color: var(--primary); }
+.doc-prose strong {
+  color: #f8fafc;
+  font-weight: 600;
+}
 
-    .prose ul, .prose ol {
-      margin-bottom: 1rem;
-      padding-left: 1.5rem;
-      color: var(--text-secondary);
-    }
-    .prose li { margin-bottom: 0.35rem; }
-    .prose li strong { color: var(--text); }
+.doc-prose em {
+  color: #cbd5e1;
+}
 
-    .prose code {
-      font-family: "JetBrains Mono", monospace;
-      font-size: 0.85em;
-      background: var(--bg-code);
-      border: 1px solid var(--border-subtle);
-      border-radius: 4px;
-      padding: 0.15em 0.4em;
-      color: var(--primary);
-    }
+.doc-prose a {
+  color: #60a5fa;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(96, 165, 250, 0.35);
+}
 
-    .prose pre {
-      background: var(--bg-code);
-      border: 1px solid var(--border-subtle);
-      border-radius: 8px;
-      padding: 1.25rem;
-      margin-bottom: 1.5rem;
-      overflow-x: auto;
-    }
+.doc-prose a:hover {
+  color: #93c5fd;
+  border-bottom-color: rgba(147, 197, 253, 0.75);
+}
 
-    .prose pre code {
-      background: none;
-      border: none;
-      padding: 0;
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
+.doc-prose ul,
+.doc-prose ol {
+  padding-left: 1.5rem;
+}
 
-    .prose blockquote {
-      border-left: 3px solid var(--primary-dim);
-      margin: 1.5rem 0;
-      padding: 0.75rem 1.25rem;
-      background: rgba(255, 255, 255, 0.04);
-      border-radius: 0 8px 8px 0;
-    }
-    .prose blockquote p { color: var(--text-secondary); margin-bottom: 0; }
+.doc-prose li {
+  margin: 0.45rem 0;
+}
 
-    .prose table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-bottom: 1.5rem;
-      font-size: 0.9rem;
-    }
+.doc-prose li::marker {
+  color: #60a5fa;
+}
 
-    .prose th {
-      text-align: left;
-      padding: 0.75rem 1rem;
-      background: var(--bg-elevated);
-      border-bottom: 2px solid var(--border);
-      font-weight: 700;
-      font-size: 0.8rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--primary);
-    }
+.doc-prose hr {
+  margin: 3rem 0;
+  border: 0;
+  border-top: 1px solid rgba(71, 85, 105, 0.5);
+}
 
-    .prose td {
-      padding: 0.65rem 1rem;
-      border-bottom: 1px solid var(--border-subtle);
-      color: var(--text-secondary);
-    }
+.doc-prose blockquote {
+  margin: 1.75rem 0;
+  border-left: 3px solid rgba(59, 130, 246, 0.8);
+  border-radius: 0 1rem 1rem 0;
+  background: rgba(37, 99, 235, 0.12);
+  padding: 1rem 1.2rem;
+  color: #cbd5e1;
+}
 
-    .prose tr:last-child td { border-bottom: none; }
+.doc-prose code {
+  font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+  background: rgba(30, 33, 40, 0.92);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 0.45rem;
+  padding: 0.14rem 0.4rem;
+}
 
-    .prose hr {
-      border: none;
-      border-top: 1px solid var(--border-subtle);
-      margin: 2rem 0;
-    }
+.doc-prose pre {
+  overflow-x: auto;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+  background: rgba(30, 33, 40, 0.95);
+  padding: 1.25rem 1.35rem;
+}
 
-    /* Index page doc cards */
-    .doc-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-      gap: 1rem;
-      margin-top: 1.5rem;
-    }
+.doc-prose pre code {
+  display: block;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #e2e8f0;
+  line-height: 1.75;
+}
 
-    .doc-card {
-      display: block;
-      background: var(--bg-elevated);
-      border: 1px solid var(--border-subtle);
-      border-radius: 12px;
-      padding: 1.5rem;
-      text-decoration: none;
-      transition: border-color 0.2s, transform 0.15s;
-    }
-    .doc-card:hover {
-      border-color: var(--primary);
-      transform: translateY(-2px);
-    }
-    .doc-card h3 {
-      color: var(--text);
-      font-size: 1.1rem;
-      font-weight: 700;
-      margin-bottom: 0.5rem;
-    }
-    .doc-card p {
-      color: var(--text-muted);
-      font-size: 0.875rem;
-      line-height: 1.5;
-    }
+.doc-prose table {
+  width: 100%;
+  margin: 1.75rem 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+}
 
-    @media (max-width: 640px) {
-      .layout { padding: 1rem; }
-      .prose h1 { font-size: 1.75rem; }
-      .prose h2 { font-size: 1.25rem; }
-      .doc-grid { grid-template-columns: 1fr; }
-    }
+.doc-prose thead th {
+  background: rgba(30, 33, 40, 0.96);
+  color: #e2e8f0;
+  text-align: left;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.85rem 1rem;
+}
+
+.doc-prose tbody td {
+  padding: 0.85rem 1rem;
+  border-top: 1px solid rgba(71, 85, 105, 0.35);
+}
+
+.doc-prose img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 2rem auto;
+  border-radius: 1rem;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+}
+
+.doc-prose iframe {
+  width: 100%;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 1rem;
+  background: rgba(30, 33, 40, 0.92);
+}
+
+@media (max-width: 640px) {
+  .doc-prose {
+    font-size: 0.95rem;
+  }
+
+  .doc-prose h2 {
+    font-size: 1.45rem;
+  }
+
+  .doc-prose h3 {
+    font-size: 1.15rem;
+  }
+
+  .doc-prose table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}

--- a/script/build-public-docs.ts
+++ b/script/build-public-docs.ts
@@ -1,8 +1,5 @@
 /**
- * Converts Markdown files in docs/public/ to beautifully styled HTML pages.
- *
- * Each .md file becomes a standalone .html file in docs/public/_site/.
- * An index.html is also generated listing all available documents.
+ * Builds the docs landing page plus standalone HTML pages for Markdown docs in docs/public/.
  *
  * Usage: npx tsx script/build-public-docs.ts
  */
@@ -12,45 +9,16 @@ import path from "node:path";
 import { marked } from "marked";
 
 const DOCS_DIR = path.resolve(import.meta.dirname, "../docs/public");
+const ROOT_DOCS_INDEX = path.resolve(import.meta.dirname, "../docs/index.html");
 const OUT_DIR = path.join(DOCS_DIR, "_site");
 const SHARED_STYLESHEET = "styles.css";
-
-/** HTML template that wraps rendered markdown content */
-function htmlTemplate(title: string, content: string, isIndex: boolean): string {
-  const navBackLink = isIndex
-    ? `<a href="../../index.html" class="nav-back">← Back to CodeFactory</a>`
-    : `<a href="./index.html" class="nav-back">← All Documentation</a>`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory Documentation — ${title}" />
-  <title>${title} | CodeFactory Docs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="${SHARED_STYLESHEET}" />
-</head>
-<body>
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <a href="../../index.html" class="brand">CodeFactory</a>
-      <span class="nav-separator">/</span>
-      <span class="nav-section">Documentation</span>
-    </div>
-  </nav>
-  <div class="layout">
-    <main class="content">
-      <div class="breadcrumb">${navBackLink}</div>
-      <article class="prose">
-        ${content}
-      </article>
-    </main>
-  </div>
-</body>
-</html>`;
-}
+const REPO_URL = "https://github.com/yungookim/codefactory";
+const COMMUNITY_URL = "https://github.com/yungookim/codefactory/discussions";
+const CHANGELOG_URL = "https://github.com/yungookim/codefactory/releases";
+const ISSUES_URL = "https://github.com/yungookim/codefactory/issues";
+const API_REFERENCE_URL = "https://github.com/yungookim/codefactory/blob/main/LOCAL_API.md";
+const CONTRIBUTING_URL = "https://github.com/yungookim/codefactory/blob/main/CONTRIBUTING.md";
+const AGENT_CONFIG_URL = "https://github.com/yungookim/codefactory/blob/main/AGENTS.md";
 
 interface DocMeta {
   slug: string;
@@ -59,15 +27,600 @@ interface DocMeta {
   htmlFile: string;
 }
 
-/** Extract the first H1 and first paragraph from markdown as title and description */
+interface DocDefinition {
+  slug: string;
+  section: "Getting Started" | "Core Concepts";
+  navLabel: string;
+  cardTitle: string;
+  icon: IconName;
+  fallbackDescription: string;
+}
+
+type IconName =
+  | "logo"
+  | "github"
+  | "community"
+  | "home"
+  | "search"
+  | "quickstart"
+  | "settings"
+  | "eye"
+  | "package"
+  | "chat"
+  | "code"
+  | "doc"
+  | "sliders"
+  | "clock"
+  | "warning"
+  | "source"
+  | "info"
+  | "plus"
+  | "server"
+  | "shield";
+
+interface RenderContext {
+  kind: "root" | "site";
+  stylesheetHref: string;
+  introHref: string;
+  docsIndexHref: string;
+  docHref: (slug: string) => string;
+}
+
+interface BottomNav {
+  href: string;
+  label: string;
+  title: string;
+}
+
+const DOC_DEFINITIONS: DocDefinition[] = [
+  {
+    slug: "getting-started",
+    section: "Getting Started",
+    navLabel: "Quickstart",
+    cardTitle: "Quickstart",
+    icon: "quickstart",
+    fallbackDescription: "Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.",
+  },
+  {
+    slug: "configuration",
+    section: "Getting Started",
+    navLabel: "Configuration",
+    cardTitle: "Configuration",
+    icon: "settings",
+    fallbackDescription: "Environment variables, storage options, database setup, and activity logging.",
+  },
+  {
+    slug: "pr-babysitter",
+    section: "Core Concepts",
+    navLabel: "PR Babysitter",
+    cardTitle: "PR Babysitter",
+    icon: "eye",
+    fallbackDescription: "Autonomous monitoring, review sync, and feedback triage for your pull requests.",
+  },
+  {
+    slug: "agent-dispatch",
+    section: "Core Concepts",
+    navLabel: "Agent Dispatch",
+    cardTitle: "Agent Dispatch",
+    icon: "package",
+    fallbackDescription: "How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.",
+  },
+  {
+    slug: "pr-questions",
+    section: "Core Concepts",
+    navLabel: "PR Q&A",
+    cardTitle: "PR Q&A",
+    icon: "chat",
+    fallbackDescription: "Ask natural-language questions about any pull request and get AI-powered answers.",
+  },
+];
+
+const WORKFLOW_STEPS = [
+  {
+    number: "1.",
+    title: "Watch Repositories",
+    description: "Add any GitHub repository. CodeFactory polls for open PRs and new review activity.",
+  },
+  {
+    number: "2.",
+    title: "Sync Reviews",
+    description: "Review comments, inline feedback, and threaded conversations are captured and stored locally.",
+  },
+  {
+    number: "3.",
+    title: "Triage Feedback",
+    description: "Feedback is classified into blocking, suggestions, and nitpicks for prioritized action.",
+  },
+  {
+    number: "4.",
+    title: "Dispatch Agents",
+    description: "Local AI agents work in isolated git worktrees to fix issues without touching your active checkout.",
+  },
+  {
+    number: "5.",
+    title: "Resolve Conflicts",
+    description: "Automated merge handling keeps agent branches clean before fixes are pushed back upstream.",
+  },
+  {
+    number: "6.",
+    title: "Commit & Push",
+    description: "Validated fixes are committed and pushed back to the PR branch automatically.",
+  },
+];
+
+function createContext(kind: "root" | "site"): RenderContext {
+  return {
+    kind,
+    stylesheetHref: kind === "root" ? "./public/styles.css" : "styles.css",
+    introHref: kind === "root" ? "./index.html" : "../../index.html",
+    docsIndexHref: kind === "root" ? "./public/_site/index.html" : "./index.html",
+    docHref: (slug) => (kind === "root" ? `./public/_site/${slug}.html` : `./${slug}.html`),
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function icon(name: IconName, className: string): string {
+  switch (name) {
+    case "logo":
+      return `<svg class="${className}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>`;
+    case "github":
+      return `<svg class="${className}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"></path></svg>`;
+    case "community":
+      return `<svg class="${className}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9v-2h2v2zm0-4H9V7h2v6z"></path></svg>`;
+    case "home":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 0 0 1 1h3m10-11 2 2m-2-2v10a1 1 0 0 1-1 1h-3m-6 0a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1m-6 0h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "search":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "quickstart":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "settings":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "eye":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "package":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "chat":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-5 5v-5z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "code":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "doc":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "sliders":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6V4m0 2a2 2 0 1 0 0 4m0-4a2 2 0 1 1 0 4m-6 8a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 1 0 0-4m0 4a2 2 0 1 1 0-4m0 4v2m0-6V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "clock":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "warning":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "source":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 20 14 4m4 4 4 4-4 4M6 16l-4-4 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "info":
+      return `<svg class="${className}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"></path></svg>`;
+    case "plus":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v6m0 0v6m0-6h6m-6 0H6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "server":
+      return `<svg class="${className}" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M5 12a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2M5 12a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2m-2-4h.01M17 16h.01" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>`;
+    case "shield":
+      return `<svg class="${className}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>`;
+  }
+}
+
+function buildHead(title: string, description: string, stylesheetHref: string): string {
+  return `<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="${escapeHtml(description)}" />
+  <title>${escapeHtml(title)}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              400: "#60a5fa",
+              500: "#3b82f6",
+              600: "#2563eb",
+            },
+            dark: {
+              900: "#0f1115",
+              800: "#1e2128",
+              700: "#2c313c",
+            }
+          },
+          fontFamily: {
+            sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "sans-serif"],
+            mono: ["Fira Code", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+          }
+        }
+      }
+    };
+  </script>
+  <link rel="stylesheet" href="${stylesheetHref}" />
+</head>`;
+}
+
+function navItemMarkup(label: string, href: string, iconName: IconName, active: boolean, external = false): string {
+  const baseClasses = active
+    ? "bg-dark-800 text-white"
+    : "text-slate-400 hover:bg-dark-800 hover:text-slate-200";
+  const target = external ? ` target="_blank" rel="noreferrer"` : "";
+  const iconColor = active ? "text-slate-400" : "text-slate-500";
+
+  return `<li>
+  <a class="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors ${baseClasses}" href="${href}"${target}>
+    ${icon(iconName, `h-4 w-4 ${iconColor}`)}
+    <span>${escapeHtml(label)}</span>
+  </a>
+</li>`;
+}
+
+function renderSidebar(context: RenderContext, activeKey: string | null, docs: DocMeta[]): string {
+  const docsBySlug = new Map(docs.map((doc) => [doc.slug, doc]));
+  const groupedDocItems = new Map<DocDefinition["section"], string[]>();
+
+  for (const section of ["Getting Started", "Core Concepts"] as const) {
+    groupedDocItems.set(section, []);
+  }
+
+  for (const definition of DOC_DEFINITIONS) {
+    if (!docsBySlug.has(definition.slug)) {
+      continue;
+    }
+
+    groupedDocItems.get(definition.section)?.push(
+      navItemMarkup(
+        definition.navLabel,
+        context.docHref(definition.slug),
+        definition.icon,
+        activeKey === definition.slug,
+      ),
+    );
+  }
+
+  return `<aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
+  <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
+    <div class="mb-4 flex items-center gap-2">
+      ${icon("logo", "h-6 w-6 text-white")}
+      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
+    </div>
+    <div class="relative mb-4">
+      ${icon("search", "pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500")}
+      <input class="doc-search-input w-full rounded-md border border-dark-700 bg-dark-800 py-1.5 pl-9 pr-3 text-sm text-gray-300 placeholder-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500" placeholder="Search documents..." type="text" />
+    </div>
+    <div class="flex gap-4 text-sm text-gray-400">
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="${REPO_URL}" target="_blank" rel="noreferrer">
+        ${icon("github", "h-4 w-4")}
+        <span>GitHub</span>
+      </a>
+      <a class="flex items-center gap-1.5 transition-colors hover:text-gray-200" href="${COMMUNITY_URL}" target="_blank" rel="noreferrer">
+        ${icon("community", "h-4 w-4")}
+        <span>Community</span>
+      </a>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-6 px-3 pb-8 pt-6">
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Getting Started</h4>
+      <ul class="space-y-0.5">
+        ${navItemMarkup("Introduction", context.introHref, "home", activeKey === "intro")}
+        ${groupedDocItems.get("Getting Started")?.join("\n") ?? ""}
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Core Concepts</h4>
+      <ul class="space-y-0.5">
+        ${groupedDocItems.get("Core Concepts")?.join("\n") ?? ""}
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Guides</h4>
+      <ul class="space-y-0.5">
+        ${navItemMarkup("Contributing", CONTRIBUTING_URL, "code", false, true)}
+        ${navItemMarkup("API Reference", API_REFERENCE_URL, "doc", false, true)}
+        ${navItemMarkup("Agent Config", AGENT_CONFIG_URL, "sliders", false, true)}
+      </ul>
+    </div>
+
+    <div>
+      <h4 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Resources</h4>
+      <ul class="space-y-0.5">
+        ${navItemMarkup("Changelog", CHANGELOG_URL, "clock", false, true)}
+        ${navItemMarkup("Report an Issue", ISSUES_URL, "warning", false, true)}
+        ${navItemMarkup("Source Code", REPO_URL, "source", false, true)}
+      </ul>
+    </div>
+  </nav>
+</aside>`;
+}
+
+function renderMobileHeader(context: RenderContext): string {
+  return `<div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
+  <a class="flex items-center gap-2 text-white" href="${context.introHref}">
+    ${icon("logo", "h-5 w-5")}
+    <span class="font-semibold">CodeFactory</span>
+  </a>
+  <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
+</div>`;
+}
+
+function renderBottomNav(bottomNav?: BottomNav): string {
+  if (!bottomNav) {
+    return "";
+  }
+
+  return `<div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
+  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="${bottomNav.href}">
+    <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">${escapeHtml(bottomNav.label)}</span>
+    <span class="flex items-center gap-2 text-lg font-medium">
+      ${escapeHtml(bottomNav.title)}
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5l7 7m0 0-7 7m7-7H3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    </span>
+  </a>
+</div>`;
+}
+
+function renderShell(
+  context: RenderContext,
+  title: string,
+  description: string,
+  activeKey: string | null,
+  bodyContent: string,
+  docs: DocMeta[],
+  bottomNav?: BottomNav,
+): string {
+  return `${buildHead(title, description, context.stylesheetHref)}
+<body class="antialiased text-sm">
+  <div class="flex min-h-screen overflow-hidden">
+    ${renderSidebar(context, activeKey, docs)}
+    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+      <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
+        ${renderMobileHeader(context)}
+        ${bodyContent}
+      </div>
+      ${renderBottomNav(bottomNav)}
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+function getDocMeta(docs: DocMeta[], slug: string): DocMeta | undefined {
+  return docs.find((doc) => doc.slug === slug);
+}
+
+function getDocDefinition(slug: string): DocDefinition | undefined {
+  return DOC_DEFINITIONS.find((definition) => definition.slug === slug);
+}
+
+function renderLandingCard(context: RenderContext, docs: DocMeta[], slug: string): string {
+  const definition = getDocDefinition(slug);
+  const doc = getDocMeta(docs, slug);
+
+  if (!definition || !doc) {
+    return "";
+  }
+
+  const description = definition.fallbackDescription;
+
+  return `<a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="${context.docHref(doc.slug)}">
+  <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+    ${icon(definition.icon, "h-5 w-5")}
+  </div>
+  <h3 class="mb-2 text-lg font-semibold text-white">${escapeHtml(definition.cardTitle)}</h3>
+  <p class="text-sm leading-relaxed text-gray-400">${escapeHtml(description)}</p>
+</a>`;
+}
+
+function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
+  const getStartedCards = ["getting-started", "configuration", "pr-babysitter", "agent-dispatch"]
+    .map((slug) => renderLandingCard(context, docs, slug))
+    .filter(Boolean)
+    .join("\n");
+  const questionsDoc = getDocMeta(docs, "pr-questions");
+  const questionsDefinition = getDocDefinition("pr-questions");
+  const questionsDescription =
+    questionsDefinition?.fallbackDescription ?? questionsDoc?.description ?? "Ask natural-language questions about any pull request and get AI-powered answers.";
+
+  const bodyContent = `<header class="mb-12">
+  <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    ${icon("plus", "h-4 w-4")}
+    <span>Welcome to CodeFactory</span>
+  </div>
+  <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
+  <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
+    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+  </p>
+
+  <div class="mb-8 flex flex-wrap gap-3">
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      ${icon("github", "h-4 w-4 text-gray-500")}
+      <span>Open Source (MIT)</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      ${icon("server", "h-4 w-4 text-gray-500")}
+      <span>Runs Locally</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      ${icon("quickstart", "h-4 w-4 text-gray-500")}
+      <span>Claude Code &amp; OpenAI Codex</span>
+    </span>
+    <span class="inline-flex items-center gap-1.5 rounded border border-dark-700 bg-dark-800 px-3 py-1 text-sm text-gray-300">
+      ${icon("shield", "h-4 w-4 text-green-500")}
+      <span>Node.js 22+</span>
+    </span>
+  </div>
+
+  <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
+    ${icon("info", "mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400")}
+    <p class="text-sm leading-relaxed text-blue-100/80">
+      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      <a class="text-blue-400 hover:underline" href="${context.docHref("getting-started")}">quickstart guide</a>.
+    </p>
+  </div>
+</header>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
+  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    ${getStartedCards}
+  </div>
+</section>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">Installation</h2>
+  <div class="overflow-hidden rounded-xl border border-dark-700 bg-dark-800">
+    <div class="flex items-center gap-2 border-b border-dark-700 bg-dark-800 px-4 py-2">
+      <div class="flex gap-1.5">
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+        <div class="h-3 w-3 rounded-full bg-dark-700"></div>
+      </div>
+    </div>
+    <div class="overflow-x-auto p-6">
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
+<span class="text-white">git clone https://github.com/yungookim/codefactory.git</span>
+<span class="text-white">cd codefactory</span>
+<span class="text-white">npm install</span>
+
+<span class="text-gray-500"># Start the dashboard</span>
+<span class="text-white">npm run dev</span></code></pre>
+    </div>
+  </div>
+</section>
+
+<section class="mb-16">
+  <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
+  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <div class="space-y-0">
+    ${WORKFLOW_STEPS.map(
+      (step) => `<div class="flex gap-6 border-b border-dark-700/50 py-6">
+      <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">${step.number}</div>
+      <div>
+        <h3 class="mb-1 text-lg font-semibold text-white">${escapeHtml(step.title)}</h3>
+        <p class="text-gray-400">${escapeHtml(step.description)}</p>
+      </div>
+    </div>`,
+    ).join("\n")}
+  </div>
+</section>
+
+<section class="mb-8">
+  <h2 class="mb-4 text-2xl font-bold text-white">Explore</h2>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="${context.docHref("pr-questions")}">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        ${icon("chat", "h-5 w-5")}
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">${escapeHtml(questionsDefinition?.cardTitle ?? "PR Q&A")}</h3>
+      <p class="text-sm leading-relaxed text-gray-400">${escapeHtml(questionsDescription)}</p>
+    </a>
+
+    <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="${API_REFERENCE_URL}" target="_blank" rel="noreferrer">
+      <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
+        ${icon("doc", "h-5 w-5")}
+      </div>
+      <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+    </a>
+  </div>
+</section>`;
+
+  return renderShell(
+    context,
+    "CodeFactory Documentation",
+    "CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code.",
+    "intro",
+    bodyContent,
+    docs,
+    {
+      href: context.docHref("getting-started"),
+      label: "Next",
+      title: "Quickstart Guide",
+    },
+  );
+}
+
+function stripLeadingTitleAndDescription(html: string): string {
+  let content = html.replace(/^\s*<h1[^>]*>.*?<\/h1>\s*/is, "");
+  content = content.replace(/^\s*<p>.*?<\/p>\s*/is, "");
+  return content;
+}
+
+function renderDocPage(context: RenderContext, doc: DocMeta, docs: DocMeta[], renderedHtml: string): string {
+  const bodyContent = `<header class="mb-12 border-b border-dark-800/60 pb-8">
+  <a class="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-gray-200" href="${context.docsIndexHref}">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
+    <span>All docs</span>
+  </a>
+  <div class="mb-5 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
+    ${icon("doc", "h-4 w-4")}
+    <span>Documentation</span>
+  </div>
+  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">${escapeHtml(doc.title)}</h1>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">${escapeHtml(doc.description)}</p>
+</header>
+
+<article class="doc-prose">
+  ${stripLeadingTitleAndDescription(renderedHtml)}
+</article>`;
+
+  const orderedDocs = DOC_DEFINITIONS.map((definition) => definition.slug).filter((slug) =>
+    docs.some((entry) => entry.slug === slug),
+  );
+  const currentIndex = orderedDocs.indexOf(doc.slug);
+  const nextSlug = currentIndex >= 0 ? orderedDocs[currentIndex + 1] : undefined;
+  const nextDoc = nextSlug ? getDocMeta(docs, nextSlug) : undefined;
+  const bottomNav =
+    nextDoc && getDocDefinition(nextDoc.slug)
+      ? {
+          href: context.docHref(nextDoc.slug),
+          label: "Next",
+          title: getDocDefinition(nextDoc.slug)?.cardTitle ?? nextDoc.title,
+        }
+      : {
+          href: context.introHref,
+          label: "Overview",
+          title: "Documentation Overview",
+        };
+
+  return renderShell(
+    context,
+    `${doc.title} | CodeFactory Docs`,
+    `${doc.title} - CodeFactory documentation`,
+    doc.slug,
+    bodyContent,
+    docs,
+    bottomNav,
+  );
+}
+
 function extractMeta(markdown: string, filename: string): { title: string; description: string } {
   const titleMatch = markdown.match(/^#\s+(.+)$/m);
   const title = titleMatch ? titleMatch[1].trim() : filename.replace(/\.md$/, "");
 
-  // Get first paragraph after the title
   const lines = markdown.split("\n");
   let description = "";
   let pastTitle = false;
+
   for (const line of lines) {
     if (!pastTitle) {
       if (titleMatch && line.startsWith("# ")) {
@@ -75,9 +628,14 @@ function extractMeta(markdown: string, filename: string): { title: string; descr
       }
       continue;
     }
+
     const trimmed = line.trim();
-    if (trimmed === "") continue;
-    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) break;
+    if (trimmed === "") {
+      continue;
+    }
+    if (trimmed.startsWith("#") || trimmed.startsWith("```") || trimmed.startsWith("|") || trimmed.startsWith("-")) {
+      break;
+    }
     description = trimmed;
     break;
   }
@@ -85,80 +643,69 @@ function extractMeta(markdown: string, filename: string): { title: string; descr
   return { title, description };
 }
 
-function generateIndexPage(docs: DocMeta[]): string {
-  const cards = docs
-    .map(
-      (doc) => `
-      <a href="./${doc.htmlFile}" class="doc-card">
-        <h3>${doc.title}</h3>
-        <p>${doc.description}</p>
-      </a>`
-    )
-    .join("\n");
-
-  const content = `
-    <h1>Documentation</h1>
-    <p>Everything you need to know about using CodeFactory to automate your PR review workflow.</p>
-    <div class="doc-grid">
-      ${cards}
-    </div>
-  `;
-
-  return htmlTemplate("Documentation", content, true);
-}
-
-// Rewrite .md links to .html links in the rendered HTML
 function rewriteLinks(html: string): string {
   return html.replace(/href="\.\/([^"]+)\.md"/g, 'href="./$1.html"');
 }
 
 async function main() {
-  // Clean output directory
   if (fs.existsSync(OUT_DIR)) {
     fs.rmSync(OUT_DIR, { recursive: true });
   }
   fs.mkdirSync(OUT_DIR, { recursive: true });
-
-  // Copy the shared stylesheet so the source stays lintable and maintainable.
   fs.copyFileSync(path.join(DOCS_DIR, SHARED_STYLESHEET), path.join(OUT_DIR, SHARED_STYLESHEET));
 
-  // Find all .md files
-  const files = fs.readdirSync(DOCS_DIR).filter((f) => f.endsWith(".md"));
+  const files = fs.readdirSync(DOCS_DIR).filter((file) => file.endsWith(".md"));
 
   if (files.length === 0) {
     console.log("No markdown files found in docs/public/");
     return;
   }
 
-  const docs: DocMeta[] = [];
-
-  // Ordered list for the index (getting-started first)
+  const preferredOrder = DOC_DEFINITIONS.map((definition) => `${definition.slug}.md`);
   const orderedFiles = [
-    "getting-started.md",
-    ...files.filter((f) => f !== "getting-started.md").sort(),
-  ].filter((f) => files.includes(f));
+    ...preferredOrder.filter((file) => files.includes(file)),
+    ...files.filter((file) => !preferredOrder.includes(file)).sort(),
+  ];
+
+  const docs: DocMeta[] = [];
+  const renderedDocs = new Map<string, string>();
 
   for (const file of orderedFiles) {
     const markdown = fs.readFileSync(path.join(DOCS_DIR, file), "utf-8");
     const { title, description } = extractMeta(markdown, file);
     const slug = file.replace(/\.md$/, "");
     const htmlFile = `${slug}.html`;
+    const definition = getDocDefinition(slug);
 
-    const rendered = rewriteLinks(await marked.parse(markdown));
-    const html = htmlTemplate(title, rendered, false);
+    docs.push({
+      slug,
+      title,
+      description: description || definition?.fallbackDescription || title,
+      htmlFile,
+    });
 
-    fs.writeFileSync(path.join(OUT_DIR, htmlFile), html);
-    docs.push({ slug, title, description, htmlFile });
-
-    console.log(`  ✓ ${file} → ${htmlFile}`);
+    renderedDocs.set(slug, rewriteLinks(await marked.parse(markdown)));
   }
 
-  // Generate index
-  const indexHtml = generateIndexPage(docs);
-  fs.writeFileSync(path.join(OUT_DIR, "index.html"), indexHtml);
-  console.log(`  ✓ index.html (${docs.length} documents)`);
+  const siteContext = createContext("site");
+  const rootContext = createContext("root");
 
-  console.log(`\nBuilt ${docs.length} docs → ${OUT_DIR}`);
+  for (const doc of docs) {
+    const rendered = renderedDocs.get(doc.slug);
+    if (!rendered) {
+      continue;
+    }
+
+    fs.writeFileSync(path.join(OUT_DIR, doc.htmlFile), renderDocPage(siteContext, doc, docs, rendered));
+    console.log(`  ✓ ${doc.slug}.md -> ${doc.htmlFile}`);
+  }
+
+  fs.writeFileSync(path.join(OUT_DIR, "index.html"), renderLandingPage(siteContext, docs));
+  fs.writeFileSync(ROOT_DOCS_INDEX, renderLandingPage(rootContext, docs));
+
+  console.log(`  ✓ _site/index.html`);
+  console.log(`  ✓ docs/index.html`);
+  console.log(`\nBuilt ${docs.length} docs -> ${OUT_DIR}`);
 }
 
 main().catch((err) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -188,3 +188,12 @@
   - Map the entry files that own that surface before touching shared or global styles.
   - Treat documentation pages and the app dashboard as separate styling systems unless the user asks for both.
   - Avoid app-wide token audits when the request names a specific page or docs surface.
+
+## 2026-03-24 - Treat user-provided reference markup as the canonical docs source
+- Pattern: I initially optimized around the existing docs landing page instead of locking onto the exact reference markup the user later provided.
+- Rule: When a user supplies canonical HTML/CSS for a docs surface, treat that snippet as the source of truth and align every related generated page to it, not just the page that looked closest already.
+- Prevention checklist:
+  - Ask for or confirm the canonical reference before redesigning an existing docs surface.
+  - Compare both the root docs entry page and any generated docs pages against the provided reference before editing.
+  - Move shared docs layout into the generator or a shared template so the reference style cannot drift between pages.
+  - Rebuild generated docs after the template change and inspect at least one root page and one generated page for matching shell structure.


### PR DESCRIPTION
## Summary
- rebuild the docs landing page and generated docs pages from one shared reference-style shell
- move shared docs prose styling into docs/public/styles.css and regenerate docs/public/_site output
- record the user correction in tasks/lessons.md so future docs theme work locks onto the provided reference markup

## Verification
- npm install
- npm run build:public-docs
- npm run check