### PR TITLE
feat: automate release management for merged prs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Dashboard from "@/pages/dashboard";
 import Settings from "@/pages/settings";
 import Changelogs from "@/pages/changelogs";
+import Releases from "@/pages/releases";
 import NotFound from "@/pages/not-found";
 
 function AppRouter() {
@@ -15,6 +16,7 @@ function AppRouter() {
       <Route path="/" component={Dashboard} />
       <Route path="/settings" component={Settings} />
       <Route path="/changelogs" component={Changelogs} />
+      <Route path="/releases" component={Releases} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -686,6 +686,12 @@ export default function Dashboard() {
           >
             changelogs
           </Link>
+          <Link
+            href="/releases"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus:outline-none"
+          >
+            releases
+          </Link>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-[11px] text-muted-foreground">

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -1,0 +1,310 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { toast } from "@/hooks/use-toast";
+import type { ReleaseRun } from "@shared/schema";
+
+type ReleaseRunStatus = ReleaseRun["status"] | string;
+
+const ACTIVE_RELEASE_STATUSES = new Set<ReleaseRunStatus>([
+  "detected",
+  "evaluating",
+  "proposed",
+  "publishing",
+]);
+
+function isActiveStatus(status: ReleaseRunStatus): boolean {
+  return ACTIVE_RELEASE_STATUSES.has(status);
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "n/a";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "n/a";
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function shortSha(sha: string | null | undefined): string {
+  if (!sha) return "n/a";
+  return sha.slice(0, 7);
+}
+
+function StatusBadge({ status }: { status: ReleaseRunStatus }) {
+  const cls = status === "published"
+    ? "border-foreground/40 text-foreground"
+    : status === "skipped"
+      ? "border-border text-muted-foreground"
+      : status === "error"
+        ? "border-destructive/40 text-destructive"
+        : isActiveStatus(status)
+          ? "border-border text-muted-foreground animate-pulse"
+          : "border-border text-muted-foreground";
+
+  return (
+    <span className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${cls}`}>
+      {status}
+    </span>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:border-foreground hover:text-foreground"
+    >
+      {copied ? "copied" : "copy"}
+    </button>
+  );
+}
+
+function ReleaseRunCard({
+  run,
+  onRetry,
+  retryPending,
+}: {
+  run: ReleaseRun;
+  onRetry: (id: string) => void;
+  retryPending: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails =
+    Boolean(run.decisionReason) ||
+    Boolean(run.releaseNotes) ||
+    Boolean(run.error) ||
+    Boolean(run.githubReleaseUrl) ||
+    run.includedPrs.length > 0;
+
+  return (
+    <div className="border border-border">
+      <button
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/30"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <StatusBadge status={run.status} />
+          <span className="truncate text-sm font-medium">{run.repo}</span>
+          <span className="text-[11px] text-muted-foreground">#{run.triggerPrNumber}</span>
+          {run.proposedVersion && (
+            <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+              {run.proposedVersion}
+            </span>
+          )}
+          {!run.proposedVersion && run.recommendedBump && (
+            <span className="text-[11px] text-muted-foreground">
+              bump {run.recommendedBump}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <span>{formatDateTime(run.createdAt)}</span>
+          <span>{expanded ? "▲" : "▼"}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border px-4 pb-4 pt-3">
+          <div className="mb-3 text-[12px] text-muted-foreground">
+            Trigger PR:{" "}
+            <a href={run.triggerPrUrl} target="_blank" rel="noreferrer" className="underline underline-offset-2">
+              #{run.triggerPrNumber} {run.triggerPrTitle}
+            </a>
+          </div>
+
+          {run.decisionReason && (
+            <p className="mb-3 text-[12px] leading-relaxed">{run.decisionReason}</p>
+          )}
+
+          {run.releaseTitle && (
+            <p className="mb-3 text-[12px]">
+              <span className="text-muted-foreground">Release title:</span>{" "}
+              <span>{run.releaseTitle}</span>
+            </p>
+          )}
+
+          <div className="mb-3 grid grid-cols-1 gap-2 text-[12px] text-muted-foreground md:grid-cols-2">
+            <div>Base branch: {run.baseBranch || "main"}</div>
+            <div>Trigger SHA: {shortSha(run.triggerMergeSha)}</div>
+            <div>Merged at: {formatDateTime(run.triggerMergedAt)}</div>
+            <div>Updated: {formatDateTime(run.updatedAt)}</div>
+          </div>
+
+          {run.includedPrs.length > 0 && (
+            <div className="mb-3">
+              <div className="mb-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+                Included PRs ({run.includedPrs.length})
+              </div>
+              <div className="space-y-1 border border-border p-3 text-[12px]">
+                {run.includedPrs.map((pr) => (
+                  <div key={`${pr.mergeSha}-${pr.number}`} className="flex items-center justify-between gap-3">
+                    <span className="truncate">
+                      #{pr.number} {pr.title}
+                    </span>
+                    <a href={pr.url} target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-foreground">
+                      open
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {run.releaseNotes && (
+            <div className="mb-3">
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Release Notes</span>
+                <CopyButton text={run.releaseNotes} />
+              </div>
+              <pre className="whitespace-pre-wrap border border-border bg-background p-3 text-[12px] leading-relaxed font-mono">
+                {run.releaseNotes}
+              </pre>
+            </div>
+          )}
+
+          {run.error && (
+            <div className="mb-3 border border-destructive/40 bg-destructive/5 p-3 text-[12px] text-destructive">
+              {run.error}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            {run.githubReleaseUrl && (
+              <a
+                href={run.githubReleaseUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
+              >
+                open release
+              </a>
+            )}
+            {run.status === "error" && (
+              <button
+                onClick={() => onRetry(run.id)}
+                disabled={retryPending}
+                className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                retry
+              </button>
+            )}
+          </div>
+
+          {!hasDetails && (
+            <p className="mt-2 text-[12px] text-muted-foreground">No details available yet.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Releases() {
+  const { data: releases = [], isLoading } = useQuery<ReleaseRun[]>({
+    queryKey: ["/api/releases"],
+    refetchInterval: (query) => {
+      const data = query.state.data as ReleaseRun[] | undefined;
+      return data?.some((run) => isActiveStatus(run.status)) ? 5000 : false;
+    },
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await apiRequest("POST", `/api/releases/${id}/retry`);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/releases"] });
+      toast({ description: "Retry queued." });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Retry failed: ${error.message}` });
+    },
+  });
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-label="Release Management">
+            <rect x="1" y="1" width="14" height="14" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M4 6h8M4 9h8M4 12h5" stroke="currentColor" strokeWidth="1" />
+          </svg>
+          <span className="text-sm font-medium tracking-tight">code factory</span>
+          <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+            releases
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/settings"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus:outline-none"
+          >
+            settings
+          </Link>
+          <Link
+            href="/"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus:outline-none"
+          >
+            ← back to dashboard
+          </Link>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-4xl">
+          <div className="mb-5">
+            <h1 className="text-base font-medium">Release Management</h1>
+            <p className="mt-1 text-[12px] text-muted-foreground">
+              Every merged PR can trigger agent evaluation. This page shows release decisions, version bumps, notes, and publishing outcomes.
+            </p>
+          </div>
+
+          {isLoading && (
+            <div className="border border-border px-4 py-6 text-center">
+              <p className="text-[12px] text-muted-foreground">Loading…</p>
+            </div>
+          )}
+
+          {!isLoading && releases.length === 0 && (
+            <div className="border border-border px-4 py-8 text-center">
+              <p className="text-sm text-muted-foreground">No release runs yet.</p>
+              <p className="mt-1 text-[12px] text-muted-foreground">
+                Runs appear after merged PRs are evaluated for release-worthiness.
+              </p>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            {releases.map((run) => (
+              <ReleaseRunCard
+                key={run.id}
+                run={run}
+                onRetry={(id) => retryMutation.mutate(id)}
+                retryPending={retryMutation.isPending}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -22,6 +22,10 @@ function isTerminalStatus(status: ReleaseRunStatus): boolean {
   return status === "published" || status === "skipped" || status === "error";
 }
 
+function hasReleaseRunStatus(value: unknown): value is { status: ReleaseRunStatus } {
+  return typeof value === "object" && value !== null && "status" in value && typeof value.status === "string";
+}
+
 function formatDateTime(value: string | null | undefined): string {
   if (!value) return "n/a";
   const date = new Date(value);

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -229,7 +229,12 @@ function ReleaseRunCard({
 export default function Releases() {
   const { data: releases = [], isLoading } = useQuery<ReleaseRun[]>({
     queryKey: ["/api/releases"],
-    refetchInterval: () => (releases.some((run) => isActiveStatus(run.status)) ? 5000 : false),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      return Array.isArray(data) && data.some((run) => hasReleaseRunStatus(run) && isActiveStatus(run.status))
+        ? 5000
+        : false;
+    },
   });
 
   const retryMutation = useMutation({

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -5,9 +5,9 @@ import { apiRequest, queryClient } from "@/lib/queryClient";
 import { toast } from "@/hooks/use-toast";
 import type { ReleaseRun } from "@shared/schema";
 
-type ReleaseRunStatus = ReleaseRun["status"] | string;
+type ReleaseRunStatus = ReleaseRun["status"];
 
-const ACTIVE_RELEASE_STATUSES = new Set<ReleaseRunStatus>([
+const ACTIVE_RELEASE_STATUSES = new Set<ReleaseRun["status"]>([
   "detected",
   "evaluating",
   "proposed",
@@ -16,6 +16,10 @@ const ACTIVE_RELEASE_STATUSES = new Set<ReleaseRunStatus>([
 
 function isActiveStatus(status: ReleaseRunStatus): boolean {
   return ACTIVE_RELEASE_STATUSES.has(status);
+}
+
+function isTerminalStatus(status: ReleaseRunStatus): boolean {
+  return status === "published" || status === "skipped" || status === "error";
 }
 
 function formatDateTime(value: string | null | undefined): string {
@@ -62,8 +66,9 @@ function CopyButton({ text }: { text: string }) {
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // no-op
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Clipboard write failed";
+      toast({ variant: "destructive", description: `Failed to copy: ${message}` });
     }
   };
 
@@ -89,10 +94,14 @@ function ReleaseRunCard({
   const [expanded, setExpanded] = useState(false);
   const hasDetails =
     Boolean(run.decisionReason) ||
+    Boolean(run.releaseTitle) ||
     Boolean(run.releaseNotes) ||
     Boolean(run.error) ||
     Boolean(run.githubReleaseUrl) ||
     run.includedPrs.length > 0;
+  const shouldShowEmptyDetails =
+    !hasDetails
+    && isTerminalStatus(run.status);
 
   return (
     <div className="border border-border">
@@ -125,7 +134,7 @@ function ReleaseRunCard({
         <div className="border-t border-border px-4 pb-4 pt-3">
           <div className="mb-3 text-[12px] text-muted-foreground">
             Trigger PR:{" "}
-            <a href={run.triggerPrUrl} target="_blank" rel="noreferrer" className="underline underline-offset-2">
+            <a href={run.triggerPrUrl} target="_blank" rel="noreferrer noopener" className="underline underline-offset-2">
               #{run.triggerPrNumber} {run.triggerPrTitle}
             </a>
           </div>
@@ -142,7 +151,7 @@ function ReleaseRunCard({
           )}
 
           <div className="mb-3 grid grid-cols-1 gap-2 text-[12px] text-muted-foreground md:grid-cols-2">
-            <div>Base branch: {run.baseBranch || "main"}</div>
+            <div>Base branch: {run.baseBranch || "n/a"}</div>
             <div>Trigger SHA: {shortSha(run.triggerMergeSha)}</div>
             <div>Merged at: {formatDateTime(run.triggerMergedAt)}</div>
             <div>Updated: {formatDateTime(run.updatedAt)}</div>
@@ -159,7 +168,7 @@ function ReleaseRunCard({
                     <span className="truncate">
                       #{pr.number} {pr.title}
                     </span>
-                    <a href={pr.url} target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-foreground">
+                    <a href={pr.url} target="_blank" rel="noreferrer noopener" className="text-muted-foreground hover:text-foreground">
                       open
                     </a>
                   </div>
@@ -191,7 +200,7 @@ function ReleaseRunCard({
               <a
                 href={run.githubReleaseUrl}
                 target="_blank"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
               >
                 open release
@@ -208,7 +217,7 @@ function ReleaseRunCard({
             )}
           </div>
 
-          {!hasDetails && (
+          {shouldShowEmptyDetails && (
             <p className="mt-2 text-[12px] text-muted-foreground">No details available yet.</p>
           )}
         </div>
@@ -220,10 +229,7 @@ function ReleaseRunCard({
 export default function Releases() {
   const { data: releases = [], isLoading } = useQuery<ReleaseRun[]>({
     queryKey: ["/api/releases"],
-    refetchInterval: (query) => {
-      const data = query.state.data as ReleaseRun[] | undefined;
-      return data?.some((run) => isActiveStatus(run.status)) ? 5000 : false;
-    },
+    refetchInterval: () => (releases.some((run) => isActiveStatus(run.status)) ? 5000 : false),
   });
 
   const retryMutation = useMutation({

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -107,6 +107,30 @@ export default function Settings() {
             </div>
           </section>
 
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Releases
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <label className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm">Automatic release creation</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Evaluate merged PRs and publish GitHub releases automatically when the agent decides they are release-worthy.
+                  </div>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={config?.autoCreateReleases ?? true}
+                  onChange={(e) => updateConfigMutation.mutate({ autoCreateReleases: e.target.checked })}
+                  disabled={updateConfigMutation.isPending}
+                  className="mt-1 accent-foreground"
+                  data-testid="checkbox-auto-create-releases"
+                />
+              </label>
+            </div>
+          </section>
+
           {/* GitHub Token */}
           <section>
             <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">

--- a/docs/plans/2026-03-28-agentic-release-management-design.md
+++ b/docs/plans/2026-03-28-agentic-release-management-design.md
@@ -1,0 +1,222 @@
+# Agentic Release Management Design
+
+**Date:** 2026-03-28
+
+## Goal
+
+Automatically evaluate every merged PR for release-worthiness, let the configured agent decide whether a release should be created and what semver bump it should use, and publish a GitHub release with agent-authored notes when appropriate. Expose the full workflow in a dedicated release management page.
+
+## Decision Summary
+
+- Trigger release evaluation for every merged PR detected by the watcher.
+- Use the configured coding agent (`claude` or `codex`) to decide:
+  - whether to create a release
+  - the semver bump: `patch`, `minor`, or `major`
+  - the release title and release notes
+- Keep irreversible operations deterministic in the app:
+  - merge confirmation
+  - latest-tag lookup
+  - next-version calculation
+  - GitHub release creation
+  - idempotency and retries
+- Add a dedicated `/releases` page for release history and operational state.
+- Add a single global config toggle to disable automatic release creation if needed.
+
+## Existing Constraints
+
+- The watcher currently infers close state by comparing tracked PRs with GitHub open PRs and archiving PRs that disappear from the open list.
+- Archived PRs are not currently distinguished as merged vs closed-without-merge.
+- The codebase already has a durable async artifact pattern with social changelogs:
+  - watcher detects a merged-PR condition
+  - storage persists a background job/result
+  - a dedicated page renders status/history
+- Published GitHub releases already trigger downstream workflows in this repository:
+  - npm publish
+  - Tauri release builds
+
+## Proposed Architecture
+
+### 1. ReleaseRun as a first-class entity
+
+Add a durable `ReleaseRun` record to store the full release automation lifecycle.
+
+Suggested fields:
+
+- `id`
+- `repo`
+- `baseBranch`
+- `triggerPrNumber`
+- `triggerPrTitle`
+- `triggerPrUrl`
+- `triggerMergeSha`
+- `triggerMergedAt`
+- `status`
+- `decisionReason`
+- `recommendedBump`
+- `proposedVersion`
+- `releaseTitle`
+- `releaseNotes`
+- `includedPrs`
+- `targetSha`
+- `githubReleaseId`
+- `githubReleaseUrl`
+- `error`
+- `createdAt`
+- `updatedAt`
+- `completedAt`
+
+Suggested statuses:
+
+- `detected`
+- `evaluating`
+- `skipped`
+- `proposed`
+- `publishing`
+- `published`
+- `error`
+
+### 2. Merge confirmation in the watcher
+
+Extend the watcher flow so that when a tracked PR disappears from GitHub open PRs, the server fetches the full PR state and confirms whether it was merged before treating it as a release trigger.
+
+If the PR was merged:
+
+- archive the PR locally as today
+- create or reconcile a `ReleaseRun` keyed by repo + trigger PR number + merge SHA
+- kick off background processing for that run
+
+If the PR was only closed:
+
+- archive the PR locally
+- do not create a release run
+
+### 3. Dedicated release manager
+
+Add a small service layer that owns:
+
+- run creation
+- state transitions
+- repo-level locking
+- idempotency checks
+- agent evaluation
+- version calculation
+- GitHub release creation
+
+The watcher should detect events, but the release manager should own the release workflow.
+
+### 4. Agent boundary
+
+The agent should return structured JSON only. It does not call GitHub and it does not invent the final version string directly.
+
+Suggested evaluation output:
+
+```json
+{
+  "shouldRelease": true,
+  "reason": "User-facing feature that changes release behavior.",
+  "bump": "minor",
+  "title": "Release management automation",
+  "notes": "## Highlights\n..."
+}
+```
+
+The app validates this output, computes the next version deterministically from the latest semver tag, and publishes the release through GitHub APIs.
+
+### 5. Versioning model
+
+- Fetch the latest semver tag from GitHub for the repository.
+- Default the starting point to `v0.1.0` semantics if no prior release exists.
+- Apply the agent-selected bump to compute the next version.
+- Reject invalid or non-semver tags as candidates for automatic bumping.
+
+### 6. Release scope
+
+One merged PR triggers evaluation, but the published release should contain all unreleased merged PRs on the release branch since the last published release.
+
+That lets the agent answer the right question:
+
+- not just “is this PR alone worthy of a release?”
+- but “given the current unreleased changes, should we publish a release now?”
+
+The `ReleaseRun` stores both:
+
+- the trigger PR
+- the final included PR summaries
+
+### 7. GitHub integration
+
+Add server helpers to:
+
+- fetch full PR close/merge state
+- list published releases
+- list tags
+- determine the latest semver release/tag
+- list merged PRs since the last release target
+- create a GitHub release
+
+Prefer GitHub release creation over raw git tagging because this repository already has release workflows wired to GitHub release publication events.
+
+### 8. UI
+
+Add a new `/releases` page with:
+
+- release-run history cards
+- status badges
+- trigger PR and included PR list
+- chosen bump and proposed/published version
+- decision rationale
+- release notes preview
+- GitHub link for published releases
+- retry action for failed runs
+
+This page should follow the current `changelogs` page pattern:
+
+- list-first history surface
+- adaptive polling while runs are active
+- expandable details
+- empty/loading/error states
+
+### 9. Configuration
+
+Add one global config flag:
+
+- `autoCreateReleases: boolean`
+
+This is an emergency stop for release publishing while keeping the rest of the feature model simple for v1.
+
+## Error Handling
+
+- If merge confirmation fails, do not create a release run.
+- If agent evaluation fails, mark the run `error`.
+- If the agent returns invalid JSON, mark the run `error`.
+- If version calculation fails due to malformed existing tags, mark the run `error`.
+- If the release/tag already exists, reconcile instead of publishing a duplicate.
+- If GitHub release creation fails, mark the run `error` with the API error.
+
+## Testing Strategy
+
+- Schema/model validation tests for `ReleaseRun`.
+- Storage tests for create/list/update/idempotent lookup.
+- GitHub helper tests for:
+  - merge confirmation parsing
+  - latest semver tag selection
+  - next-version calculation
+  - release creation request shape
+- Release manager tests for:
+  - merged PR creates a run
+  - closed-unmerged PR does not
+  - skipped decision
+  - successful publish
+  - duplicate merge/retry reconciliation
+- Route tests for release APIs.
+- UI smoke coverage for release page rendering and polling behavior.
+
+## Out of Scope for V1
+
+- Per-repo release policies
+- Manual version overrides
+- Approval queue before publish
+- Multiple release branches per repo
+- Editing release notes in the app before publishing
+- Draft releases
+- Release rollback tooling

--- a/docs/plans/2026-03-28-agentic-release-management.md
+++ b/docs/plans/2026-03-28-agentic-release-management.md
@@ -1,0 +1,360 @@
+# Agentic Release Management Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically evaluate merged PRs for release-worthiness, publish GitHub releases with agent-authored notes when warranted, and expose durable release history in a dedicated UI.
+
+**Architecture:** Extend the watcher to confirm merges, persist `ReleaseRun` jobs, process them through a dedicated release manager, and publish releases through GitHub APIs. Mirror the existing social-changelog pattern for storage/API/UI, but keep versioning and publish logic deterministic in the app.
+
+**Tech Stack:** TypeScript, Express, React, TanStack Query, SQLite, Zod, Octokit, Node test runner
+
+---
+
+### Task 1: Add shared release types
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `shared/models.ts`
+
+**Step 1: Write the failing test**
+
+Add schema/model assertions for a new `ReleaseRun` type and the new config flag in existing schema-adjacent tests or in a new server storage test path.
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/storage.test.ts`
+Expected: FAIL because `ReleaseRun` types and config support do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add `releaseRunStatusEnum`
+- Add `releaseRunIncludedPRSchema`
+- Add `releaseRunSchema`
+- Add `autoCreateReleases` to `configSchema`
+- Add `createReleaseRun` and `applyReleaseRunUpdate`
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/storage.test.ts`
+Expected: PASS for schema/model coverage.
+
+**Step 5: Commit**
+
+```bash
+git add shared/schema.ts shared/models.ts server/storage.test.ts
+git commit -m "feat: add release run schemas"
+```
+
+### Task 2: Extend storage for release runs
+
+**Files:**
+- Modify: `server/storage.ts`
+- Modify: `server/memoryStorage.ts`
+- Modify: `server/sqliteStorage.ts`
+- Modify: `server/storage.test.ts`
+- Modify: `server/memoryStorage.test.ts`
+
+**Step 1: Write the failing test**
+
+Add storage tests for:
+
+- create/list/update release run
+- lookup by repo + merge SHA
+- config round-trip for `autoCreateReleases`
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/storage.test.ts server/memoryStorage.test.ts`
+Expected: FAIL because storage methods and SQLite schema do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add `release_runs` table and indexes
+- Add parsing helpers and CRUD methods
+- Update memory storage maps and config defaults
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/storage.test.ts server/memoryStorage.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/storage.ts server/memoryStorage.ts server/sqliteStorage.ts server/storage.test.ts server/memoryStorage.test.ts server/defaultConfig.ts
+git commit -m "feat: persist release runs"
+```
+
+### Task 3: Add GitHub release primitives
+
+**Files:**
+- Modify: `server/github.ts`
+- Modify: `server/github.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- fetching merged PR detail including merged metadata
+- choosing the latest semver tag
+- bumping versions from `patch|minor|major`
+- creating a GitHub release request
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/github.test.ts`
+Expected: FAIL because helper functions do not exist.
+
+**Step 3: Write minimal implementation**
+
+- Add merged PR detail fetch helper
+- Add release/tag listing helper
+- Add semver parsing/version bump helpers
+- Add GitHub release creation helper
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/github.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/github.ts server/github.test.ts
+git commit -m "feat: add github release helpers"
+```
+
+### Task 4: Add agent release evaluation
+
+**Files:**
+- Create: `server/releaseAgent.ts`
+- Modify: `server/agentRunner.ts`
+- Add or Modify: `server/agentRunner.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests for parsing structured evaluation JSON and rejecting invalid output.
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/agentRunner.test.ts`
+Expected: FAIL because release evaluation helpers do not exist.
+
+**Step 3: Write minimal implementation**
+
+- Extract generic JSON-evaluation support if needed
+- Add prompt builder/parser for release decisions
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/agentRunner.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/releaseAgent.ts server/agentRunner.ts server/agentRunner.test.ts
+git commit -m "feat: add release evaluation agent"
+```
+
+### Task 5: Add release manager orchestration
+
+**Files:**
+- Create: `server/releaseManager.ts`
+- Add: `server/releaseManager.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- merged PR creates a release run
+- unmerged closure does not
+- skipped decision persists
+- successful publish persists release URL/version
+- duplicate trigger does not create duplicate publish
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/releaseManager.test.ts`
+Expected: FAIL because the release manager does not exist.
+
+**Step 3: Write minimal implementation**
+
+- Add repo-level run lock
+- Add `enqueueMergedPrReleaseEvaluation(...)`
+- Add `processReleaseRun(...)`
+- Keep publish deterministic and idempotent
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/releaseManager.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/releaseManager.ts server/releaseManager.test.ts
+git commit -m "feat: add release manager"
+```
+
+### Task 6: Hook merge detection into the watcher
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Write the failing test**
+
+Add watcher/babysitter tests for:
+
+- merged archived PR enqueues release evaluation
+- closed-unmerged PR only archives
+- auto-release disable flag skips enqueue
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/babysitter.test.ts`
+Expected: FAIL because the watcher does not notify a release manager today.
+
+**Step 3: Write minimal implementation**
+
+- Inject the release manager dependency
+- Confirm merge status before enqueue
+- Preserve existing archive and social-changelog behavior
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/babysitter.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/babysitter.ts server/babysitter.test.ts
+git commit -m "feat: enqueue releases from merged prs"
+```
+
+### Task 7: Add release APIs
+
+**Files:**
+- Modify: `server/routes.ts`
+- Add or Modify: route-level tests if present
+
+**Step 1: Write the failing test**
+
+Add API coverage for:
+
+- `GET /api/releases`
+- `GET /api/releases/:id`
+- `POST /api/releases/:id/retry`
+- `PATCH /api/config` round-trip for `autoCreateReleases`
+
+**Step 2: Run test to verify it fails**
+
+Run: `./node_modules/.bin/tsx --test server/*.test.ts`
+Expected: FAIL because routes do not exist.
+
+**Step 3: Write minimal implementation**
+
+- Expose release list/detail/retry endpoints
+- Reuse existing config mutation path
+
+**Step 4: Run test to verify it passes**
+
+Run: `./node_modules/.bin/tsx --test server/*.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/routes.ts
+git commit -m "feat: expose release management api"
+```
+
+### Task 8: Add releases page and navigation
+
+**Files:**
+- Modify: `client/src/App.tsx`
+- Modify: `client/src/pages/dashboard.tsx`
+- Create: `client/src/pages/releases.tsx`
+- Modify: `client/src/pages/settings.tsx`
+
+**Step 1: Write the failing test**
+
+Add focused UI coverage if the repo already has page tests, otherwise validate manually after implementation.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run check`
+Expected: FAIL once imports/routes reference the new types and page before implementation.
+
+**Step 3: Write minimal implementation**
+
+- Add `/releases` route
+- Add dashboard header link
+- Build release history page with adaptive polling and expandable cards
+- Add `autoCreateReleases` toggle in settings
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run check`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add client/src/App.tsx client/src/pages/dashboard.tsx client/src/pages/releases.tsx client/src/pages/settings.tsx
+git commit -m "feat: add release management ui"
+```
+
+### Task 9: End-to-end verification
+
+**Files:**
+- Modify: any touched files as needed from verification failures
+
+**Step 1: Run focused test suites**
+
+Run:
+
+```bash
+./node_modules/.bin/tsx --test server/github.test.ts server/agentRunner.test.ts server/releaseManager.test.ts server/babysitter.test.ts server/storage.test.ts server/memoryStorage.test.ts
+```
+
+Expected: PASS
+
+**Step 2: Run typecheck**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS
+
+**Step 3: Run full server tests**
+
+Run:
+
+```bash
+node --test --import tsx server/*.test.ts
+```
+
+Expected: PASS
+
+**Step 4: Review diff for simplicity**
+
+Run:
+
+```bash
+git diff --stat
+```
+
+Expected: release feature touches only the server, shared types, storage, and UI surfaces needed for the feature.
+
+**Step 5: Commit**
+
+```bash
+git add .
+git commit -m "feat: automate release management for merged prs"
+```

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -120,6 +120,40 @@ function makeGitRunCommand(params?: {
   };
 }
 
+function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
+  return {
+    buildOctokit: async () => ({}) as never,
+    fetchFeedbackItemsForPR: async () => [],
+    fetchPullSummary: async () => {
+      throw new Error("unused");
+    },
+    fetchPullCloseState: async () => ({
+      number: 42,
+      title: "Example PR",
+      url: "https://github.com/octo/example/pull/42",
+      author: "octocat",
+      baseRef: "main",
+      headRef: "feature/example",
+      headSha: "head123",
+      merged: true,
+      mergedAt: "2026-03-28T12:00:00.000Z",
+      closedAt: "2026-03-28T12:00:00.000Z",
+      mergeCommitSha: "merge123",
+    }),
+    listFailingStatuses: async () => [],
+    checkCISettled: async () => true,
+    listOpenPullsForRepo: async () => [],
+    postFollowUpForFeedbackItem: async () => undefined,
+    resolveReviewThread: async () => undefined,
+    resolveGitHubAuthToken: async () => undefined,
+    addReactionToComment: async () => undefined,
+    postStatusReplyForFeedbackItem: async () => null,
+    updateStatusReply: async () => undefined,
+    postPRComment: async () => undefined,
+    ...overrides,
+  };
+}
+
 test("pollForCICompletion tolerates transient status API errors and eventually succeeds", async () => {
   const storage = new MemStorage();
   const logs: Array<{ level: "info" | "warn" | "error"; message: string }> = [];
@@ -297,6 +331,159 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
 
   assert.equal(updated.status, "watching");
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
+});
+
+test("syncAndBabysitTrackedRepos queues release evaluation for merged archived PRs", async () => {
+  const storage = new MemStorage();
+  const queued: Array<Record<string, string | number>> = [];
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService(),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    {
+      enqueueMergedPullReleaseEvaluation: async (input) => {
+        queued.push(input as Record<string, string | number>);
+      },
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(updated?.status, "archived");
+  assert.equal(queued.length, 1);
+  assert.equal(queued[0]?.triggerMergeSha, "merge123");
+  assert.ok(logs.some((log) => log.message.includes("queued release evaluation")));
+});
+
+test("syncAndBabysitTrackedRepos does not queue release evaluation for closed-unmerged PRs", async () => {
+  const storage = new MemStorage();
+  const queued: Array<Record<string, string | number>> = [];
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchPullCloseState: async () => ({
+        number: 42,
+        title: "Example PR",
+        url: "https://github.com/octo/example/pull/42",
+        author: "octocat",
+        baseRef: "main",
+        headRef: "feature/example",
+        headSha: "head123",
+        merged: false,
+        mergedAt: null,
+        closedAt: "2026-03-28T12:00:00.000Z",
+        mergeCommitSha: null,
+      }),
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    {
+      enqueueMergedPullReleaseEvaluation: async (input) => {
+        queued.push(input as Record<string, string | number>);
+      },
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(updated?.status, "archived");
+  assert.equal(queued.length, 0);
+  assert.ok(logs.some((log) => log.message.includes("closed without merge")));
+});
+
+test("syncAndBabysitTrackedRepos respects autoCreateReleases when a merged PR is archived", async () => {
+  const storage = new MemStorage();
+  const queued: Array<Record<string, string | number>> = [];
+  await storage.updateConfig({ autoCreateReleases: false });
+
+  await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService(),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    {
+      enqueueMergedPullReleaseEvaluation: async (input) => {
+        queued.push(input as Record<string, string | number>);
+      },
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  assert.equal(queued.length, 0);
 });
 
 test("babysitPR skips new runs while drain mode is enabled", async () => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -486,6 +486,68 @@ test("syncAndBabysitTrackedRepos respects autoCreateReleases when a merged PR is
   assert.equal(queued.length, 0);
 });
 
+test("syncAndBabysitTrackedRepos skips release evaluation when merged PR metadata is incomplete", async () => {
+  const storage = new MemStorage();
+  const queued: Array<Record<string, string | number>> = [];
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchPullCloseState: async () => ({
+        number: 42,
+        title: "Example PR",
+        url: "https://github.com/octo/example/pull/42",
+        author: "octocat",
+        baseRef: "",
+        headRef: "feature/example",
+        headSha: "",
+        merged: true,
+        mergedAt: null,
+        closedAt: null,
+        mergeCommitSha: null,
+      }),
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    {
+      enqueueMergedPullReleaseEvaluation: async (input) => {
+        queued.push(input as Record<string, string | number>);
+      },
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(queued.length, 0);
+  assert.ok(logs.some((log) => log.message.includes("release evaluation was not queued because GitHub did not return")));
+  assert.ok(logs.some((log) => log.message.includes("base branch")));
+  assert.ok(logs.some((log) => log.message.includes("merge SHA")));
+  assert.ok(logs.some((log) => log.message.includes("merge timestamp")));
+});
+
 test("babysitPR skips new runs while drain mode is enabled", async () => {
   const storage = new MemStorage();
   const pr = await storage.addPR({

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -544,7 +544,7 @@ test("syncAndBabysitTrackedRepos skips release evaluation when merged PR metadat
   assert.equal(queued.length, 0);
   assert.ok(logs.some((log) => log.message.includes("release evaluation was not queued because GitHub did not return")));
   assert.ok(logs.some((log) => log.message.includes("base branch")));
-  assert.ok(logs.some((log) => log.message.includes("merge SHA")));
+  assert.ok(logs.some((log) => log.message.includes("commit SHA")));
   assert.ok(logs.some((log) => log.message.includes("merge timestamp")));
 });
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -13,6 +13,7 @@ import {
   buildOctokit,
   checkCISettled,
   fetchFeedbackItemsForPR,
+  fetchPullCloseState,
   fetchPullSummary,
   formatRepoSlug,
   GitHubIntegrationError,
@@ -54,6 +55,7 @@ type GitHubService = {
   buildOctokit: typeof buildOctokit;
   checkCISettled: typeof checkCISettled;
   fetchFeedbackItemsForPR: typeof fetchFeedbackItemsForPR;
+  fetchPullCloseState?: typeof fetchPullCloseState;
   fetchPullSummary: typeof fetchPullSummary;
   listFailingStatuses: typeof listFailingStatuses;
   listMergedPullsToday?: typeof listMergedPullsToday; // optional — absent in test mocks
@@ -74,11 +76,24 @@ type BabysitterRuntime = {
   ciPollIntervalMs?: number;
 };
 
+type ReleaseManagerLike = {
+  enqueueMergedPullReleaseEvaluation(input: {
+    repo: string;
+    baseBranch: string;
+    triggerPrNumber: number;
+    triggerPrTitle: string;
+    triggerPrUrl: string;
+    triggerMergeSha: string;
+    triggerMergedAt: string;
+  }): Promise<unknown>;
+};
+
 const defaultGitHubService: GitHubService = {
   addReactionToComment,
   buildOctokit,
   checkCISettled,
   fetchFeedbackItemsForPR,
+  fetchPullCloseState,
   fetchPullSummary,
   listFailingStatuses,
   listMergedPullsToday,
@@ -542,15 +557,18 @@ export class PRBabysitter {
   private readonly feedbackMutationLocks = new Map<string, Promise<void>>();
   private readonly github: GitHubService;
   private readonly runtime: BabysitterRuntime;
+  private readonly releaseManager?: ReleaseManagerLike;
 
   constructor(
     storage: IStorage,
     github: GitHubService = defaultGitHubService,
     runtime: BabysitterRuntime = defaultBabysitterRuntime,
+    releaseManager?: ReleaseManagerLike,
   ) {
     this.storage = storage;
     this.github = github;
     this.runtime = runtime;
+    this.releaseManager = releaseManager;
   }
 
   getActiveRunCount(): number {
@@ -775,10 +793,61 @@ export class PRBabysitter {
       let hadNewlyArchived = false;
       for (const pr of trackedForRepo) {
         if (!openNumbers.has(pr.number) && pr.status !== "archived") {
+          let closeState:
+            | Awaited<ReturnType<NonNullable<GitHubService["fetchPullCloseState"]>>>
+            | undefined;
+          if (this.github.fetchPullCloseState) {
+            try {
+              closeState = await this.github.fetchPullCloseState(octokit, {
+                owner: repo.owner,
+                repo: repo.repo,
+                number: pr.number,
+              });
+            } catch (error) {
+              await this.storage.addLog(pr.id, "warn", `Could not confirm merge state before archival: ${summarizeUnknownError(error)}`, {
+                phase: "watcher",
+              });
+            }
+          }
+
           await this.storage.updatePR(pr.id, { status: "archived" });
           await this.storage.addLog(pr.id, "info", `PR #${pr.number} is no longer open on GitHub — archived`, {
             phase: "watcher",
           });
+
+          if (closeState?.merged && this.releaseManager && config.autoCreateReleases) {
+            const triggerMergeSha = closeState.mergeCommitSha || closeState.headSha || pr.branch;
+            const triggerMergedAt = closeState.mergedAt || closeState.closedAt || new Date().toISOString();
+
+            try {
+              await this.releaseManager.enqueueMergedPullReleaseEvaluation({
+                repo: repoSlug,
+                baseBranch: closeState.baseRef || "main",
+                triggerPrNumber: closeState.number,
+                triggerPrTitle: closeState.title,
+                triggerPrUrl: closeState.url,
+                triggerMergeSha,
+                triggerMergedAt,
+              });
+
+              await this.storage.addLog(pr.id, "info", `PR #${pr.number} was merged — queued release evaluation`, {
+                phase: "watcher",
+                metadata: {
+                  baseBranch: closeState.baseRef || "main",
+                  triggerMergeSha,
+                },
+              });
+            } catch (error) {
+              await this.storage.addLog(pr.id, "warn", `PR #${pr.number} was merged, but release evaluation could not be queued: ${summarizeUnknownError(error)}`, {
+                phase: "watcher",
+              });
+            }
+          } else if (closeState && !closeState.merged) {
+            await this.storage.addLog(pr.id, "info", `PR #${pr.number} closed without merge`, {
+              phase: "watcher",
+            });
+          }
+
           hadNewlyArchived = true;
         }
       }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -816,19 +816,19 @@ export class PRBabysitter {
           });
 
           if (closeState?.merged && this.releaseManager && config.autoCreateReleases) {
-            const baseBranch = closeState.baseRef;
+            const baseBranch = closeState.baseRef.trim();
             const triggerMergeSha = closeState.mergeCommitSha || closeState.headSha;
             const triggerMergedAt = closeState.mergedAt || closeState.closedAt;
             if (!baseBranch || !triggerMergeSha || !triggerMergedAt) {
               const missingReleaseMetadata = [
-                !baseBranch ? "base branch" : null,
-                !triggerMergeSha ? "merge SHA" : null,
-                !triggerMergedAt ? "merge timestamp" : null,
+                !baseBranch ? "a base branch" : null,
+                !triggerMergeSha ? "a commit SHA" : null,
+                !triggerMergedAt ? "a merge timestamp" : null,
               ].filter((value): value is string => Boolean(value));
               await this.storage.addLog(
                 pr.id,
                 "warn",
-                `PR #${pr.number} was merged, but release evaluation was not queued because GitHub did not return: ${missingReleaseMetadata.join(", ")}`,
+                `PR #${pr.number} was merged, but release evaluation was not queued because GitHub did not return ${missingReleaseMetadata.join(" and ")}.`,
                 {
                   phase: "watcher",
                   metadata: {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -816,31 +816,54 @@ export class PRBabysitter {
           });
 
           if (closeState?.merged && this.releaseManager && config.autoCreateReleases) {
-            const triggerMergeSha = closeState.mergeCommitSha || closeState.headSha || pr.branch;
-            const triggerMergedAt = closeState.mergedAt || closeState.closedAt || new Date().toISOString();
-
-            try {
-              await this.releaseManager.enqueueMergedPullReleaseEvaluation({
-                repo: repoSlug,
-                baseBranch: closeState.baseRef || "main",
-                triggerPrNumber: closeState.number,
-                triggerPrTitle: closeState.title,
-                triggerPrUrl: closeState.url,
-                triggerMergeSha,
-                triggerMergedAt,
-              });
-
-              await this.storage.addLog(pr.id, "info", `PR #${pr.number} was merged — queued release evaluation`, {
-                phase: "watcher",
-                metadata: {
-                  baseBranch: closeState.baseRef || "main",
-                  triggerMergeSha,
+            const baseBranch = closeState.baseRef;
+            const triggerMergeSha = closeState.mergeCommitSha || closeState.headSha;
+            const triggerMergedAt = closeState.mergedAt || closeState.closedAt;
+            if (!baseBranch || !triggerMergeSha || !triggerMergedAt) {
+              const missingReleaseMetadata = [
+                !baseBranch ? "base branch" : null,
+                !triggerMergeSha ? "merge SHA" : null,
+                !triggerMergedAt ? "merge timestamp" : null,
+              ].filter((value): value is string => Boolean(value));
+              await this.storage.addLog(
+                pr.id,
+                "warn",
+                `PR #${pr.number} was merged, but release evaluation was not queued because GitHub did not return: ${missingReleaseMetadata.join(", ")}`,
+                {
+                  phase: "watcher",
+                  metadata: {
+                    baseBranch,
+                    headSha: closeState.headSha,
+                    mergeCommitSha: closeState.mergeCommitSha,
+                    mergedAt: closeState.mergedAt,
+                    closedAt: closeState.closedAt,
+                  },
                 },
-              });
-            } catch (error) {
-              await this.storage.addLog(pr.id, "warn", `PR #${pr.number} was merged, but release evaluation could not be queued: ${summarizeUnknownError(error)}`, {
-                phase: "watcher",
-              });
+              );
+            } else {
+              try {
+                await this.releaseManager.enqueueMergedPullReleaseEvaluation({
+                  repo: repoSlug,
+                  baseBranch,
+                  triggerPrNumber: closeState.number,
+                  triggerPrTitle: closeState.title,
+                  triggerPrUrl: closeState.url,
+                  triggerMergeSha,
+                  triggerMergedAt,
+                });
+
+                await this.storage.addLog(pr.id, "info", `PR #${pr.number} was merged — queued release evaluation`, {
+                  phase: "watcher",
+                  metadata: {
+                    baseBranch,
+                    triggerMergeSha,
+                  },
+                });
+              } catch (error) {
+                await this.storage.addLog(pr.id, "warn", `PR #${pr.number} was merged, but release evaluation could not be queued: ${summarizeUnknownError(error)}`, {
+                  phase: "watcher",
+                });
+              }
             }
           } else if (closeState && !closeState.merged) {
             await this.storage.addLog(pr.id, "info", `PR #${pr.number} closed without merge`, {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIG: Config = {
   pollIntervalMs: 120000,
   maxChangesPerRun: 20,
   autoResolveMergeConflicts: true,
+  autoCreateReleases: true,
   watchedRepos: [],
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -5,13 +5,22 @@ import {
   GitHubIntegrationError,
   buildFeedbackAuditToken,
   checkOnboardingStatus,
+  createGitHubRelease,
   fetchFeedbackItemsForPR,
+  fetchPullCloseState,
   formatRepoSlug,
+  getLatestSemverTagForRepo,
+  listMergedPullsSince,
+  listReleasesForRepo,
+  listTagsForRepo,
+  listUnreleasedMergedPulls,
   parsePRUrl,
   parseRepoSlug,
   postFollowUpForFeedbackItem,
   postStatusReplyForFeedbackItem,
+  resolveNextSemverTag,
   resolveReviewThread,
+  selectLatestSemverTag,
   updateStatusReply,
 } from "./github";
 
@@ -795,6 +804,370 @@ test("postStatusReplyForFeedbackItem rejects malformed review-thread reply paylo
       return true;
     },
   );
+});
+
+test("fetchPullCloseState returns merged close metadata", async () => {
+  const octokit = {
+    pulls: {
+      get: async () => ({
+        data: {
+          number: 123,
+          title: "Ship release automation",
+          html_url: "https://github.com/octo/example/pull/123",
+          user: { login: "alice" },
+          base: { ref: "main" },
+          head: { ref: "feature/releases", sha: "head123" },
+          merged_at: "2026-03-28T10:00:00Z",
+          closed_at: "2026-03-28T10:01:00Z",
+          merge_commit_sha: "merge123",
+        },
+      }),
+    },
+  };
+
+  const state = await fetchPullCloseState(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 123 },
+  );
+
+  assert.deepEqual(state, {
+    number: 123,
+    title: "Ship release automation",
+    url: "https://github.com/octo/example/pull/123",
+    author: "alice",
+    baseRef: "main",
+    headRef: "feature/releases",
+    headSha: "head123",
+    merged: true,
+    mergedAt: "2026-03-28T10:00:00Z",
+    closedAt: "2026-03-28T10:01:00Z",
+    mergeCommitSha: "merge123",
+  });
+});
+
+test("selectLatestSemverTag picks highest semver and ignores non-semver tags", () => {
+  const tag = selectLatestSemverTag([
+    "build-42",
+    "v1.9.9",
+    "2.0.0",
+    "release-candidate",
+    "v1.10.0",
+  ]);
+
+  assert.equal(tag, "2.0.0");
+});
+
+test("resolveNextSemverTag bumps patch/minor/major and defaults from empty baseline", () => {
+  assert.equal(resolveNextSemverTag("v1.2.3", "patch"), "v1.2.4");
+  assert.equal(resolveNextSemverTag("v1.2.3", "minor"), "v1.3.0");
+  assert.equal(resolveNextSemverTag("v1.2.3", "major"), "v2.0.0");
+  assert.equal(resolveNextSemverTag(null, "patch"), "v0.0.1");
+});
+
+test("resolveNextSemverTag rejects invalid latest tags", () => {
+  assert.throws(
+    () => resolveNextSemverTag("release-2026-03-28", "minor"),
+    /Cannot calculate next semver tag from invalid tag/,
+  );
+});
+
+test("listReleasesForRepo maps repository releases", async () => {
+  const listReleases = Symbol("listReleases");
+  const octokit = {
+    paginate: async (method: symbol) => {
+      assert.equal(method, listReleases);
+      return [
+        {
+          id: 10,
+          tag_name: "v1.2.0",
+          name: "Release v1.2.0",
+          body: "Notes",
+          html_url: "https://github.com/octo/example/releases/tag/v1.2.0",
+          url: "https://api.github.com/repos/octo/example/releases/10",
+          draft: false,
+          prerelease: false,
+          target_commitish: "main",
+          published_at: "2026-03-27T00:00:00Z",
+        },
+      ];
+    },
+    repos: {
+      listReleases,
+    },
+  };
+
+  const releases = await listReleasesForRepo(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+  );
+
+  assert.equal(releases.length, 1);
+  assert.deepEqual(releases[0], {
+    id: 10,
+    tagName: "v1.2.0",
+    name: "Release v1.2.0",
+    body: "Notes",
+    htmlUrl: "https://github.com/octo/example/releases/tag/v1.2.0",
+    apiUrl: "https://api.github.com/repos/octo/example/releases/10",
+    draft: false,
+    prerelease: false,
+    targetCommitish: "main",
+    publishedAt: "2026-03-27T00:00:00Z",
+  });
+});
+
+test("listTagsForRepo maps repository tags", async () => {
+  const listTags = Symbol("listTags");
+  const octokit = {
+    paginate: async (method: symbol) => {
+      assert.equal(method, listTags);
+      return [
+        { name: "v1.2.0", commit: { sha: "abc123" } },
+        { name: "v1.1.0", commit: { sha: "def456" } },
+      ];
+    },
+    repos: {
+      listTags,
+    },
+  };
+
+  const tags = await listTagsForRepo(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+  );
+
+  assert.deepEqual(tags, [
+    { name: "v1.2.0", commitSha: "abc123" },
+    { name: "v1.1.0", commitSha: "def456" },
+  ]);
+});
+
+test("getLatestSemverTagForRepo considers releases and tags", async () => {
+  const listReleases = Symbol("listReleases");
+  const listTags = Symbol("listTags");
+
+  const octokit = {
+    paginate: async (method: symbol) => {
+      if (method === listReleases) {
+        return [
+          {
+            id: 10,
+            tag_name: "v1.2.0",
+            name: "Release v1.2.0",
+            body: null,
+            html_url: "https://github.com/octo/example/releases/tag/v1.2.0",
+            url: "https://api.github.com/repos/octo/example/releases/10",
+            draft: false,
+            prerelease: false,
+            target_commitish: "main",
+            published_at: "2026-03-27T00:00:00Z",
+          },
+        ];
+      }
+
+      if (method === listTags) {
+        return [
+          { name: "v1.3.0", commit: { sha: "tag123" } },
+        ];
+      }
+
+      throw new Error("unexpected paginate method");
+    },
+    repos: {
+      listReleases,
+      listTags,
+    },
+  };
+
+  const latest = await getLatestSemverTagForRepo(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+  );
+
+  assert.equal(latest, "v1.3.0");
+});
+
+test("createGitHubRelease calls GitHub API with release payload", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const octokit = {
+    repos: {
+      createRelease: async (params: Record<string, unknown>) => {
+        calls.push(params);
+        return {
+          data: {
+            id: 99,
+            tag_name: "v2.0.0",
+            name: "v2.0.0",
+            body: "Release notes",
+            html_url: "https://github.com/octo/example/releases/tag/v2.0.0",
+            url: "https://api.github.com/repos/octo/example/releases/99",
+            draft: false,
+            prerelease: false,
+            target_commitish: "abc123",
+            published_at: "2026-03-28T10:00:00Z",
+          },
+        };
+      },
+    },
+  };
+
+  const created = await createGitHubRelease(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+    {
+      tagName: "v2.0.0",
+      name: "v2.0.0",
+      body: "Release notes",
+      targetCommitish: "abc123",
+      generateReleaseNotes: true,
+    },
+  );
+
+  assert.deepEqual(calls, [
+    {
+      owner: "octo",
+      repo: "example",
+      tag_name: "v2.0.0",
+      name: "v2.0.0",
+      body: "Release notes",
+      target_commitish: "abc123",
+      draft: false,
+      prerelease: false,
+      generate_release_notes: true,
+    },
+  ]);
+
+  assert.deepEqual(created, {
+    id: 99,
+    tagName: "v2.0.0",
+    name: "v2.0.0",
+    body: "Release notes",
+    htmlUrl: "https://github.com/octo/example/releases/tag/v2.0.0",
+    apiUrl: "https://api.github.com/repos/octo/example/releases/99",
+    draft: false,
+    prerelease: false,
+    targetCommitish: "abc123",
+    publishedAt: "2026-03-28T10:00:00Z",
+  });
+});
+
+test("listMergedPullsSince applies timestamp and merge-sha boundaries", async () => {
+  const listPulls = Symbol("listPulls");
+  const octokit = {
+    paginate: async (method: symbol) => {
+      assert.equal(method, listPulls);
+      return [
+        {
+          number: 30,
+          title: "latest",
+          html_url: "https://github.com/octo/example/pull/30",
+          user: { login: "a" },
+          merged_at: "2026-03-28T12:00:00Z",
+          merge_commit_sha: "sha-30",
+        },
+        {
+          number: 20,
+          title: "boundary",
+          html_url: "https://github.com/octo/example/pull/20",
+          user: { login: "b" },
+          merged_at: "2026-03-28T11:00:00Z",
+          merge_commit_sha: "sha-20",
+        },
+        {
+          number: 10,
+          title: "old",
+          html_url: "https://github.com/octo/example/pull/10",
+          user: { login: "c" },
+          merged_at: "2026-03-28T10:00:00Z",
+          merge_commit_sha: "sha-10",
+        },
+      ];
+    },
+    pulls: {
+      list: listPulls,
+    },
+  };
+
+  const merged = await listMergedPullsSince(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+    {
+      baseRef: "main",
+      sinceMergedAt: "2026-03-28T10:30:00Z",
+      sinceMergeCommitSha: "sha-20",
+    },
+  );
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0]?.number, 30);
+  assert.equal(merged[0]?.mergeCommitSha, "sha-30");
+});
+
+test("listUnreleasedMergedPulls uses latest published release when no explicit boundary is provided", async () => {
+  const listReleases = Symbol("listReleases");
+  const listPulls = Symbol("listPulls");
+  const paginateCalls: symbol[] = [];
+
+  const octokit = {
+    paginate: async (method: symbol) => {
+      paginateCalls.push(method);
+
+      if (method === listReleases) {
+        return [
+          {
+            id: 1,
+            tag_name: "v1.0.0",
+            name: "v1.0.0",
+            body: null,
+            html_url: "https://github.com/octo/example/releases/tag/v1.0.0",
+            url: "https://api.github.com/repos/octo/example/releases/1",
+            draft: false,
+            prerelease: false,
+            target_commitish: "main",
+            published_at: "2026-03-28T11:00:00Z",
+          },
+        ];
+      }
+
+      if (method === listPulls) {
+        return [
+          {
+            number: 50,
+            title: "new",
+            html_url: "https://github.com/octo/example/pull/50",
+            user: { login: "a" },
+            merged_at: "2026-03-28T12:00:00Z",
+            merge_commit_sha: "sha-50",
+          },
+          {
+            number: 40,
+            title: "old",
+            html_url: "https://github.com/octo/example/pull/40",
+            user: { login: "b" },
+            merged_at: "2026-03-28T10:00:00Z",
+            merge_commit_sha: "sha-40",
+          },
+        ];
+      }
+
+      throw new Error("unexpected paginate method");
+    },
+    repos: {
+      listReleases,
+    },
+    pulls: {
+      list: listPulls,
+    },
+  };
+
+  const merged = await listUnreleasedMergedPulls(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+  );
+
+  assert.deepEqual(paginateCalls, [listReleases, listPulls]);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0]?.number, 50);
 });
 
 // ---------------------------------------------------------------------------

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -1175,6 +1175,40 @@ test("listMergedPullsSince applies timestamp and merge-sha boundaries", async ()
   assert.equal(merged[0]?.mergeCommitSha, "sha-30");
 });
 
+test("listMergedPullsSince uses the repository default branch when none is provided", async () => {
+  const listPulls = Symbol("listPulls");
+  let repoLookups = 0;
+
+  const octokit = {
+    paginate: async (method: symbol, params: { base: string }) => {
+      assert.equal(method, listPulls);
+      assert.equal(params.base, "develop");
+      return [];
+    },
+    pulls: {
+      list: listPulls,
+    },
+    repos: {
+      get: async () => {
+        repoLookups += 1;
+        return {
+          data: {
+            default_branch: "develop",
+          },
+        };
+      },
+    },
+  };
+
+  const merged = await listMergedPullsSince(
+    octokit as never,
+    { owner: "octo", repo: "example" },
+  );
+
+  assert.deepEqual(merged, []);
+  assert.equal(repoLookups, 1);
+});
+
 test("listUnreleasedMergedPulls uses latest published release when no explicit boundary is provided", async () => {
   const listReleases = Symbol("listReleases");
   const listPulls = Symbol("listPulls");
@@ -1225,6 +1259,11 @@ test("listUnreleasedMergedPulls uses latest published release when no explicit b
       throw new Error("unexpected paginate method");
     },
     repos: {
+      get: async () => ({
+        data: {
+          default_branch: "develop",
+        },
+      }),
       listReleases,
     },
     pulls: {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -8,6 +8,7 @@ import {
   createGitHubRelease,
   fetchFeedbackItemsForPR,
   fetchPullCloseState,
+  fetchPullSummary,
   formatRepoSlug,
   getLatestSemverTagForRepo,
   listMergedPullsSince,
@@ -843,6 +844,77 @@ test("fetchPullCloseState returns merged close metadata", async () => {
     closedAt: "2026-03-28T10:01:00Z",
     mergeCommitSha: "merge123",
   });
+});
+
+test("fetchPullSummary falls back to the repo default branch when the base ref is missing", async () => {
+  const octokit = {
+    pulls: {
+      get: async () => ({
+        data: {
+          number: 124,
+          title: "Prepare release branch handling",
+          html_url: "https://github.com/octo/example/pull/124",
+          user: { login: "alice" },
+          base: {
+            ref: null,
+            repo: {
+              full_name: "octo/example",
+              clone_url: "https://github.com/octo/example.git",
+              default_branch: "develop",
+            },
+          },
+          head: {
+            ref: "feature/releases",
+            sha: "head124",
+            repo: {
+              full_name: "octo/example",
+              clone_url: "https://github.com/octo/example.git",
+            },
+          },
+          mergeable: true,
+        },
+      }),
+    },
+  };
+
+  const summary = await fetchPullSummary(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 124 },
+  );
+
+  assert.equal(summary.baseRef, "develop");
+});
+
+test("fetchPullCloseState falls back to the repo default branch when the base ref is missing", async () => {
+  const octokit = {
+    pulls: {
+      get: async () => ({
+        data: {
+          number: 125,
+          title: "Prepare release branch handling",
+          html_url: "https://github.com/octo/example/pull/125",
+          user: { login: "alice" },
+          base: {
+            ref: null,
+            repo: {
+              default_branch: "develop",
+            },
+          },
+          head: { ref: "feature/releases", sha: "head125" },
+          merged_at: "2026-03-28T10:00:00Z",
+          closed_at: "2026-03-28T10:01:00Z",
+          merge_commit_sha: "merge125",
+        },
+      }),
+    },
+  };
+
+  const state = await fetchPullCloseState(
+    octokit as never,
+    { owner: "octo", repo: "example", number: 125 },
+  );
+
+  assert.equal(state.baseRef, "develop");
 });
 
 test("selectLatestSemverTag picks highest semver and ignores non-semver tags", () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -37,6 +37,48 @@ export type GitHubStatusFailure = {
   targetUrl: string | null;
 };
 
+export type GitHubPullCloseState = {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  baseRef: string;
+  headRef: string;
+  headSha: string;
+  merged: boolean;
+  mergedAt: string | null;
+  closedAt: string | null;
+  mergeCommitSha: string | null;
+};
+
+export type ReleaseBump = "patch" | "minor" | "major";
+
+export type SemverVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+export type GitHubReleaseSummary = {
+  id: number;
+  tagName: string;
+  name: string;
+  body: string | null;
+  htmlUrl: string;
+  apiUrl: string;
+  draft: boolean;
+  prerelease: boolean;
+  targetCommitish: string | null;
+  publishedAt: string | null;
+};
+
+export type GitHubRepoTag = {
+  name: string;
+  commitSha: string | null;
+};
+
+const SEMVER_TAG_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
 const GITHUB_API_VERSION = "2022-11-28";
 const GH_AUTH_CACHE_TTL_MS = 15000;
 const REVIEW_THREADS_QUERY = `
@@ -579,6 +621,214 @@ export async function fetchPullSummary(
     headRepoCloneUrl: pull.head?.repo?.clone_url || `https://github.com/${parsed.owner}/${parsed.repo}.git`,
     baseRef: pull.base?.ref || "main",
     mergeable: typeof pull.mergeable === "boolean" ? pull.mergeable : null,
+  };
+}
+
+export async function fetchPullCloseState(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+): Promise<GitHubPullCloseState> {
+  const response = await withGitHubErrorHandling("PR close state", parsed, () =>
+    octokit.pulls.get({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      pull_number: parsed.number,
+    }),
+  );
+
+  const pull = response.data;
+
+  return {
+    number: pull.number,
+    title: pull.title || `PR #${pull.number}`,
+    url: pull.html_url || `https://github.com/${parsed.owner}/${parsed.repo}/pull/${pull.number}`,
+    author: pull.user?.login || "unknown",
+    baseRef: pull.base?.ref || "main",
+    headRef: pull.head?.ref || "",
+    headSha: pull.head?.sha || "",
+    merged: Boolean(pull.merged_at),
+    mergedAt: pull.merged_at || null,
+    closedAt: pull.closed_at || null,
+    mergeCommitSha: pull.merge_commit_sha || null,
+  };
+}
+
+export function parseSemverTag(tagName: string): SemverVersion | null {
+  const match = tagName.trim().match(SEMVER_TAG_PATTERN);
+  if (!match) return null;
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+  };
+}
+
+function compareSemver(a: SemverVersion, b: SemverVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+function formatSemverTag(version: SemverVersion): string {
+  return `v${version.major}.${version.minor}.${version.patch}`;
+}
+
+export function selectLatestSemverTag(tagNames: string[]): string | null {
+  let winner: { tag: string; version: SemverVersion } | null = null;
+
+  for (const tag of tagNames) {
+    const parsed = parseSemverTag(tag);
+    if (!parsed) continue;
+
+    if (!winner || compareSemver(parsed, winner.version) > 0) {
+      winner = { tag, version: parsed };
+    }
+  }
+
+  return winner?.tag ?? null;
+}
+
+export function resolveNextSemverTag(
+  latestTag: string | null | undefined,
+  bump: ReleaseBump,
+): string {
+  const current = latestTag
+    ? parseSemverTag(latestTag)
+    : { major: 0, minor: 0, patch: 0 };
+
+  if (!current) {
+    throw new GitHubIntegrationError(`Cannot calculate next semver tag from invalid tag: ${latestTag}`, 400);
+  }
+
+  const next: SemverVersion = {
+    major: current.major,
+    minor: current.minor,
+    patch: current.patch,
+  };
+
+  if (bump === "major") {
+    next.major += 1;
+    next.minor = 0;
+    next.patch = 0;
+  } else if (bump === "minor") {
+    next.minor += 1;
+    next.patch = 0;
+  } else {
+    next.patch += 1;
+  }
+
+  return formatSemverTag(next);
+}
+
+function parseDateMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export async function listReleasesForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<GitHubReleaseSummary[]> {
+  const releases = await withGitHubErrorHandling("repository releases", repo, () =>
+    octokit.paginate(octokit.repos.listReleases, {
+      owner: repo.owner,
+      repo: repo.repo,
+      per_page: 100,
+    }),
+  );
+
+  return releases.map((release) => ({
+    id: release.id,
+    tagName: release.tag_name || "",
+    name: release.name || release.tag_name || `Release ${release.id}`,
+    body: release.body || null,
+    htmlUrl: release.html_url || "",
+    apiUrl: release.url || "",
+    draft: Boolean(release.draft),
+    prerelease: Boolean(release.prerelease),
+    targetCommitish: release.target_commitish || null,
+    publishedAt: release.published_at || null,
+  }));
+}
+
+export async function listTagsForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<GitHubRepoTag[]> {
+  const tags = await withGitHubErrorHandling("repository tags", repo, () =>
+    octokit.paginate(octokit.repos.listTags, {
+      owner: repo.owner,
+      repo: repo.repo,
+      per_page: 100,
+    }),
+  );
+
+  return tags.map((tag) => ({
+    name: tag.name,
+    commitSha: tag.commit?.sha || null,
+  }));
+}
+
+export async function getLatestSemverTagForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<string | null> {
+  const [releases, tags] = await Promise.all([
+    listReleasesForRepo(octokit, repo),
+    listTagsForRepo(octokit, repo),
+  ]);
+
+  const candidates = [
+    ...releases
+      .filter((release) => !release.draft)
+      .map((release) => release.tagName),
+    ...tags.map((tag) => tag.name),
+  ];
+
+  return selectLatestSemverTag(candidates);
+}
+
+export async function createGitHubRelease(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  input: {
+    tagName: string;
+    name: string;
+    body: string;
+    targetCommitish?: string | null;
+    draft?: boolean;
+    prerelease?: boolean;
+    generateReleaseNotes?: boolean;
+  },
+): Promise<GitHubReleaseSummary> {
+  const response = await withGitHubErrorHandling("release creation", repo, () =>
+    octokit.repos.createRelease({
+      owner: repo.owner,
+      repo: repo.repo,
+      tag_name: input.tagName,
+      name: input.name,
+      body: input.body,
+      target_commitish: input.targetCommitish ?? undefined,
+      draft: input.draft ?? false,
+      prerelease: input.prerelease ?? false,
+      generate_release_notes: input.generateReleaseNotes ?? false,
+    }),
+  );
+
+  const release = response.data;
+  return {
+    id: release.id,
+    tagName: release.tag_name || input.tagName,
+    name: release.name || input.name,
+    body: release.body || null,
+    htmlUrl: release.html_url || "",
+    apiUrl: release.url || "",
+    draft: Boolean(release.draft),
+    prerelease: Boolean(release.prerelease),
+    targetCommitish: release.target_commitish || null,
+    publishedAt: release.published_at || null,
   };
 }
 
@@ -1216,19 +1466,46 @@ export type MergedPRSummary = {
   url: string;
   author: string;
   repo: string;
+  mergedAt: string;
+  mergeCommitSha: string | null;
 };
 
-/**
- * Returns pull requests that were merged to the given base branch today (UTC).
- * Used to determine whether the social changelog trigger threshold has been reached.
- */
-export async function listMergedPullsToday(
+function normalizeMergedPullSummary(
+  pull: {
+    number: number;
+    title: string | null;
+    html_url: string | null;
+    user?: { login?: string | null } | null;
+    merged_at: string | null;
+    merge_commit_sha?: string | null;
+  },
+  repo: ParsedRepoSlug,
+): MergedPRSummary | null {
+  if (!pull.merged_at) return null;
+
+  return {
+    number: pull.number,
+    title: pull.title || `PR #${pull.number}`,
+    url: pull.html_url || `https://github.com/${repo.owner}/${repo.repo}/pull/${pull.number}`,
+    author: pull.user?.login ?? "unknown",
+    repo: formatRepoSlug(repo),
+    mergedAt: pull.merged_at,
+    mergeCommitSha: pull.merge_commit_sha || null,
+  };
+}
+
+export async function listMergedPullsSince(
   octokit: Octokit,
   repo: ParsedRepoSlug,
-  baseRef = "main",
+  options?: {
+    baseRef?: string;
+    sinceMergedAt?: string | null;
+    sinceMergeCommitSha?: string | null;
+  },
 ): Promise<MergedPRSummary[]> {
-  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const repoSlug = formatRepoSlug(repo);
+  const baseRef = options?.baseRef ?? "main";
+  const sinceMergedAtMs = parseDateMs(options?.sinceMergedAt);
+  const sinceMergeCommitSha = options?.sinceMergeCommitSha?.trim() || null;
 
   const pulls = await withGitHubErrorHandling("merged pull requests", repo, () =>
     octokit.paginate(octokit.pulls.list, {
@@ -1242,13 +1519,63 @@ export async function listMergedPullsToday(
     }),
   );
 
-  return pulls
-    .filter((p) => p.merged_at != null && p.merged_at.startsWith(today))
-    .map((p) => ({
-      number: p.number,
-      title: p.title || `PR #${p.number}`,
-      url: p.html_url || `https://github.com/${repo.owner}/${repo.repo}/pull/${p.number}`,
-      author: p.user?.login ?? "unknown",
-      repo: repoSlug,
-    }));
+  const merged = pulls
+    .map((pull) => normalizeMergedPullSummary(pull, repo))
+    .filter((pull): pull is MergedPRSummary => Boolean(pull))
+    .filter((pull) => {
+      if (sinceMergedAtMs === null) return true;
+      return Date.parse(pull.mergedAt) > sinceMergedAtMs;
+    });
+
+  let boundedBySha = merged;
+  if (sinceMergeCommitSha) {
+    const boundaryIndex = merged.findIndex((pull) => pull.mergeCommitSha === sinceMergeCommitSha);
+    if (boundaryIndex >= 0) {
+      boundedBySha = merged.slice(0, boundaryIndex);
+    }
+  }
+
+  return boundedBySha.sort((a, b) => Date.parse(a.mergedAt) - Date.parse(b.mergedAt));
+}
+
+export async function listUnreleasedMergedPulls(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  options?: {
+    baseRef?: string;
+    sinceMergedAt?: string | null;
+    sinceMergeCommitSha?: string | null;
+  },
+): Promise<MergedPRSummary[]> {
+  let boundaryMergedAt = options?.sinceMergedAt ?? null;
+  let boundaryMergeCommitSha = options?.sinceMergeCommitSha ?? null;
+
+  if (!boundaryMergedAt && !boundaryMergeCommitSha) {
+    const releases = await listReleasesForRepo(octokit, repo);
+    const latestPublished = releases
+      .filter((release) => !release.draft && release.publishedAt)
+      .sort((a, b) => Date.parse(b.publishedAt || "") - Date.parse(a.publishedAt || ""))[0];
+
+    boundaryMergedAt = latestPublished?.publishedAt ?? null;
+  }
+
+  return listMergedPullsSince(octokit, repo, {
+    baseRef: options?.baseRef,
+    sinceMergedAt: boundaryMergedAt,
+    sinceMergeCommitSha: boundaryMergeCommitSha,
+  });
+}
+
+/**
+ * Returns pull requests that were merged to the given base branch today (UTC).
+ * Used to determine whether the social changelog trigger threshold has been reached.
+ */
+export async function listMergedPullsToday(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  baseRef = "main",
+): Promise<MergedPRSummary[]> {
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const pulls = await listMergedPullsSince(octokit, repo, { baseRef });
+  return pulls.filter((pull) => pull.mergedAt.startsWith(today));
 }

--- a/server/github.ts
+++ b/server/github.ts
@@ -606,6 +606,7 @@ export async function fetchPullSummary(
   );
 
   const pull = response.data;
+  const baseRef = pull.base?.ref || pull.base?.repo?.default_branch || "";
 
   return {
     number: pull.number,
@@ -619,7 +620,7 @@ export async function fetchPullSummary(
     headRef: pull.head?.ref || "",
     headRepoFullName: pull.head?.repo?.full_name || `${parsed.owner}/${parsed.repo}`,
     headRepoCloneUrl: pull.head?.repo?.clone_url || `https://github.com/${parsed.owner}/${parsed.repo}.git`,
-    baseRef: pull.base?.ref || "main",
+    baseRef,
     mergeable: typeof pull.mergeable === "boolean" ? pull.mergeable : null,
   };
 }
@@ -637,13 +638,14 @@ export async function fetchPullCloseState(
   );
 
   const pull = response.data;
+  const baseRef = pull.base?.ref || pull.base?.repo?.default_branch || "";
 
   return {
     number: pull.number,
     title: pull.title || `PR #${pull.number}`,
     url: pull.html_url || `https://github.com/${parsed.owner}/${parsed.repo}/pull/${pull.number}`,
     author: pull.user?.login || "unknown",
-    baseRef: pull.base?.ref || "main",
+    baseRef,
     headRef: pull.head?.ref || "",
     headSha: pull.head?.sha || "",
     merged: Boolean(pull.merged_at),
@@ -725,6 +727,25 @@ function parseDateMs(value: string | null | undefined): number | null {
   if (!value) return null;
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+async function getDefaultBranchForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<string> {
+  const response = await withGitHubErrorHandling("repository metadata", repo, () =>
+    octokit.repos.get({
+      owner: repo.owner,
+      repo: repo.repo,
+    }),
+  );
+
+  const defaultBranch = response.data.default_branch?.trim();
+  if (!defaultBranch) {
+    throw new GitHubIntegrationError(`GitHub did not return a default branch for ${formatRepoSlug(repo)}`, 502);
+  }
+
+  return defaultBranch;
 }
 
 export async function listReleasesForRepo(
@@ -1237,7 +1258,7 @@ export async function listOpenPullsForRepo(
     headRef: pull.head?.ref || "",
     headRepoFullName: pull.head?.repo?.full_name || `${repo.owner}/${repo.repo}`,
     headRepoCloneUrl: pull.head?.repo?.clone_url || `https://github.com/${repo.owner}/${repo.repo}.git`,
-    baseRef: pull.base?.ref || "main",
+    baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
     mergeable: null,
   }));
 }
@@ -1503,7 +1524,7 @@ export async function listMergedPullsSince(
     sinceMergeCommitSha?: string | null;
   },
 ): Promise<MergedPRSummary[]> {
-  const baseRef = options?.baseRef ?? "main";
+  const baseRef = options?.baseRef?.trim() || await getDefaultBranchForRepo(octokit, repo);
   const sinceMergedAtMs = parseDateMs(options?.sinceMergedAt);
   const sinceMergeCommitSha = options?.sinceMergeCommitSha?.trim() || null;
 
@@ -1548,7 +1569,7 @@ export async function listUnreleasedMergedPulls(
   },
 ): Promise<MergedPRSummary[]> {
   let boundaryMergedAt = options?.sinceMergedAt ?? null;
-  let boundaryMergeCommitSha = options?.sinceMergeCommitSha ?? null;
+  const boundaryMergeCommitSha = options?.sinceMergeCommitSha ?? null;
 
   if (!boundaryMergedAt && !boundaryMergeCommitSha) {
     const releases = await listReleasesForRepo(octokit, repo);
@@ -1573,9 +1594,15 @@ export async function listUnreleasedMergedPulls(
 export async function listMergedPullsToday(
   octokit: Octokit,
   repo: ParsedRepoSlug,
-  baseRef = "main",
+  baseRef?: string,
 ): Promise<MergedPRSummary[]> {
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const pulls = await listMergedPullsSince(octokit, repo, { baseRef });
+  const pulls = await listMergedPullsSince(
+    octokit,
+    repo,
+    baseRef
+      ? { baseRef }
+      : undefined,
+  );
   return pulls.filter((pull) => pull.mergedAt.startsWith(today));
 }

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -328,6 +328,7 @@ describe("MemStorage", () => {
       const config = await storage.getConfig();
       assert.equal(config.codingAgent, DEFAULT_CONFIG.codingAgent);
       assert.equal(config.maxTurns, DEFAULT_CONFIG.maxTurns);
+      assert.equal(config.autoCreateReleases, DEFAULT_CONFIG.autoCreateReleases);
       assert.deepEqual(config.watchedRepos, []);
     });
   });
@@ -338,12 +339,194 @@ describe("MemStorage", () => {
       assert.equal(updated.maxTurns, 25);
       // Other fields preserved
       assert.equal(updated.codingAgent, "claude");
+      assert.equal(updated.autoCreateReleases, true);
     });
 
     it("returns the updated config", async () => {
       const updated = await storage.updateConfig({ githubToken: "tok_123" });
       const fetched = await storage.getConfig();
       assert.deepEqual(updated, fetched);
+    });
+  });
+
+  // ── ReleaseRuns ─────────────────────────────────────────
+
+  describe("createReleaseRun/getReleaseRun", () => {
+    it("creates a release run and looks it up by id", async () => {
+      const run = await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 42,
+        triggerPrTitle: "Ship feature",
+        triggerPrUrl: "https://github.com/owner/repo/pull/42",
+        triggerMergeSha: "abc123",
+        triggerMergedAt: "2026-03-28T12:00:00.000Z",
+        status: "detected",
+        decisionReason: null,
+        recommendedBump: null,
+        proposedVersion: null,
+        releaseTitle: null,
+        releaseNotes: null,
+        includedPrs: [],
+        targetSha: null,
+        githubReleaseId: null,
+        githubReleaseUrl: null,
+        error: null,
+        completedAt: null,
+      });
+
+      const fetched = await storage.getReleaseRun(run.id);
+      assert.ok(fetched);
+      assert.equal(fetched.id, run.id);
+      assert.equal(fetched.repo, "owner/repo");
+    });
+
+    it("updates an existing release run", async () => {
+      const run = await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 43,
+        triggerPrTitle: "Update status",
+        triggerPrUrl: "https://github.com/owner/repo/pull/43",
+        triggerMergeSha: "merge-sha-43",
+        triggerMergedAt: "2026-03-28T12:00:00.000Z",
+        status: "detected",
+        decisionReason: null,
+        recommendedBump: null,
+        proposedVersion: null,
+        releaseTitle: null,
+        releaseNotes: null,
+        includedPrs: [],
+        targetSha: null,
+        githubReleaseId: null,
+        githubReleaseUrl: null,
+        error: null,
+        completedAt: null,
+      });
+
+      const updated = await storage.updateReleaseRun(run.id, {
+        status: "published",
+        recommendedBump: "patch",
+        proposedVersion: "v1.0.1",
+        completedAt: "2026-03-28T12:10:00.000Z",
+      });
+
+      assert.equal(updated?.status, "published");
+      assert.equal(updated?.proposedVersion, "v1.0.1");
+      assert.equal(updated?.completedAt, "2026-03-28T12:10:00.000Z");
+    });
+  });
+
+  describe("release run idempotent lookups", () => {
+    it("looks up by repo + triggerMergeSha", async () => {
+      const run = await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 8,
+        triggerPrTitle: "Test",
+        triggerPrUrl: "https://github.com/owner/repo/pull/8",
+        triggerMergeSha: "merge-sha-8",
+        triggerMergedAt: "2026-03-28T12:00:00.000Z",
+        status: "detected",
+        decisionReason: null,
+        recommendedBump: null,
+        proposedVersion: null,
+        releaseTitle: null,
+        releaseNotes: null,
+        includedPrs: [],
+        targetSha: null,
+        githubReleaseId: null,
+        githubReleaseUrl: null,
+        error: null,
+        completedAt: null,
+      });
+
+      const found = await storage.getReleaseRunByRepoAndMergeSha("owner/repo", "merge-sha-8");
+      assert.equal(found?.id, run.id);
+    });
+
+    it("looks up by repo + triggerPrNumber + triggerMergeSha", async () => {
+      const run = await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 9,
+        triggerPrTitle: "Test two",
+        triggerPrUrl: "https://github.com/owner/repo/pull/9",
+        triggerMergeSha: "merge-sha-9",
+        triggerMergedAt: "2026-03-28T12:00:00.000Z",
+        status: "detected",
+        decisionReason: null,
+        recommendedBump: null,
+        proposedVersion: null,
+        releaseTitle: null,
+        releaseNotes: null,
+        includedPrs: [],
+        targetSha: null,
+        githubReleaseId: null,
+        githubReleaseUrl: null,
+        error: null,
+        completedAt: null,
+      });
+
+      const found = await storage.getReleaseRunByTrigger("owner/repo", 9, "merge-sha-9");
+      assert.equal(found?.id, run.id);
+    });
+  });
+
+  describe("listReleaseRuns", () => {
+    it("returns newest-first", async (t) => {
+      t.mock.timers.enable({ apis: ["Date"], now: new Date("2026-03-28T12:00:00.000Z") });
+
+      await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 10,
+        triggerPrTitle: "Older",
+        triggerPrUrl: "https://github.com/owner/repo/pull/10",
+        triggerMergeSha: "sha-10",
+        triggerMergedAt: "2026-03-28T12:00:00.000Z",
+        status: "detected",
+        decisionReason: null,
+        recommendedBump: null,
+        proposedVersion: null,
+        releaseTitle: null,
+        releaseNotes: null,
+        includedPrs: [],
+        targetSha: null,
+        githubReleaseId: null,
+        githubReleaseUrl: null,
+        error: null,
+        completedAt: null,
+      });
+
+      t.mock.timers.tick(100);
+
+      await storage.createReleaseRun({
+        repo: "owner/repo",
+        baseBranch: "main",
+        triggerPrNumber: 11,
+        triggerPrTitle: "Newer",
+        triggerPrUrl: "https://github.com/owner/repo/pull/11",
+        triggerMergeSha: "sha-11",
+        triggerMergedAt: "2026-03-28T12:01:00.000Z",
+        status: "published",
+        decisionReason: "release-worthy",
+        recommendedBump: "minor",
+        proposedVersion: "v1.2.0",
+        releaseTitle: "Release v1.2.0",
+        releaseNotes: "Notes",
+        includedPrs: [],
+        targetSha: "target",
+        githubReleaseId: 1,
+        githubReleaseUrl: "https://github.com/owner/repo/releases/tag/v1.2.0",
+        error: null,
+        completedAt: "2026-03-28T12:01:00.000Z",
+      });
+
+      const runs = await storage.listReleaseRuns();
+      assert.equal(runs.length, 2);
+      assert.equal(runs[0].triggerPrNumber, 11);
+      assert.equal(runs[1].triggerPrNumber, 10);
     });
   });
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -1,12 +1,25 @@
-import type { AgentRun, AgentRunStatus, Config, LogEntry, PR, PRQuestion, RuntimeState, SocialChangelog } from "@shared/schema";
+import type {
+  AgentRun,
+  AgentRunStatus,
+  Config,
+  LogEntry,
+  PR,
+  PRQuestion,
+  ReleaseRun,
+  ReleaseRunStatus,
+  RuntimeState,
+  SocialChangelog,
+} from "@shared/schema";
 import {
   applyConfigUpdate,
   applyPRQuestionUpdate,
   applyPRUpdate,
+  applyReleaseRunUpdate,
   applySocialChangelogUpdate,
   createLogEntry,
   createPR,
   createPRQuestion,
+  createReleaseRun,
   createSocialChangelog,
   touchAgentRun,
 } from "@shared/models";
@@ -23,8 +36,16 @@ export class MemStorage implements IStorage {
     drainRequestedAt: null,
     drainReason: null,
   };
+  private releaseRuns: Map<string, ReleaseRun> = new Map();
   private agentRuns: Map<string, AgentRun> = new Map();
   private socialChangelogs: Map<string, SocialChangelog> = new Map();
+
+  private cloneReleaseRun(run: ReleaseRun): ReleaseRun {
+    return {
+      ...run,
+      includedPrs: run.includedPrs.map((pr) => ({ ...pr })),
+    };
+  }
 
   async getPRs(): Promise<PR[]> {
     return Array.from(this.prs.values())
@@ -138,6 +159,65 @@ export class MemStorage implements IStorage {
     };
 
     return { ...this.runtimeState };
+  }
+
+  async getReleaseRun(id: string): Promise<ReleaseRun | undefined> {
+    const run = this.releaseRuns.get(id);
+    return run ? this.cloneReleaseRun(run) : undefined;
+  }
+
+  async getReleaseRunByRepoAndMergeSha(repo: string, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
+    const run = Array.from(this.releaseRuns.values()).find(
+      (candidate) => candidate.repo === repo && candidate.triggerMergeSha === triggerMergeSha,
+    );
+    return run ? this.cloneReleaseRun(run) : undefined;
+  }
+
+  async getReleaseRunByTrigger(repo: string, triggerPrNumber: number, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
+    const run = Array.from(this.releaseRuns.values()).find(
+      (candidate) =>
+        candidate.repo === repo
+        && candidate.triggerPrNumber === triggerPrNumber
+        && candidate.triggerMergeSha === triggerMergeSha,
+    );
+    return run ? this.cloneReleaseRun(run) : undefined;
+  }
+
+  async listReleaseRuns(filters?: {
+    status?: ReleaseRunStatus;
+    repo?: string;
+  }): Promise<ReleaseRun[]> {
+    return Array.from(this.releaseRuns.values())
+      .map((run, index) => ({ run, index }))
+      .filter((run) => {
+        if (filters?.status && run.run.status !== filters.status) return false;
+        if (filters?.repo && run.run.repo !== filters.repo) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const createdDiff = new Date(b.run.createdAt).getTime() - new Date(a.run.createdAt).getTime();
+        if (createdDiff !== 0) {
+          return createdDiff;
+        }
+
+        // If timestamps match to the same millisecond, prefer later insertion.
+        return b.index - a.index;
+      })
+      .map(({ run }) => this.cloneReleaseRun(run));
+  }
+
+  async createReleaseRun(data: Omit<ReleaseRun, "id" | "createdAt" | "updatedAt">): Promise<ReleaseRun> {
+    const entry = createReleaseRun(data);
+    this.releaseRuns.set(entry.id, entry);
+    return this.cloneReleaseRun(entry);
+  }
+
+  async updateReleaseRun(id: string, updates: Partial<ReleaseRun>): Promise<ReleaseRun | undefined> {
+    const existing = this.releaseRuns.get(id);
+    if (!existing) return undefined;
+    const updated = applyReleaseRunUpdate(existing, updates);
+    this.releaseRuns.set(id, updated);
+    return this.cloneReleaseRun(updated);
   }
 
   async getAgentRun(id: string): Promise<AgentRun | undefined> {

--- a/server/releaseAgent.test.ts
+++ b/server/releaseAgent.test.ts
@@ -89,4 +89,8 @@ test("buildReleaseDecisionPrompt includes trigger and included PR context", () =
   assert.match(prompt, /Latest release tag: v1\.2\.3/);
   assert.match(prompt, /Trigger PR: #71 "Add release automation"/);
   assert.match(prompt, /1\. PR #70 by @octocat/);
+  assert.match(prompt, /## Why This Matters/);
+  assert.match(prompt, /## Detailed Changes/);
+  assert.match(prompt, /user-friendly, value-driven summary/i);
+  assert.match(prompt, /line-by-line changelog/i);
 });

--- a/server/releaseAgent.test.ts
+++ b/server/releaseAgent.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildReleaseDecisionPrompt, parseReleaseDecisionOutput } from "./releaseAgent";
+
+test("parseReleaseDecisionOutput normalizes a release-worthy decision", () => {
+  const parsed = parseReleaseDecisionOutput(`
+    {
+      "shouldRelease": true,
+      "reason": "User-visible release automation was added.",
+      "bump": "minor",
+      "title": "Automated release management",
+      "notes": "## Highlights\\n- Adds release automation."
+    }
+  `);
+
+  assert.deepEqual(parsed, {
+    shouldRelease: true,
+    reason: "User-visible release automation was added.",
+    bump: "minor",
+    title: "Automated release management",
+    notes: "## Highlights\n- Adds release automation.",
+  });
+});
+
+test("parseReleaseDecisionOutput allows surrounding text and normalizes skipped decisions", () => {
+  const parsed = parseReleaseDecisionOutput(`
+    Here is the result:
+    {
+      "shouldRelease": false,
+      "reason": "Internal maintenance only.",
+      "bump": "patch",
+      "title": "ignored",
+      "notes": "ignored"
+    }
+  `);
+
+  assert.deepEqual(parsed, {
+    shouldRelease: false,
+    reason: "Internal maintenance only.",
+    bump: null,
+    title: null,
+    notes: null,
+  });
+});
+
+test("parseReleaseDecisionOutput rejects release decisions with invalid bumps", () => {
+  assert.throws(
+    () =>
+      parseReleaseDecisionOutput(`
+        {
+          "shouldRelease": true,
+          "reason": "Important change",
+          "bump": "feature",
+          "title": "Bad bump",
+          "notes": "notes"
+        }
+      `),
+    /invalid 'bump'/i,
+  );
+});
+
+test("buildReleaseDecisionPrompt includes trigger and included PR context", () => {
+  const prompt = buildReleaseDecisionPrompt({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    latestTag: "v1.2.3",
+    triggerPr: {
+      number: 71,
+      title: "Add release automation",
+      url: "https://github.com/yungookim/codefactory/pull/71",
+      author: "octocat",
+      repo: "yungookim/codefactory",
+      mergedAt: "2026-03-28T15:00:00.000Z",
+      mergeSha: "abc123",
+    },
+    includedPulls: [
+      {
+        number: 70,
+        title: "Improve changelog generation",
+        url: "https://github.com/yungookim/codefactory/pull/70",
+        author: "octocat",
+        repo: "yungookim/codefactory",
+        mergedAt: "2026-03-28T14:00:00.000Z",
+        mergeSha: "def456",
+      },
+    ],
+  });
+
+  assert.match(prompt, /Latest release tag: v1\.2\.3/);
+  assert.match(prompt, /Trigger PR: #71 "Add release automation"/);
+  assert.match(prompt, /1\. PR #70 by @octocat/);
+});

--- a/server/releaseAgent.test.ts
+++ b/server/releaseAgent.test.ts
@@ -61,15 +61,15 @@ test("parseReleaseDecisionOutput rejects release decisions with invalid bumps", 
 
 test("buildReleaseDecisionPrompt includes trigger and included PR context", () => {
   const prompt = buildReleaseDecisionPrompt({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     latestTag: "v1.2.3",
     triggerPr: {
       number: 71,
       title: "Add release automation",
-      url: "https://github.com/yungookim/codefactory/pull/71",
+      url: "https://github.com/yungookim/oh-my-pr/pull/71",
       author: "octocat",
-      repo: "yungookim/codefactory",
+      repo: "yungookim/oh-my-pr",
       mergedAt: "2026-03-28T15:00:00.000Z",
       mergeSha: "abc123",
     },
@@ -77,9 +77,9 @@ test("buildReleaseDecisionPrompt includes trigger and included PR context", () =
       {
         number: 70,
         title: "Improve changelog generation",
-        url: "https://github.com/yungookim/codefactory/pull/70",
+        url: "https://github.com/yungookim/oh-my-pr/pull/70",
         author: "octocat",
-        repo: "yungookim/codefactory",
+        repo: "yungookim/oh-my-pr",
         mergedAt: "2026-03-28T14:00:00.000Z",
         mergeSha: "def456",
       },

--- a/server/releaseAgent.ts
+++ b/server/releaseAgent.ts
@@ -133,7 +133,11 @@ export function buildReleaseDecisionPrompt(params: {
     "- Use patch for fixes or small improvements, minor for additive user-facing features, and major for breaking changes.",
     "- title should be short and release-note ready when shouldRelease=true, else null.",
     "- notes should be GitHub-release Markdown focused on user-visible/operator-visible impact when shouldRelease=true, else null.",
+    "- notes must have exactly TWO sections in this order:",
+    "  1. '## Why This Matters' — a user-friendly, value-driven summary at the top that explains how the release makes users' lives better.",
+    "  2. '## Detailed Changes' — a line-by-line changelog of the included changes in plain English, more detailed than a headline but not deeply technical.",
     "- notes should mention the key merged PRs in plain language, not internal process commentary.",
+    "- Prefer user outcomes, workflow improvements, and visible behavior over implementation details.",
   ].join("\n");
 }
 

--- a/server/releaseAgent.ts
+++ b/server/releaseAgent.ts
@@ -1,0 +1,211 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { resolveAgent, runCommand, type CodingAgent } from "./agentRunner";
+
+const DEFAULT_RELEASE_AGENT_TIMEOUT_MS = 120_000;
+
+export type ReleaseBump = "patch" | "minor" | "major";
+
+export type ReleaseAgentPullSummary = {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  repo: string;
+  mergedAt: string;
+  mergeSha: string;
+};
+
+export type ReleaseEvaluationDecision = {
+  shouldRelease: boolean;
+  reason: string;
+  bump: ReleaseBump | null;
+  title: string | null;
+  notes: string | null;
+};
+
+export async function evaluateReleaseWorthinessWithAgent(params: {
+  preferredAgent: CodingAgent;
+  repo: string;
+  baseBranch: string;
+  latestTag: string | null;
+  triggerPr: ReleaseAgentPullSummary;
+  includedPulls: ReleaseAgentPullSummary[];
+  cwd?: string;
+  timeoutMs?: number;
+}): Promise<ReleaseEvaluationDecision> {
+  const cwd = params.cwd ?? process.cwd();
+  const timeoutMs = params.timeoutMs ?? DEFAULT_RELEASE_AGENT_TIMEOUT_MS;
+  const agent = await resolveAgent(params.preferredAgent);
+  const prompt = buildReleaseDecisionPrompt(params);
+
+  if (agent === "codex") {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "codex-release-eval-"));
+    const outputFile = path.join(tempDir, "output.txt");
+
+    try {
+      const result = await runCommand(
+        "codex",
+        [
+          "exec",
+          "--skip-git-repo-check",
+          "--sandbox",
+          "read-only",
+          "-o",
+          outputFile,
+          prompt,
+        ],
+        { cwd, timeoutMs },
+      );
+
+      if (result.code !== 0) {
+        throw new Error(`codex release evaluation failed (${result.code}): ${result.stderr || result.stdout}`);
+      }
+
+      const raw = await readFile(outputFile, "utf8");
+      return parseReleaseDecisionOutput(raw);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  const result = await runCommand(
+    "claude",
+    [
+      "-p",
+      "--output-format",
+      "text",
+      prompt,
+    ],
+    { cwd, timeoutMs },
+  );
+
+  if (result.code !== 0) {
+    throw new Error(`claude release evaluation failed (${result.code}): ${result.stderr || result.stdout}`);
+  }
+
+  return parseReleaseDecisionOutput(result.stdout);
+}
+
+export function buildReleaseDecisionPrompt(params: {
+  repo: string;
+  baseBranch: string;
+  latestTag: string | null;
+  triggerPr: ReleaseAgentPullSummary;
+  includedPulls: ReleaseAgentPullSummary[];
+}): string {
+  const includedPullsSection = params.includedPulls
+    .map((pr, index) => {
+      return [
+        `${index + 1}. PR #${pr.number} by @${pr.author}`,
+        `   Title: ${pr.title}`,
+        `   URL: ${pr.url}`,
+        `   Merged at: ${pr.mergedAt}`,
+        `   Merge SHA: ${pr.mergeSha}`,
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    "Respond with ONLY valid JSON and nothing else.",
+    "Schema:",
+    "{\"shouldRelease\":boolean,\"reason\":string,\"bump\":\"patch\"|\"minor\"|\"major\"|null,\"title\":string|null,\"notes\":string|null}",
+    "",
+    "You are deciding whether a merged set of pull requests should be published as a GitHub release.",
+    "Be conservative. Release only when the merged changes are meaningful enough for users or operators to care about.",
+    "",
+    `Repository: ${params.repo}`,
+    `Release branch: ${params.baseBranch}`,
+    `Latest release tag: ${params.latestTag ?? "none"}`,
+    "",
+    `Trigger PR: #${params.triggerPr.number} "${params.triggerPr.title}"`,
+    `Trigger merged at: ${params.triggerPr.mergedAt}`,
+    `Trigger merge SHA: ${params.triggerPr.mergeSha}`,
+    "",
+    "Merged PRs included in this candidate release:",
+    includedPullsSection || "(none)",
+    "",
+    "Decision rules:",
+    "- shouldRelease=true only when the merged changes are worth announcing as a GitHub release.",
+    "- bump must be null when shouldRelease=false.",
+    "- bump must be one of patch, minor, or major when shouldRelease=true.",
+    "- Use patch for fixes or small improvements, minor for additive user-facing features, and major for breaking changes.",
+    "- title should be short and release-note ready when shouldRelease=true, else null.",
+    "- notes should be GitHub-release Markdown focused on user-visible/operator-visible impact when shouldRelease=true, else null.",
+    "- notes should mention the key merged PRs in plain language, not internal process commentary.",
+  ].join("\n");
+}
+
+export function parseReleaseDecisionOutput(output: string): ReleaseEvaluationDecision {
+  const parsed = tryParseJsonFromText(output.trim());
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Could not parse release evaluation JSON: ${output.slice(0, 500)}`);
+  }
+
+  const candidate = parsed as {
+    shouldRelease?: unknown;
+    reason?: unknown;
+    bump?: unknown;
+    title?: unknown;
+    notes?: unknown;
+  };
+
+  if (typeof candidate.shouldRelease !== "boolean") {
+    throw new Error("Release evaluation missing boolean 'shouldRelease'");
+  }
+
+  if (typeof candidate.reason !== "string" || candidate.reason.trim().length === 0) {
+    throw new Error("Release evaluation missing string 'reason'");
+  }
+
+  if (!candidate.shouldRelease) {
+    return {
+      shouldRelease: false,
+      reason: candidate.reason.trim(),
+      bump: null,
+      title: null,
+      notes: null,
+    };
+  }
+
+  if (candidate.bump !== "patch" && candidate.bump !== "minor" && candidate.bump !== "major") {
+    throw new Error("Release evaluation returned invalid 'bump'");
+  }
+
+  if (typeof candidate.title !== "string" || candidate.title.trim().length === 0) {
+    throw new Error("Release evaluation missing non-empty 'title'");
+  }
+
+  if (typeof candidate.notes !== "string" || candidate.notes.trim().length === 0) {
+    throw new Error("Release evaluation missing non-empty 'notes'");
+  }
+
+  return {
+    shouldRelease: true,
+    reason: candidate.reason.trim(),
+    bump: candidate.bump,
+    title: candidate.title.trim(),
+    notes: candidate.notes.trim(),
+  };
+}
+
+function tryParseJsonFromText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // fall through
+  }
+
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text.slice(firstBrace, lastBrace + 1));
+  } catch {
+    return null;
+  }
+}

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MemStorage } from "./memoryStorage";
+import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
+import type { Config } from "@shared/schema";
+import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    githubToken: "",
+    codingAgent: "claude",
+    maxTurns: 15,
+    batchWindowMs: 300000,
+    pollIntervalMs: 120000,
+    maxChangesPerRun: 20,
+    autoResolveMergeConflicts: true,
+    autoCreateReleases: true,
+    watchedRepos: [],
+    trustedReviewers: [],
+    ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],
+    ...overrides,
+  };
+}
+
+function makePublishedRelease(tagName = "v1.3.0") {
+  return {
+    id: 123,
+    url: `https://github.com/yungookim/codefactory/releases/tag/${tagName}`,
+    tagName,
+    name: tagName,
+  };
+}
+
+function makeMergedSummary(overrides: Partial<ReleaseAgentPullSummary> = {}): ReleaseAgentPullSummary {
+  return {
+    number: 71,
+    title: "Release automation",
+    url: "https://github.com/yungookim/codefactory/pull/71",
+    author: "octocat",
+    repo: "yungookim/codefactory",
+    mergedAt: "2026-03-28T15:00:00.000Z",
+    mergeSha: "abc123",
+    ...overrides,
+  };
+}
+
+function makeGitHubService(overrides: Partial<ReleaseGitHubService> = {}): ReleaseGitHubService {
+  return {
+    buildOctokit: async () => ({}),
+    findLatestSemverReleaseTag: async () => "v1.2.3",
+    bumpReleaseTag: (latestTag, bump) => {
+      if (latestTag !== "v1.2.3") {
+        throw new Error(`unexpected latest tag: ${latestTag}`);
+      }
+      if (bump === "major") return "v2.0.0";
+      if (bump === "minor") return "v1.3.0";
+      return "v1.2.4";
+    },
+    listMergedPullsForReleaseCandidate: async (_octokit, _repo, options) => [
+      makeMergedSummary({
+        number: 70,
+        title: "Earlier merged change",
+        mergedAt: "2026-03-28T14:00:00.000Z",
+        mergeSha: "def456",
+      }),
+      options.triggerPr,
+    ],
+    findReleaseByTag: async () => null,
+    createGitHubRelease: async (_octokit, _repo, params) => makePublishedRelease(params.tagName),
+    ...overrides,
+  };
+}
+
+test("ReleaseManager publishes a release for a positive agent decision", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  let createCalls = 0;
+  const manager = new ReleaseManager(storage, {
+    github: makeGitHubService({
+      createGitHubRelease: async (_octokit, _repo, params) => {
+        createCalls += 1;
+        assert.equal(params.tagName, "v1.3.0");
+        assert.equal(params.targetCommitish, "abc123");
+        return makePublishedRelease(params.tagName);
+      },
+    }),
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: true,
+      reason: "User-facing release automation",
+      bump: "minor",
+      title: "Automated release management",
+      notes: "## Highlights\n- Adds automated releases.",
+    }),
+  });
+
+  const created = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    triggerPrNumber: 71,
+    triggerPrTitle: "Release automation",
+    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/71",
+    triggerMergeSha: "abc123",
+    triggerMergedAt: "2026-03-28T15:00:00.000Z",
+  });
+
+  await manager.waitForIdle();
+  const stored = await storage.getReleaseRun(created.id);
+
+  assert.ok(stored);
+  assert.equal(stored.status, "published");
+  assert.equal(stored.recommendedBump, "minor");
+  assert.equal(stored.proposedVersion, "v1.3.0");
+  assert.equal(stored.githubReleaseUrl, "https://github.com/yungookim/codefactory/releases/tag/v1.3.0");
+  assert.equal(stored.includedPrs.length, 2);
+  assert.equal(createCalls, 1);
+});
+
+test("ReleaseManager marks runs skipped when the agent rejects release creation", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  let createCalls = 0;
+  const manager = new ReleaseManager(storage, {
+    github: makeGitHubService({
+      createGitHubRelease: async () => {
+        createCalls += 1;
+        return makePublishedRelease();
+      },
+    }),
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: false,
+      reason: "No user-visible changes.",
+      bump: null,
+      title: null,
+      notes: null,
+    }),
+  });
+
+  const created = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    triggerPrNumber: 72,
+    triggerPrTitle: "Refactor internals",
+    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/72",
+    triggerMergeSha: "skip123",
+    triggerMergedAt: "2026-03-28T16:00:00.000Z",
+  });
+
+  await manager.waitForIdle();
+  const stored = await storage.getReleaseRun(created.id);
+
+  assert.ok(stored);
+  assert.equal(stored.status, "skipped");
+  assert.equal(stored.decisionReason, "No user-visible changes.");
+  assert.equal(createCalls, 0);
+});
+
+test("ReleaseManager deduplicates runs for the same repo and merge sha", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  let evaluateCalls = 0;
+  const manager = new ReleaseManager(storage, {
+    github: makeGitHubService(),
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => {
+      evaluateCalls += 1;
+      return {
+        shouldRelease: true,
+        reason: "Worth a patch release",
+        bump: "patch",
+        title: "Patch release",
+        notes: "Patch notes",
+      };
+    },
+  });
+
+  const first = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    triggerPrNumber: 73,
+    triggerPrTitle: "Bug fix",
+    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/73",
+    triggerMergeSha: "same-sha",
+    triggerMergedAt: "2026-03-28T17:00:00.000Z",
+  });
+  const second = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    triggerPrNumber: 73,
+    triggerPrTitle: "Bug fix",
+    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/73",
+    triggerMergeSha: "same-sha",
+    triggerMergedAt: "2026-03-28T17:00:00.000Z",
+  });
+
+  await manager.waitForIdle();
+  const runs = await storage.listReleaseRuns();
+
+  assert.equal(first.id, second.id);
+  assert.equal(runs.length, 1);
+  assert.equal(evaluateCalls, 1);
+});
+
+test("ReleaseManager can retry a failed run", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  let failFirst = true;
+  const manager = new ReleaseManager(storage, {
+    github: makeGitHubService({
+      createGitHubRelease: async (_octokit, _repo, params) => {
+        if (failFirst) {
+          failFirst = false;
+          throw new Error("temporary GitHub failure");
+        }
+        return makePublishedRelease(params.tagName);
+      },
+    }),
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: true,
+      reason: "Worth a patch release",
+      bump: "patch",
+      title: "Patch release",
+      notes: "Patch notes",
+    }),
+  });
+
+  const created = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/codefactory",
+    baseBranch: "main",
+    triggerPrNumber: 74,
+    triggerPrTitle: "Retryable release",
+    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/74",
+    triggerMergeSha: "retry-sha",
+    triggerMergedAt: "2026-03-28T18:00:00.000Z",
+  });
+
+  await manager.waitForIdle();
+  let stored = await storage.getReleaseRun(created.id);
+  assert.equal(stored?.status, "error");
+
+  const retried = await manager.retryReleaseRun(created.id);
+  assert.ok(retried);
+  await manager.waitForIdle();
+
+  stored = await storage.getReleaseRun(created.id);
+  assert.equal(stored?.status, "published");
+});

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { Octokit } from "@octokit/rest";
 import { MemStorage } from "./memoryStorage";
 import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 import type { Config } from "@shared/schema";
@@ -46,7 +47,7 @@ function makeMergedSummary(overrides: Partial<ReleaseAgentPullSummary> = {}): Re
 
 function makeGitHubService(overrides: Partial<ReleaseGitHubService> = {}): ReleaseGitHubService {
   return {
-    buildOctokit: async () => ({}),
+    buildOctokit: async () => ({}) as Octokit,
     findLatestSemverReleaseTag: async () => "v1.2.3",
     bumpReleaseTag: (latestTag, bump) => {
       if (latestTag !== "v1.2.3") {

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -25,7 +25,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 function makePublishedRelease(tagName = "v1.3.0") {
   return {
     id: 123,
-    url: `https://github.com/yungookim/codefactory/releases/tag/${tagName}`,
+    url: `https://github.com/yungookim/oh-my-pr/releases/tag/${tagName}`,
     tagName,
     name: tagName,
   };
@@ -35,9 +35,9 @@ function makeMergedSummary(overrides: Partial<ReleaseAgentPullSummary> = {}): Re
   return {
     number: 71,
     title: "Release automation",
-    url: "https://github.com/yungookim/codefactory/pull/71",
+    url: "https://github.com/yungookim/oh-my-pr/pull/71",
     author: "octocat",
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     mergedAt: "2026-03-28T15:00:00.000Z",
     mergeSha: "abc123",
     ...overrides,
@@ -95,11 +95,11 @@ test("ReleaseManager publishes a release for a positive agent decision", async (
   });
 
   const created = await manager.enqueueMergedPullReleaseEvaluation({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     triggerPrNumber: 71,
     triggerPrTitle: "Release automation",
-    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/71",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/71",
     triggerMergeSha: "abc123",
     triggerMergedAt: "2026-03-28T15:00:00.000Z",
   });
@@ -111,7 +111,7 @@ test("ReleaseManager publishes a release for a positive agent decision", async (
   assert.equal(stored.status, "published");
   assert.equal(stored.recommendedBump, "minor");
   assert.equal(stored.proposedVersion, "v1.3.0");
-  assert.equal(stored.githubReleaseUrl, "https://github.com/yungookim/codefactory/releases/tag/v1.3.0");
+  assert.equal(stored.githubReleaseUrl, "https://github.com/yungookim/oh-my-pr/releases/tag/v1.3.0");
   assert.equal(stored.includedPrs.length, 2);
   assert.equal(createCalls, 1);
 });
@@ -138,11 +138,11 @@ test("ReleaseManager marks runs skipped when the agent rejects release creation"
   });
 
   const created = await manager.enqueueMergedPullReleaseEvaluation({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     triggerPrNumber: 72,
     triggerPrTitle: "Refactor internals",
-    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/72",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/72",
     triggerMergeSha: "skip123",
     triggerMergedAt: "2026-03-28T16:00:00.000Z",
   });
@@ -176,20 +176,20 @@ test("ReleaseManager deduplicates runs for the same repo and merge sha", async (
   });
 
   const first = await manager.enqueueMergedPullReleaseEvaluation({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     triggerPrNumber: 73,
     triggerPrTitle: "Bug fix",
-    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/73",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/73",
     triggerMergeSha: "same-sha",
     triggerMergedAt: "2026-03-28T17:00:00.000Z",
   });
   const second = await manager.enqueueMergedPullReleaseEvaluation({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     triggerPrNumber: 73,
     triggerPrTitle: "Bug fix",
-    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/73",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/73",
     triggerMergeSha: "same-sha",
     triggerMergedAt: "2026-03-28T17:00:00.000Z",
   });
@@ -227,11 +227,11 @@ test("ReleaseManager can retry a failed run", async () => {
   });
 
   const created = await manager.enqueueMergedPullReleaseEvaluation({
-    repo: "yungookim/codefactory",
+    repo: "yungookim/oh-my-pr",
     baseBranch: "main",
     triggerPrNumber: 74,
     triggerPrTitle: "Retryable release",
-    triggerPrUrl: "https://github.com/yungookim/codefactory/pull/74",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/74",
     triggerMergeSha: "retry-sha",
     triggerMergedAt: "2026-03-28T18:00:00.000Z",
   });

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -1,0 +1,400 @@
+import type { Config, ReleaseRun, ReleaseRunIncludedPR } from "@shared/schema";
+import type { CodingAgent } from "./agentRunner";
+import { parseRepoSlug } from "./github";
+import type { IStorage } from "./storage";
+import {
+  evaluateReleaseWorthinessWithAgent,
+  type ReleaseAgentPullSummary,
+  type ReleaseBump,
+  type ReleaseEvaluationDecision,
+} from "./releaseAgent";
+
+type ReleaseRepo = {
+  owner: string;
+  repo: string;
+};
+
+type PublishedRelease = {
+  id: number;
+  url: string;
+  tagName: string;
+  name: string | null;
+};
+
+export type ReleaseGitHubService = {
+  buildOctokit(config: Config): Promise<unknown>;
+  findLatestSemverReleaseTag(octokit: unknown, repo: ReleaseRepo): Promise<string | null>;
+  bumpReleaseTag(latestTag: string | null, bump: ReleaseBump): string;
+  listMergedPullsForReleaseCandidate?(
+    octokit: unknown,
+    repo: ReleaseRepo,
+    options: {
+      baseBranch: string;
+      untilMergedAt: string;
+      triggerPr: ReleaseAgentPullSummary;
+    },
+  ): Promise<ReleaseAgentPullSummary[]>;
+  findReleaseByTag?(octokit: unknown, repo: ReleaseRepo, tagName: string): Promise<PublishedRelease | null>;
+  createGitHubRelease(
+    octokit: unknown,
+    repo: ReleaseRepo,
+    params: {
+      tagName: string;
+      targetCommitish: string;
+      name: string;
+      body: string;
+    },
+  ): Promise<PublishedRelease>;
+};
+
+export class ReleaseManager {
+  private readonly storage: IStorage;
+  private readonly github: ReleaseGitHubService;
+  private readonly evaluateRelease: typeof evaluateReleaseWorthinessWithAgent;
+  private readonly inProgress = new Set<string>();
+  private readonly backgroundJobs = new Set<Promise<void>>();
+  private readonly repoLocks = new Map<string, Promise<void>>();
+
+  constructor(
+    storage: IStorage,
+    params: {
+      github: ReleaseGitHubService;
+      evaluateRelease?: typeof evaluateReleaseWorthinessWithAgent;
+    },
+  ) {
+    this.storage = storage;
+    this.github = params.github;
+    this.evaluateRelease = params.evaluateRelease ?? evaluateReleaseWorthinessWithAgent;
+  }
+
+  getActiveRunCount(): number {
+    return this.inProgress.size;
+  }
+
+  async waitForIdle(timeoutMs = 120_000): Promise<boolean> {
+    const startedAt = Date.now();
+
+    while (this.inProgress.size > 0 || this.backgroundJobs.size > 0) {
+      if (Date.now() - startedAt >= timeoutMs) {
+        return false;
+      }
+      await wait(50);
+    }
+
+    return true;
+  }
+
+  async enqueueMergedPullReleaseEvaluation(input: {
+    repo: string;
+    baseBranch: string;
+    triggerPrNumber: number;
+    triggerPrTitle: string;
+    triggerPrUrl: string;
+    triggerMergeSha: string;
+    triggerMergedAt: string;
+  }): Promise<ReleaseRun> {
+    const existing = await this.storage.getReleaseRunByTrigger(
+      input.repo,
+      input.triggerPrNumber,
+      input.triggerMergeSha,
+    );
+    if (existing) {
+      if (!isTerminalReleaseStatus(existing.status)) {
+        this.scheduleProcessing(existing.id);
+      }
+      return existing;
+    }
+
+    const created = await this.storage.createReleaseRun({
+      repo: input.repo,
+      baseBranch: input.baseBranch,
+      triggerPrNumber: input.triggerPrNumber,
+      triggerPrTitle: input.triggerPrTitle,
+      triggerPrUrl: input.triggerPrUrl,
+      triggerMergeSha: input.triggerMergeSha,
+      triggerMergedAt: input.triggerMergedAt,
+      status: "detected",
+      decisionReason: null,
+      recommendedBump: null,
+      proposedVersion: null,
+      releaseTitle: null,
+      releaseNotes: null,
+      includedPrs: [],
+      targetSha: input.triggerMergeSha,
+      githubReleaseId: null,
+      githubReleaseUrl: null,
+      error: null,
+      completedAt: null,
+    });
+
+    this.scheduleProcessing(created.id);
+    return created;
+  }
+
+  async retryReleaseRun(id: string): Promise<ReleaseRun | undefined> {
+    const existing = await this.storage.getReleaseRun(id);
+    if (!existing) {
+      return undefined;
+    }
+
+    const reset = await this.storage.updateReleaseRun(id, {
+      status: "detected",
+      error: null,
+      completedAt: null,
+    });
+
+    if (!reset) {
+      return undefined;
+    }
+
+    this.scheduleProcessing(id);
+    return reset;
+  }
+
+  async processReleaseRun(id: string): Promise<ReleaseRun | undefined> {
+    const initial = await this.storage.getReleaseRun(id);
+    if (!initial) {
+      return undefined;
+    }
+
+    return this.withRepoLock(initial.repo, async () => {
+      if (this.inProgress.has(id)) {
+        return this.storage.getReleaseRun(id);
+      }
+
+      this.inProgress.add(id);
+      try {
+        const run = await this.storage.getReleaseRun(id);
+        if (!run) {
+          return undefined;
+        }
+
+        if (run.status === "published" || run.status === "skipped") {
+          return run;
+        }
+
+        const parsedRepo = parseRepoSlug(run.repo);
+        if (!parsedRepo) {
+          return this.failRun(id, `Invalid repository slug: ${run.repo}`);
+        }
+
+        const config = await this.storage.getConfig();
+        if (!config.autoCreateReleases) {
+          const skipped = await this.storage.updateReleaseRun(id, {
+            status: "skipped",
+            decisionReason: "Automatic release creation is disabled in settings",
+            completedAt: new Date().toISOString(),
+          });
+          return skipped ?? undefined;
+        }
+
+        await this.storage.updateReleaseRun(id, {
+          status: "evaluating",
+          error: null,
+          completedAt: null,
+        });
+
+        const octokit = await this.github.buildOctokit(config);
+        const latestTag = await this.github.findLatestSemverReleaseTag(octokit, parsedRepo);
+        const triggerPr = toTriggerSummary(run);
+        const includedPulls = await this.loadIncludedPulls(octokit, parsedRepo, run, triggerPr);
+        const includedPrs = includedPulls.map(toIncludedPR);
+        const decision = await this.evaluateRelease({
+          preferredAgent: config.codingAgent as CodingAgent,
+          repo: run.repo,
+          baseBranch: run.baseBranch,
+          latestTag,
+          triggerPr,
+          includedPulls: includedPulls,
+        });
+
+        if (!decision.shouldRelease) {
+          const skipped = await this.storage.updateReleaseRun(id, {
+            status: "skipped",
+            decisionReason: decision.reason,
+            recommendedBump: null,
+            proposedVersion: null,
+            releaseTitle: null,
+            releaseNotes: null,
+            includedPrs,
+            targetSha: run.triggerMergeSha,
+            completedAt: new Date().toISOString(),
+          });
+          return skipped ?? undefined;
+        }
+
+        if (!decision.bump) {
+          throw new Error("Release evaluation approved publishing but did not provide a semver bump");
+        }
+
+        const proposedVersion = this.github.bumpReleaseTag(latestTag, decision.bump);
+        const releaseTitle = normalizeReleaseTitle(decision, proposedVersion);
+        const releaseNotes = decision.notes ?? `Release ${proposedVersion}`;
+        await this.storage.updateReleaseRun(id, {
+          status: "proposed",
+          decisionReason: decision.reason,
+          recommendedBump: decision.bump,
+          proposedVersion,
+          releaseTitle,
+          releaseNotes,
+          includedPrs,
+          targetSha: run.triggerMergeSha,
+        });
+
+        const existingRelease = this.github.findReleaseByTag
+          ? await this.github.findReleaseByTag(octokit, parsedRepo, proposedVersion)
+          : null;
+
+        if (existingRelease) {
+          const published = await this.storage.updateReleaseRun(id, {
+            status: "published",
+            githubReleaseId: existingRelease.id,
+            githubReleaseUrl: existingRelease.url,
+            completedAt: new Date().toISOString(),
+          });
+          return published ?? undefined;
+        }
+
+        await this.storage.updateReleaseRun(id, {
+          status: "publishing",
+        });
+
+        const created = await this.github.createGitHubRelease(octokit, parsedRepo, {
+          tagName: proposedVersion,
+          targetCommitish: run.triggerMergeSha,
+          name: releaseTitle,
+          body: releaseNotes,
+        });
+
+        const published = await this.storage.updateReleaseRun(id, {
+          status: "published",
+          githubReleaseId: created.id,
+          githubReleaseUrl: created.url,
+          completedAt: new Date().toISOString(),
+        });
+
+        return published ?? undefined;
+      } catch (error) {
+        return this.failRun(id, summarizeError(error));
+      } finally {
+        this.inProgress.delete(id);
+      }
+    });
+  }
+
+  private async loadIncludedPulls(
+    octokit: unknown,
+    repo: ReleaseRepo,
+    run: ReleaseRun,
+    triggerPr: ReleaseAgentPullSummary,
+  ): Promise<ReleaseAgentPullSummary[]> {
+    if (!this.github.listMergedPullsForReleaseCandidate) {
+      return [triggerPr];
+    }
+
+    const included = await this.github.listMergedPullsForReleaseCandidate(octokit, repo, {
+      baseBranch: run.baseBranch,
+      untilMergedAt: run.triggerMergedAt,
+      triggerPr,
+    });
+
+    const deduped = new Map<string, ReleaseAgentPullSummary>();
+    for (const pr of included) {
+      deduped.set(pr.mergeSha || `${pr.repo}#${pr.number}`, pr);
+    }
+    if (!deduped.has(triggerPr.mergeSha)) {
+      deduped.set(triggerPr.mergeSha, triggerPr);
+    }
+
+    return Array.from(deduped.values()).sort((a, b) => a.mergedAt.localeCompare(b.mergedAt));
+  }
+
+  private async failRun(id: string, error: string): Promise<ReleaseRun | undefined> {
+    return this.storage.updateReleaseRun(id, {
+      status: "error",
+      error,
+      completedAt: new Date().toISOString(),
+    });
+  }
+
+  private async withRepoLock<T>(
+    repo: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previousLock = this.repoLocks.get(repo) ?? Promise.resolve();
+    let releaseCurrentLock: (() => void) | undefined;
+    const currentLock = new Promise<void>((resolve) => {
+      releaseCurrentLock = () => resolve();
+    });
+    const lockQueue = previousLock.then(() => currentLock);
+    this.repoLocks.set(repo, lockQueue);
+
+    await previousLock;
+    try {
+      return await operation();
+    } finally {
+      releaseCurrentLock?.();
+      if (this.repoLocks.get(repo) === lockQueue) {
+        this.repoLocks.delete(repo);
+      }
+    }
+  }
+
+  private scheduleProcessing(id: string): void {
+    const job = this.processReleaseRun(id)
+      .then(() => undefined)
+      .catch(() => undefined)
+      .finally(() => {
+        this.backgroundJobs.delete(job);
+      });
+    this.backgroundJobs.add(job);
+  }
+}
+
+function toTriggerSummary(run: ReleaseRun): ReleaseAgentPullSummary {
+  return {
+    number: run.triggerPrNumber,
+    title: run.triggerPrTitle,
+    url: run.triggerPrUrl,
+    author: "unknown",
+    repo: run.repo,
+    mergedAt: run.triggerMergedAt,
+    mergeSha: run.triggerMergeSha,
+  };
+}
+
+function toIncludedPR(pr: ReleaseAgentPullSummary): ReleaseRunIncludedPR {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    author: pr.author,
+    mergedAt: pr.mergedAt,
+    mergeSha: pr.mergeSha,
+  };
+}
+
+function normalizeReleaseTitle(
+  decision: ReleaseEvaluationDecision,
+  version: string,
+): string {
+  const title = decision.title?.trim();
+  if (!title) {
+    return version;
+  }
+
+  return title.startsWith(version) ? title : `${version} - ${title}`;
+}
+
+function summarizeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.trim().slice(0, 2_000);
+}
+
+function isTerminalReleaseStatus(status: ReleaseRun["status"]): boolean {
+  return status === "skipped" || status === "published";
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -1,3 +1,4 @@
+import type { Octokit } from "@octokit/rest";
 import type { Config, ReleaseRun, ReleaseRunIncludedPR } from "@shared/schema";
 import type { CodingAgent } from "./agentRunner";
 import { parseRepoSlug } from "./github";
@@ -22,11 +23,11 @@ type PublishedRelease = {
 };
 
 export type ReleaseGitHubService = {
-  buildOctokit(config: Config): Promise<unknown>;
-  findLatestSemverReleaseTag(octokit: unknown, repo: ReleaseRepo): Promise<string | null>;
+  buildOctokit(config: Config): Promise<Octokit>;
+  findLatestSemverReleaseTag(octokit: Octokit, repo: ReleaseRepo): Promise<string | null>;
   bumpReleaseTag(latestTag: string | null, bump: ReleaseBump): string;
   listMergedPullsForReleaseCandidate?(
-    octokit: unknown,
+    octokit: Octokit,
     repo: ReleaseRepo,
     options: {
       baseBranch: string;
@@ -34,9 +35,9 @@ export type ReleaseGitHubService = {
       triggerPr: ReleaseAgentPullSummary;
     },
   ): Promise<ReleaseAgentPullSummary[]>;
-  findReleaseByTag?(octokit: unknown, repo: ReleaseRepo, tagName: string): Promise<PublishedRelease | null>;
+  findReleaseByTag?(octokit: Octokit, repo: ReleaseRepo, tagName: string): Promise<PublishedRelease | null>;
   createGitHubRelease(
-    octokit: unknown,
+    octokit: Octokit,
     repo: ReleaseRepo,
     params: {
       tagName: string;
@@ -283,7 +284,7 @@ export class ReleaseManager {
   }
 
   private async loadIncludedPulls(
-    octokit: unknown,
+    octokit: Octokit,
     repo: ReleaseRepo,
     run: ReleaseRun,
     triggerPr: ReleaseAgentPullSummary,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,22 +7,85 @@ import { PRBabysitter } from "./babysitter";
 import { applyEvaluationDecision, applyFlagDecision, applyManualDecision } from "./feedbackLifecycle";
 import { createWatcherScheduler } from "./watcherScheduler";
 import { answerPRQuestion } from "./prQuestionAgent";
+import { ReleaseManager } from "./releaseManager";
 import {
   buildOctokit,
   checkOnboardingStatus,
+  createGitHubRelease,
   fetchPullSummary,
   formatRepoSlug,
+  getLatestSemverTagForRepo,
   GitHubIntegrationError,
   installCodeReviewWorkflow,
+  listReleasesForRepo,
+  listUnreleasedMergedPulls,
   parsePRUrl,
   parseRepoSlug,
+  resolveNextSemverTag,
 } from "./github";
 
 export async function registerRoutes(
   httpServer: Server,
   app: Express,
 ): Promise<Server> {
-  const babysitter = new PRBabysitter(storage);
+  const releaseManager = new ReleaseManager(storage, {
+    github: {
+      buildOctokit,
+      findLatestSemverReleaseTag: getLatestSemverTagForRepo,
+      bumpReleaseTag: resolveNextSemverTag,
+      listMergedPullsForReleaseCandidate: async (octokit, repo, options) => {
+        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
+        const merged = await listUnreleasedMergedPulls(client, repo, {
+          baseRef: options.baseBranch,
+        });
+        const cutoffMs = Date.parse(options.untilMergedAt);
+
+        return merged
+          .filter((pull) => !Number.isFinite(cutoffMs) || Date.parse(pull.mergedAt) <= cutoffMs)
+          .map((pull) => ({
+            number: pull.number,
+            title: pull.title,
+            url: pull.url,
+            author: pull.author,
+            repo: pull.repo,
+            mergedAt: pull.mergedAt,
+            mergeSha: pull.mergeCommitSha ?? `${pull.repo}#${pull.number}`,
+          }));
+      },
+      findReleaseByTag: async (octokit, repo, tagName) => {
+        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
+        const releases = await listReleasesForRepo(client, repo);
+        const existing = releases.find((release) => !release.draft && release.tagName === tagName);
+        if (!existing) {
+          return null;
+        }
+
+        return {
+          id: existing.id,
+          url: existing.htmlUrl,
+          tagName: existing.tagName,
+          name: existing.name,
+        };
+      },
+      createGitHubRelease: async (octokit, repo, params) => {
+        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
+        const created = await createGitHubRelease(client, repo, {
+          tagName: params.tagName,
+          targetCommitish: params.targetCommitish,
+          name: params.name,
+          body: params.body,
+        });
+
+        return {
+          id: created.id,
+          url: created.htmlUrl,
+          tagName: created.tagName,
+          name: created.name,
+        };
+      },
+    },
+  });
+  const babysitter = new PRBabysitter(storage, undefined, undefined, releaseManager);
   let watcherTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
 
@@ -511,6 +574,44 @@ export async function registerRoutes(
         return res.status(404).json({ error: "Changelog not found" });
       }
       res.json(changelog);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── Release runs ────────────────────────────────────────────────────────
+
+  app.get("/api/releases", async (_req, res) => {
+    try {
+      const releases = await storage.listReleaseRuns();
+      res.json(releases);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  app.get("/api/releases/:id", async (req, res) => {
+    try {
+      const release = await storage.getReleaseRun(req.params.id);
+      if (!release) {
+        return res.status(404).json({ error: "Release run not found" });
+      }
+      res.json(release);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  app.post("/api/releases/:id/retry", async (req, res) => {
+    try {
+      const release = await releaseManager.retryReleaseRun(req.params.id);
+      if (!release) {
+        return res.status(404).json({ error: "Release run not found" });
+      }
+      res.json(release);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       res.status(500).json({ error: message });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -34,8 +34,7 @@ export async function registerRoutes(
       findLatestSemverReleaseTag: getLatestSemverTagForRepo,
       bumpReleaseTag: resolveNextSemverTag,
       listMergedPullsForReleaseCandidate: async (octokit, repo, options) => {
-        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
-        const merged = await listUnreleasedMergedPulls(client, repo, {
+        const merged = await listUnreleasedMergedPulls(octokit, repo, {
           baseRef: options.baseBranch,
         });
         const cutoffMs = Date.parse(options.untilMergedAt);
@@ -53,8 +52,7 @@ export async function registerRoutes(
           }));
       },
       findReleaseByTag: async (octokit, repo, tagName) => {
-        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
-        const releases = await listReleasesForRepo(client, repo);
+        const releases = await listReleasesForRepo(octokit, repo);
         const existing = releases.find((release) => !release.draft && release.tagName === tagName);
         if (!existing) {
           return null;
@@ -68,8 +66,7 @@ export async function registerRoutes(
         };
       },
       createGitHubRelease: async (octokit, repo, params) => {
-        const client = octokit as Awaited<ReturnType<typeof buildOctokit>>;
-        const created = await createGitHubRelease(client, repo, {
+        const created = await createGitHubRelease(octokit, repo, {
           tagName: params.tagName,
           targetCommitish: params.targetCommitish,
           name: params.name,

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -2,15 +2,29 @@ import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import type { SQLInputValue } from "node:sqlite";
 import { feedbackStatusEnum } from "@shared/schema";
-import type { AgentRun, AgentRunStatus, Config, FeedbackItem, LogEntry, PR, PRQuestion, RuntimeState, SocialChangelog } from "@shared/schema";
+import type {
+  AgentRun,
+  AgentRunStatus,
+  Config,
+  FeedbackItem,
+  LogEntry,
+  PR,
+  PRQuestion,
+  ReleaseRun,
+  ReleaseRunStatus,
+  RuntimeState,
+  SocialChangelog,
+} from "@shared/schema";
 import {
   applyConfigUpdate,
   applyPRQuestionUpdate,
   applyPRUpdate,
+  applyReleaseRunUpdate,
   applySocialChangelogUpdate,
   createLogEntry,
   createPR,
   createPRQuestion,
+  createReleaseRun,
   createSocialChangelog,
 } from "@shared/models";
 import type { IStorage } from "./storage";
@@ -27,6 +41,7 @@ type ConfigRow = {
   poll_interval_ms: number;
   max_changes_per_run: number;
   auto_resolve_merge_conflicts: number;
+  auto_create_releases: number;
   trusted_reviewers_json: string;
   ignored_bots_json: string;
 };
@@ -142,6 +157,31 @@ type SocialChangelogRow = {
   status: SocialChangelog["status"];
   error: string | null;
   created_at: string;
+  completed_at: string | null;
+};
+
+type ReleaseRunRow = {
+  id: string;
+  repo: string;
+  base_branch: string;
+  trigger_pr_number: number;
+  trigger_pr_title: string;
+  trigger_pr_url: string;
+  trigger_merge_sha: string;
+  trigger_merged_at: string;
+  status: ReleaseRunStatus;
+  decision_reason: string | null;
+  recommended_bump: "patch" | "minor" | "major" | null;
+  proposed_version: string | null;
+  release_title: string | null;
+  release_notes: string | null;
+  included_prs_json: string;
+  target_sha: string | null;
+  github_release_id: number | null;
+  github_release_url: string | null;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
   completed_at: string | null;
 };
 
@@ -290,6 +330,8 @@ export class SqliteStorage implements IStorage {
         batch_window_ms INTEGER NOT NULL,
         poll_interval_ms INTEGER NOT NULL,
         max_changes_per_run INTEGER NOT NULL,
+        auto_resolve_merge_conflicts INTEGER NOT NULL DEFAULT 1,
+        auto_create_releases INTEGER NOT NULL DEFAULT 1,
         trusted_reviewers_json TEXT NOT NULL,
         ignored_bots_json TEXT NOT NULL
       );
@@ -402,11 +444,40 @@ export class SqliteStorage implements IStorage {
         UNIQUE(date, trigger_count)
       );
 
+      CREATE TABLE IF NOT EXISTS release_runs (
+        id TEXT PRIMARY KEY,
+        repo TEXT NOT NULL,
+        base_branch TEXT NOT NULL,
+        trigger_pr_number INTEGER NOT NULL,
+        trigger_pr_title TEXT NOT NULL,
+        trigger_pr_url TEXT NOT NULL,
+        trigger_merge_sha TEXT NOT NULL,
+        trigger_merged_at TEXT NOT NULL,
+        status TEXT NOT NULL,
+        decision_reason TEXT,
+        recommended_bump TEXT,
+        proposed_version TEXT,
+        release_title TEXT,
+        release_notes TEXT,
+        included_prs_json TEXT NOT NULL,
+        target_sha TEXT,
+        github_release_id INTEGER,
+        github_release_url TEXT,
+        error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        completed_at TEXT,
+        UNIQUE(repo, trigger_pr_number, trigger_merge_sha)
+      );
+
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
       CREATE INDEX IF NOT EXISTS idx_logs_pr_id_timestamp ON logs(pr_id, timestamp);
       CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated_at ON agent_runs(status, updated_at);
       CREATE INDEX IF NOT EXISTS idx_pr_questions_pr_id ON pr_questions(pr_id);
       CREATE INDEX IF NOT EXISTS idx_social_changelogs_date ON social_changelogs(date);
+      CREATE INDEX IF NOT EXISTS idx_release_runs_created_at ON release_runs(created_at);
+      CREATE INDEX IF NOT EXISTS idx_release_runs_status_created_at ON release_runs(status, created_at);
+      CREATE INDEX IF NOT EXISTS idx_release_runs_repo_trigger_merge_sha ON release_runs(repo, trigger_merge_sha);
     `);
 
     this.ensureColumn("feedback_items", "reply_kind", "TEXT NOT NULL DEFAULT 'general_comment'");
@@ -419,6 +490,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("feedback_items", "status", "TEXT NOT NULL DEFAULT 'pending'");
     this.ensureColumn("feedback_items", "status_reason", "TEXT");
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -461,6 +533,7 @@ export class SqliteStorage implements IStorage {
       pollIntervalMs: row.poll_interval_ms,
       maxChangesPerRun: row.max_changes_per_run,
       autoResolveMergeConflicts: Boolean(row.auto_resolve_merge_conflicts),
+      autoCreateReleases: Boolean(row.auto_create_releases ?? 1),
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
       ignoredBots: JSON.parse(row.ignored_bots_json),
@@ -484,9 +557,10 @@ export class SqliteStorage implements IStorage {
           poll_interval_ms,
           max_changes_per_run,
           auto_resolve_merge_conflicts,
+          auto_create_releases,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           coding_agent = excluded.coding_agent,
@@ -496,6 +570,7 @@ export class SqliteStorage implements IStorage {
           poll_interval_ms = excluded.poll_interval_ms,
           max_changes_per_run = excluded.max_changes_per_run,
           auto_resolve_merge_conflicts = excluded.auto_resolve_merge_conflicts,
+          auto_create_releases = excluded.auto_create_releases,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
           ignored_bots_json = excluded.ignored_bots_json
       `,
@@ -508,6 +583,7 @@ export class SqliteStorage implements IStorage {
         config.pollIntervalMs,
         config.maxChangesPerRun,
         Number(config.autoResolveMergeConflicts),
+        Number(config.autoCreateReleases),
         JSON.stringify(config.trustedReviewers),
         JSON.stringify(config.ignoredBots),
       );
@@ -923,7 +999,7 @@ export class SqliteStorage implements IStorage {
   async getConfig(): Promise<Config> {
     const row = this.get<ConfigRow>(`
       SELECT github_token, coding_agent, model, max_turns, batch_window_ms,
-             poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts,
+             poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
              trusted_reviewers_json, ignored_bots_json
       FROM config
       WHERE id = 1
@@ -1134,6 +1210,177 @@ export class SqliteStorage implements IStorage {
       createdAt: row.created_at,
       completedAt: row.completed_at,
     };
+  }
+
+  private parseReleaseRunRow(row: ReleaseRunRow): ReleaseRun {
+    return {
+      id: row.id,
+      repo: row.repo,
+      baseBranch: row.base_branch,
+      triggerPrNumber: row.trigger_pr_number,
+      triggerPrTitle: row.trigger_pr_title,
+      triggerPrUrl: row.trigger_pr_url,
+      triggerMergeSha: row.trigger_merge_sha,
+      triggerMergedAt: row.trigger_merged_at,
+      status: row.status,
+      decisionReason: row.decision_reason,
+      recommendedBump: row.recommended_bump,
+      proposedVersion: row.proposed_version,
+      releaseTitle: row.release_title,
+      releaseNotes: row.release_notes,
+      includedPrs: JSON.parse(row.included_prs_json) as ReleaseRun["includedPrs"],
+      targetSha: row.target_sha,
+      githubReleaseId: row.github_release_id,
+      githubReleaseUrl: row.github_release_url,
+      error: row.error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      completedAt: row.completed_at,
+    };
+  }
+
+  async getReleaseRun(id: string): Promise<ReleaseRun | undefined> {
+    const row = this.get<ReleaseRunRow>(`
+      SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
+             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             proposed_version, release_title, release_notes, included_prs_json, target_sha,
+             github_release_id, github_release_url, error, created_at, updated_at, completed_at
+      FROM release_runs
+      WHERE id = ?
+    `, id);
+    return row ? this.parseReleaseRunRow(row) : undefined;
+  }
+
+  async getReleaseRunByRepoAndMergeSha(repo: string, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
+    const row = this.get<ReleaseRunRow>(`
+      SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
+             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             proposed_version, release_title, release_notes, included_prs_json, target_sha,
+             github_release_id, github_release_url, error, created_at, updated_at, completed_at
+      FROM release_runs
+      WHERE repo = ? AND trigger_merge_sha = ?
+      ORDER BY datetime(created_at) DESC, rowid DESC
+      LIMIT 1
+    `, repo, triggerMergeSha);
+    return row ? this.parseReleaseRunRow(row) : undefined;
+  }
+
+  async getReleaseRunByTrigger(repo: string, triggerPrNumber: number, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
+    const row = this.get<ReleaseRunRow>(`
+      SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
+             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             proposed_version, release_title, release_notes, included_prs_json, target_sha,
+             github_release_id, github_release_url, error, created_at, updated_at, completed_at
+      FROM release_runs
+      WHERE repo = ? AND trigger_pr_number = ? AND trigger_merge_sha = ?
+      ORDER BY datetime(created_at) DESC, rowid DESC
+      LIMIT 1
+    `, repo, triggerPrNumber, triggerMergeSha);
+    return row ? this.parseReleaseRunRow(row) : undefined;
+  }
+
+  async listReleaseRuns(filters?: { status?: ReleaseRunStatus; repo?: string }): Promise<ReleaseRun[]> {
+    const clauses: string[] = [];
+    const values: Array<string | ReleaseRunStatus> = [];
+
+    if (filters?.status) {
+      clauses.push("status = ?");
+      values.push(filters.status);
+    }
+
+    if (filters?.repo) {
+      clauses.push("repo = ?");
+      values.push(filters.repo);
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = this.all<ReleaseRunRow>(`
+      SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
+             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             proposed_version, release_title, release_notes, included_prs_json, target_sha,
+             github_release_id, github_release_url, error, created_at, updated_at, completed_at
+      FROM release_runs
+      ${whereClause}
+      ORDER BY datetime(created_at) DESC, rowid DESC
+    `, ...values);
+
+    return rows.map((row) => this.parseReleaseRunRow(row));
+  }
+
+  async createReleaseRun(data: Omit<ReleaseRun, "id" | "createdAt" | "updatedAt">): Promise<ReleaseRun> {
+    const entry = createReleaseRun(data);
+    this.run(`
+      INSERT INTO release_runs (
+        id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
+        trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+        proposed_version, release_title, release_notes, included_prs_json, target_sha,
+        github_release_id, github_release_url, error, created_at, updated_at, completed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      entry.id,
+      entry.repo,
+      entry.baseBranch,
+      entry.triggerPrNumber,
+      entry.triggerPrTitle,
+      entry.triggerPrUrl,
+      entry.triggerMergeSha,
+      entry.triggerMergedAt,
+      entry.status,
+      entry.decisionReason,
+      entry.recommendedBump,
+      entry.proposedVersion,
+      entry.releaseTitle,
+      entry.releaseNotes,
+      JSON.stringify(entry.includedPrs),
+      entry.targetSha,
+      entry.githubReleaseId,
+      entry.githubReleaseUrl,
+      entry.error,
+      entry.createdAt,
+      entry.updatedAt,
+      entry.completedAt,
+    );
+    return entry;
+  }
+
+  async updateReleaseRun(id: string, updates: Partial<ReleaseRun>): Promise<ReleaseRun | undefined> {
+    const existing = await this.getReleaseRun(id);
+    if (!existing) return undefined;
+    const next = applyReleaseRunUpdate(existing, updates);
+
+    this.run(`
+      UPDATE release_runs
+      SET repo = ?, base_branch = ?, trigger_pr_number = ?, trigger_pr_title = ?, trigger_pr_url = ?,
+          trigger_merge_sha = ?, trigger_merged_at = ?, status = ?, decision_reason = ?,
+          recommended_bump = ?, proposed_version = ?, release_title = ?, release_notes = ?,
+          included_prs_json = ?, target_sha = ?, github_release_id = ?, github_release_url = ?,
+          error = ?, created_at = ?, updated_at = ?, completed_at = ?
+      WHERE id = ?
+    `,
+      next.repo,
+      next.baseBranch,
+      next.triggerPrNumber,
+      next.triggerPrTitle,
+      next.triggerPrUrl,
+      next.triggerMergeSha,
+      next.triggerMergedAt,
+      next.status,
+      next.decisionReason,
+      next.recommendedBump,
+      next.proposedVersion,
+      next.releaseTitle,
+      next.releaseNotes,
+      JSON.stringify(next.includedPrs),
+      next.targetSha,
+      next.githubReleaseId,
+      next.githubReleaseUrl,
+      next.error,
+      next.createdAt,
+      next.updatedAt,
+      next.completedAt,
+      id,
+    );
+    return next;
   }
 
   close(): void {

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -58,6 +58,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const first = new SqliteStorage(root);
   await first.updateConfig({
     pollIntervalMs: 45000,
+    autoCreateReleases: false,
     watchedRepos: ["alex-morgan-o/lolodex"],
   });
   await first.updateRuntimeState({
@@ -131,6 +132,27 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     createdAt: "2026-03-18T10:01:00.000Z",
     updatedAt: "2026-03-18T10:02:00.000Z",
   });
+  const releaseRun = await first.createReleaseRun({
+    repo: "alex-morgan-o/lolodex",
+    baseBranch: "main",
+    triggerPrNumber: 106,
+    triggerPrTitle: "Example PR",
+    triggerPrUrl: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    triggerMergeSha: "merge-sha-106",
+    triggerMergedAt: "2026-03-18T10:05:00.000Z",
+    status: "detected",
+    decisionReason: null,
+    recommendedBump: null,
+    proposedVersion: null,
+    releaseTitle: null,
+    releaseNotes: null,
+    includedPrs: [],
+    targetSha: null,
+    githubReleaseId: null,
+    githubReleaseUrl: null,
+    error: null,
+    completedAt: null,
+  });
   first.close();
 
   const second = new SqliteStorage(root);
@@ -139,9 +161,11 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const reloadedPr = await second.getPR(pr.id);
   const run = await second.getAgentRun("run-1");
   const runningRuns = await second.listAgentRuns({ status: "running" });
+  const release = await second.getReleaseRun(releaseRun.id);
   const logs = await second.getLogs(pr.id);
 
   assert.equal(config.pollIntervalMs, 45000);
+  assert.equal(config.autoCreateReleases, false);
   assert.deepEqual(config.watchedRepos, ["alex-morgan-o/lolodex"]);
   assert.equal(runtime.drainMode, true);
   assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
@@ -160,6 +184,8 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(run?.initialHeadSha, "abc123");
   assert.equal(runningRuns.length, 1);
   assert.equal(runningRuns[0]?.id, "run-1");
+  assert.equal(release?.triggerMergeSha, "merge-sha-106");
+  assert.equal(release?.status, "detected");
   assert.equal(logs.length, 1);
   assert.equal(logs[0]?.phase, "agent");
   assert.deepEqual(logs[0]?.metadata, { attempt: 1 });
@@ -262,6 +288,67 @@ test("SqliteStorage upsertAgentRun preserves the original createdAt", async () =
   assert.equal(fetched?.createdAt, "2026-03-18T10:01:00.000Z");
   assert.equal(fetched?.status, "completed");
   assert.equal(fetched?.phase, "run.done");
+  storage.close();
+});
+
+test("SqliteStorage release run lookup is idempotent and list is newest-first", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+
+  const older = await storage.createReleaseRun({
+    repo: "owner/repo",
+    baseBranch: "main",
+    triggerPrNumber: 1,
+    triggerPrTitle: "Older",
+    triggerPrUrl: "https://github.com/owner/repo/pull/1",
+    triggerMergeSha: "merge-sha-1",
+    triggerMergedAt: "2026-03-28T10:00:00.000Z",
+    status: "detected",
+    decisionReason: null,
+    recommendedBump: null,
+    proposedVersion: null,
+    releaseTitle: null,
+    releaseNotes: null,
+    includedPrs: [],
+    targetSha: null,
+    githubReleaseId: null,
+    githubReleaseUrl: null,
+    error: null,
+    completedAt: null,
+  });
+
+  await storage.createReleaseRun({
+    repo: "owner/repo",
+    baseBranch: "main",
+    triggerPrNumber: 2,
+    triggerPrTitle: "Newer",
+    triggerPrUrl: "https://github.com/owner/repo/pull/2",
+    triggerMergeSha: "merge-sha-2",
+    triggerMergedAt: "2026-03-28T10:01:00.000Z",
+    status: "published",
+    decisionReason: "Ship it",
+    recommendedBump: "minor",
+    proposedVersion: "v1.1.0",
+    releaseTitle: "v1.1.0",
+    releaseNotes: "notes",
+    includedPrs: [],
+    targetSha: "abc",
+    githubReleaseId: 123,
+    githubReleaseUrl: "https://github.com/owner/repo/releases/tag/v1.1.0",
+    error: null,
+    completedAt: "2026-03-28T10:02:00.000Z",
+  });
+
+  const byRepoAndSha = await storage.getReleaseRunByRepoAndMergeSha("owner/repo", "merge-sha-1");
+  assert.equal(byRepoAndSha?.id, older.id);
+
+  const byTrigger = await storage.getReleaseRunByTrigger("owner/repo", 1, "merge-sha-1");
+  assert.equal(byTrigger?.id, older.id);
+
+  const runs = await storage.listReleaseRuns();
+  assert.equal(runs.length, 2);
+  assert.equal(runs[0]?.triggerPrNumber, 2);
+  assert.equal(runs[1]?.triggerPrNumber, 1);
   storage.close();
 });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,15 @@
-import type { AgentRun, AgentRunStatus, Config, LogEntry, PR, PRQuestion, RuntimeState, SocialChangelog } from "@shared/schema";
+import type {
+  AgentRun,
+  AgentRunStatus,
+  Config,
+  LogEntry,
+  PR,
+  PRQuestion,
+  ReleaseRun,
+  ReleaseRunStatus,
+  RuntimeState,
+  SocialChangelog,
+} from "@shared/schema";
 export { MemStorage } from "./memoryStorage";
 import { SqliteStorage } from "./sqliteStorage";
 
@@ -45,6 +56,17 @@ export interface IStorage {
   getSocialChangelogForDateAndCount(date: string, triggerCount: number): Promise<SocialChangelog | undefined>;
   createSocialChangelog(data: Omit<SocialChangelog, "id" | "createdAt">): Promise<SocialChangelog>;
   updateSocialChangelog(id: string, updates: Partial<SocialChangelog>): Promise<SocialChangelog | undefined>;
+
+  // Release runs
+  getReleaseRun(id: string): Promise<ReleaseRun | undefined>;
+  getReleaseRunByRepoAndMergeSha(repo: string, triggerMergeSha: string): Promise<ReleaseRun | undefined>;
+  getReleaseRunByTrigger(repo: string, triggerPrNumber: number, triggerMergeSha: string): Promise<ReleaseRun | undefined>;
+  listReleaseRuns(filters?: {
+    status?: ReleaseRunStatus;
+    repo?: string;
+  }): Promise<ReleaseRun[]>;
+  createReleaseRun(data: Omit<ReleaseRun, "id" | "createdAt" | "updatedAt">): Promise<ReleaseRun>;
+  updateReleaseRun(id: string, updates: Partial<ReleaseRun>): Promise<ReleaseRun | undefined>;
 
   // Durable agent run journal
   getAgentRun(id: string): Promise<AgentRun | undefined>;

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -6,6 +6,7 @@ import {
   logEntrySchema,
   prQuestionSchema,
   prSchema,
+  releaseRunSchema,
   socialChangelogSchema,
 } from "./schema";
 import type {
@@ -15,6 +16,7 @@ import type {
   LogEntry,
   PR,
   PRQuestion,
+  ReleaseRun,
   SocialChangelog,
 } from "./schema";
 
@@ -146,6 +148,34 @@ export function applySocialChangelogUpdate(
     // Immutable fields
     id: existing.id,
     createdAt: existing.createdAt,
+  });
+}
+
+// ── Release runs ──────────────────────────────────────────────────────────────
+
+export function createReleaseRun(
+  data: Omit<ReleaseRun, "id" | "createdAt" | "updatedAt">,
+): ReleaseRun {
+  const now = new Date().toISOString();
+  return releaseRunSchema.parse({
+    ...data,
+    id: randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+export function applyReleaseRunUpdate(
+  existing: ReleaseRun,
+  updates: Partial<ReleaseRun>,
+): ReleaseRun {
+  return releaseRunSchema.parse({
+    ...existing,
+    ...updates,
+    // Immutable fields
+    id: existing.id,
+    createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
   });
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -151,6 +151,56 @@ export const socialChangelogSchema = z.object({
 });
 export type SocialChangelog = z.infer<typeof socialChangelogSchema>;
 
+export const releaseRunStatusEnum = z.enum([
+  "detected",
+  "evaluating",
+  "skipped",
+  "proposed",
+  "publishing",
+  "published",
+  "error",
+]);
+export type ReleaseRunStatus = z.infer<typeof releaseRunStatusEnum>;
+
+export const releaseBumpEnum = z.enum(["patch", "minor", "major"]);
+export type ReleaseBump = z.infer<typeof releaseBumpEnum>;
+
+export const releaseRunIncludedPRSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  url: z.string(),
+  author: z.string(),
+  mergedAt: z.string(),
+  mergeSha: z.string(),
+});
+export type ReleaseRunIncludedPR = z.infer<typeof releaseRunIncludedPRSchema>;
+
+export const releaseRunSchema = z.object({
+  id: z.string(),
+  repo: z.string(),
+  baseBranch: z.string(),
+  triggerPrNumber: z.number(),
+  triggerPrTitle: z.string(),
+  triggerPrUrl: z.string(),
+  triggerMergeSha: z.string(),
+  triggerMergedAt: z.string(),
+  status: releaseRunStatusEnum,
+  decisionReason: z.string().nullable(),
+  recommendedBump: releaseBumpEnum.nullable(),
+  proposedVersion: z.string().nullable(),
+  releaseTitle: z.string().nullable(),
+  releaseNotes: z.string().nullable(),
+  includedPrs: z.array(releaseRunIncludedPRSchema),
+  targetSha: z.string().nullable(),
+  githubReleaseId: z.number().nullable(),
+  githubReleaseUrl: z.string().nullable(),
+  error: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  completedAt: z.string().nullable(),
+});
+export type ReleaseRun = z.infer<typeof releaseRunSchema>;
+
 export const configSchema = z.object({
   githubToken: z.string(),
   codingAgent: z.enum(["codex", "claude"]),
@@ -159,6 +209,7 @@ export const configSchema = z.object({
   pollIntervalMs: z.number(),
   maxChangesPerRun: z.number(),
   autoResolveMergeConflicts: z.boolean(),
+  autoCreateReleases: z.boolean(),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
   ignoredBots: z.array(z.string()),

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -205,3 +205,12 @@
   - Compare both the root docs entry page and any generated docs pages against the provided reference before editing.
   - Move shared docs layout into the generator or a shared template so the reference style cannot drift between pages.
   - Rebuild generated docs after the template change and inspect at least one root page and one generated page for matching shell structure.
+
+## 2026-03-28 - Lock generated content structure into prompts and tests
+- Pattern: I implemented release-note generation without encoding the exact user-requested structure, and the user corrected it to require a value-driven summary followed by detailed plain-English changelog lines.
+- Rule: When a feature depends on AI-generated text, translate any user-specified output structure into explicit prompt instructions and add a regression test that asserts those instructions are present.
+- Prevention checklist:
+  - Restate required sections, ordering, and tone before finalizing any prompt-backed feature.
+  - Treat content shape requirements as part of the contract, not as optional wording polish.
+  - Add a focused test on the prompt builder whenever the user specifies exact output sections.
+  - Prefer explicit section headings in prompts when the output will be surfaced directly in the product.


### PR DESCRIPTION
## Summary
- add durable release-run storage and release manager orchestration for merged PR evaluation
- add GitHub merge/release helpers and wire watcher-triggered release evaluation into the server
- add a Releases page plus settings toggle for automatic release creation

## Verification
- npm run check
- ./node_modules/.bin/tsx --test server/releaseAgent.test.ts server/releaseManager.test.ts server/babysitter.test.ts server/storage.test.ts server/memoryStorage.test.ts server/github.test.ts
- node --test --import tsx server/*.test.ts