### PR TITLE
feat: auto-assess PR documentation updates

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -722,6 +722,21 @@ export default function Dashboard() {
             />
             Auto-resolve conflicts
           </label>
+          <label className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={config?.autoUpdateDocs ?? true}
+              onChange={(e) =>
+                updateConfigMutation.mutate({
+                  autoUpdateDocs: e.target.checked,
+                })
+              }
+              disabled={updateConfigMutation.isPending}
+              data-testid="checkbox-auto-update-docs"
+              className="accent-foreground"
+            />
+            Auto-update docs
+          </label>
           <Link
             href="/settings"
             className="border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -104,6 +104,25 @@ export default function Settings() {
                 onChange={(v) => updateConfigMutation.mutate({ maxChangesPerRun: v })}
                 disabled={updateConfigMutation.isPending}
               />
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm">Auto-update docs</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Automatically assess whether tracked PRs need documentation updates.
+                  </div>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={config?.autoUpdateDocs ?? true}
+                  onChange={(e) =>
+                    updateConfigMutation.mutate({
+                      autoUpdateDocs: e.target.checked,
+                    })
+                  }
+                  disabled={updateConfigMutation.isPending}
+                  className="h-4 w-4 accent-foreground"
+                />
+              </div>
             </div>
           </section>
 

--- a/docs/plans/2026-03-28-conditional-pr-documentation-updates-design.md
+++ b/docs/plans/2026-03-28-conditional-pr-documentation-updates-design.md
@@ -1,0 +1,126 @@
+# Conditional PR Documentation Updates Design
+
+**Date:** 2026-03-28
+**Status:** Approved
+
+## Goal
+
+Teach Code Factory to decide, for arbitrary tracked repositories, whether a pull request changes user-facing behavior, public API, configuration, setup, or operator workflow enough to require documentation updates, and if so update the appropriate repository docs as part of the autonomous PR babysitter flow.
+
+## Requirements
+
+- Keep the feature repository-agnostic. Do not hardcode this repo's own docs layout or CI pipeline into product behavior.
+- Run documentation assessment for newly tracked PRs and again whenever the tracked PR's head SHA changes.
+- Add a global `autoUpdateDocs` setting, default `true`.
+- Let the agent decide both whether docs are needed and which documents should be edited.
+- Treat a docs-needed decision as real autonomous work, even if the PR has no review comments or failing CI statuses.
+- Persist per-PR documentation assessment state so successful same-SHA decisions are reused and failed same-SHA assessments are retried.
+- Keep documentation assessment out of GitHub feedback items and out of GitHub audit comments.
+- Do not let documentation assessment failure abort the rest of the babysitter run.
+- Continue to run all assessment and remediation inside the app-owned `~/.codefactory` repo cache and worktree model.
+
+## Architecture
+
+Add a new global config flag, `autoUpdateDocs`, and a small optional `docsAssessment` record on each tracked PR. That PR-level record should store the last attempted head SHA, an outcome (`needed`, `not_needed`, or `failed`), a short summary, and an assessment timestamp.
+
+Code Factory should compare the current GitHub head SHA to the stored docs assessment state after it fetches the latest PR summary. If docs automation is enabled and the current SHA has never been assessed, has changed since the last successful assessment, or the last assessment for this SHA failed, the babysitter should run a dedicated documentation assessment step.
+
+That assessment must happen inside the prepared PR worktree, not from the Code Factory repo itself. The agent needs actual repository context to judge whether docs should change, so the babysitter should prepare the isolated worktree, fetch the base branch, and build prompt context from the branch diff before asking the agent for a yes/no decision.
+
+If the agent says docs are needed, the babysitter should keep using the existing autonomous fix run rather than inventing a second remediation pipeline. The fix prompt should include a docs task that tells the agent to update the appropriate repository documentation according to that repo's own conventions. Code Factory should not maintain a hardcoded document allowlist.
+
+## Data Model
+
+### Config
+
+Add `autoUpdateDocs: boolean` to the shared config schema and default config. Persist it through both memory and SQLite storage, expose it through the existing config API, and include it in the MCP `update_config` schema.
+
+### PR State
+
+Add an optional `docsAssessment` object to the shared PR schema with:
+
+- `headSha`
+- `status`
+- `summary`
+- `assessedAt`
+
+Store this on the PR itself rather than in feedback items. This is internal automation state, not reviewer-authored feedback.
+
+### SQLite Persistence
+
+Persist the docs assessment as JSON in the `prs` table via a new `docs_assessment_json` column. That keeps the change small while still making the assessment durable across restarts. Fresh databases and migrated databases must share the same schema shape.
+
+## Assessment Flow
+
+1. Fetch the latest PR summary and failing statuses.
+2. Evaluate pending GitHub feedback and failing statuses as today.
+3. Decide whether docs assessment is due for the current head SHA.
+4. If there is no comment work, no status work, no follow-up work, no conflict work, and no docs assessment due or docs-needed state for the current SHA, end the run as a no-op.
+5. If docs assessment is due, or other work already requires a worktree, prepare the isolated PR worktree.
+6. Fetch `origin/<baseRef>` into the worktree and gather diff context such as:
+   - `git diff --name-only origin/<baseRef>...HEAD`
+   - `git diff --stat origin/<baseRef>...HEAD`
+7. Ask the configured agent whether the PR requires documentation changes. Reuse the existing evaluation JSON shape (`needsFix` + `reason`) instead of adding a second parsing contract.
+8. Persist the assessment result on the PR and write explicit logs for required / not required / failed decisions.
+9. If the result is `needed`, include documentation work in the main fix prompt and treat that as actionable work even with zero comment/status tasks.
+
+## Prompt Contract
+
+The documentation assessment prompt should:
+
+- identify the repo, PR number, title, base branch, and head branch;
+- include changed-file and diff-stat context from the prepared worktree;
+- ask for JSON only;
+- use `needsFix=true` only when repository docs should be updated in the PR branch;
+- require `reason` to explain what kind of docs are likely stale, such as README, setup docs, API docs, config docs, or operator docs.
+
+The remediation prompt should add a documentation task only when the current PR state says docs are needed. That prompt should tell the agent to follow repo conventions, update canonical docs sources when obvious, and avoid unrelated rewrites.
+
+## Re-run Semantics
+
+- Same SHA + `needed`: reuse the stored docs-required decision and retry remediation without reassessing.
+- Same SHA + `not_needed`: skip reassessment.
+- Same SHA + `failed`: retry assessment on the next babysitter run.
+- New SHA: reassess docs need, regardless of the prior decision.
+
+If the babysitter pushes a documentation update successfully, the next watcher cycle will see a new head SHA and reassess that new branch state normally.
+
+## Operator Visibility
+
+- Add `autoUpdateDocs` controls to the dashboard/settings config surfaces.
+- Keep the docs assessment record in the PR API response for future UI use.
+- Add explicit log entries for:
+  - docs assessment skipped because SHA already assessed,
+  - docs assessment started,
+  - docs update required,
+  - docs update not required,
+  - docs assessment failed,
+  - docs task injected into the autonomous fix prompt.
+
+Do not post separate GitHub comments for docs assessment decisions.
+
+## Error Handling
+
+If docs assessment fails, store `failed` for that SHA, log the failure, and continue the babysitter run. Feedback-driven or status-driven remediation should still proceed.
+
+If docs are required and the later autonomous fix run fails, keep the `needed` decision attached to that SHA so the next babysitter run can retry remediation without re-running the assessment first.
+
+## Testing Strategy
+
+Add targeted coverage for:
+
+- shared schema / default config updates;
+- SQLite and memory-storage round-trips for `autoUpdateDocs` and `docsAssessment`;
+- watcher/manual babysitter behavior when docs automation is disabled;
+- first-run docs assessment on a new SHA;
+- same-SHA reuse for `needed` and `not_needed`;
+- same-SHA retry for `failed`;
+- prompt injection when docs are required;
+- autonomous agent execution triggered by docs-needed work alone;
+- graceful continuation when docs assessment fails.
+
+## Risks And Constraints
+
+- Diff-only context may be imperfect for repositories with unusual docs generation flows. The prompt should bias toward canonical source docs when that distinction is obvious, but the agent remains responsible for following the repo's actual conventions.
+- A successful docs-only run will create a new head SHA, so the next watcher cycle will reassess the branch. Same-SHA caching prevents immediate loops on unchanged commits.
+- Reusing the existing evaluation contract keeps the system simpler and avoids introducing a second structured parser path in `server/agentRunner.ts`.

--- a/docs/plans/2026-03-28-conditional-pr-documentation-updates.md
+++ b/docs/plans/2026-03-28-conditional-pr-documentation-updates.md
@@ -1,0 +1,193 @@
+# Conditional PR Documentation Updates Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Teach Code Factory to have the configured agent assess whether a tracked PR needs documentation updates and, when needed, include those docs changes in the autonomous PR babysitter run.
+
+**Architecture:** Add a global `autoUpdateDocs` config flag plus a small per-PR docs-assessment record. Reuse the existing `evaluateFixNecessityWithAgent` JSON contract for a dedicated docs-assessment prompt that runs inside the prepared PR worktree, persist the result per head SHA, and inject a docs task into the normal fix prompt only when the current SHA needs docs work.
+
+**Tech Stack:** TypeScript, Express, React, SQLite (`node:sqlite`), Node test runner (`node --test --import tsx`).
+
+---
+
+### Task 1: Add Shared Docs Assessment And Config Types
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `shared/models.ts`
+- Modify: `server/defaultConfig.ts`
+- Modify: `server/defaultConfig.test.ts`
+- Modify: `server/github.test.ts`
+
+**Step 1: Add failing config assertions**
+Add assertions in `server/defaultConfig.test.ts` that require `autoUpdateDocs` to exist and default to `true`.
+
+**Step 2: Run the default-config test**
+Run: `node --test --import tsx server/defaultConfig.test.ts`
+Expected: FAIL because `autoUpdateDocs` is not defined yet.
+
+**Step 3: Implement the shared schema changes**
+Add:
+- `docsAssessmentStatusEnum`
+- `docsAssessmentSchema`
+- optional `docsAssessment` on `prSchema`
+- `autoUpdateDocs` on `configSchema`
+- `applyConfigUpdate` merge support
+- `DEFAULT_CONFIG.autoUpdateDocs = true`
+- any required config-fixture updates in `server/github.test.ts`
+
+**Step 4: Re-run the default-config test**
+Run: `node --test --import tsx server/defaultConfig.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: add docs assessment schema and config defaults"`
+
+### Task 2: Persist Docs Assessment State And Config
+
+**Files:**
+- Modify: `server/memoryStorage.ts`
+- Modify: `server/sqliteStorage.ts`
+- Modify: `server/storage.test.ts`
+- Modify: `server/memoryStorage.test.ts`
+
+**Step 1: Add failing storage tests**
+Add coverage for:
+- `autoUpdateDocs` round-tripping through storage,
+- `docsAssessment` round-tripping on a stored PR,
+- config fallback still returning `autoUpdateDocs: true` when the singleton config row is missing.
+
+**Step 2: Run targeted storage tests**
+Run: `node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts`
+Expected: FAIL.
+
+**Step 3: Implement storage persistence**
+Implement:
+- config parsing/writing for `autoUpdateDocs`,
+- `docs_assessment_json` in the SQLite `prs` table definition,
+- matching `ensureColumn` migration for existing databases,
+- JSON serialize/deserialize for PR docs assessment state,
+- memory-storage preservation of the same field.
+
+**Step 4: Re-run targeted storage tests**
+Run: `node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: persist per-pr docs assessment state"`
+
+### Task 3: Expose The Global Docs Toggle In Product Surfaces
+
+**Files:**
+- Modify: `client/src/pages/dashboard.tsx`
+- Modify: `client/src/pages/settings.tsx`
+- Modify: `server/mcp.ts`
+
+**Step 1: Add the product controls**
+Implement:
+- a dashboard-header checkbox alongside the existing autonomous controls,
+- a settings-page control with a short explanation of what the feature does,
+- MCP `update_config` schema/description support for `autoUpdateDocs`.
+
+**Step 2: Run strict typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 3: Run the production build**
+Run: `npm run build`
+Expected: PASS.
+
+**Step 4: Manual config smoke check**
+Start the app, toggle `autoUpdateDocs` off and on, and confirm the setting persists across a refresh.
+
+**Step 5: Commit**
+`git commit -m "feat: add auto-update docs configuration controls"`
+
+### Task 4: Add Worktree-Based Documentation Assessment
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Add failing babysitter tests for assessment behavior**
+Add tests for:
+- docs assessment runs on the first unseen head SHA when `autoUpdateDocs` is enabled,
+- `not_needed` on the same SHA skips reassessment,
+- `failed` on the same SHA retries assessment,
+- disabled config skips docs assessment entirely.
+
+**Step 2: Run the babysitter test file**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL.
+
+**Step 3: Implement the docs assessment flow**
+Implement:
+- `buildDocumentationAssessmentPrompt(...)`,
+- stale/failed-SHA detection using `pr.docsAssessment`,
+- worktree preparation when docs assessment is due,
+- base-branch fetch plus diff context collection (`git diff --name-only` / `--stat`),
+- agent evaluation for docs need using the existing evaluation helper,
+- PR-state/log updates for `needed`, `not_needed`, and `failed`.
+
+**Step 4: Re-run the babysitter tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS for the assessment-only cases.
+
+**Step 5: Commit**
+`git commit -m "feat: assess documentation needs in pr worktrees"`
+
+### Task 5: Make Docs-Needed A First-Class Remediation Task
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Add failing remediation tests**
+Add tests for:
+- a `needed` docs assessment extending the autonomous fix prompt,
+- docs-needed work alone triggering agent execution even with zero comment/status tasks,
+- `not_needed` leaving the fix prompt unchanged,
+- a failed fix run preserving the `needed` state for same-SHA retry.
+
+**Step 2: Run the babysitter test file**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL.
+
+**Step 3: Implement docs remediation integration**
+Implement:
+- a docs section in `buildAgentFixPrompt(...)`,
+- prompt wording that lets the agent choose the right repository docs while following repo conventions,
+- `hasAgentWork` support for docs-only remediation,
+- same-SHA reuse of successful docs decisions,
+- preservation of `needed` state across failed remediation runs.
+
+**Step 4: Re-run the babysitter tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git commit -m "feat: include docs updates in autonomous pr remediation"`
+
+### Task 6: Final Verification Sweep
+
+**Files:**
+- Modify: only files above as needed
+
+**Step 1: Run targeted backend tests**
+Run: `node --test --import tsx server/defaultConfig.test.ts server/storage.test.ts server/memoryStorage.test.ts server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 2: Run the full server test suite**
+Run: `node --test --import tsx server/*.test.ts`
+Expected: PASS.
+
+**Step 3: Run strict typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 4: Run the production build**
+Run: `npm run build`
+Expected: PASS.
+
+**Step 5: Commit final verification fixes**
+`git commit -m "test: verify conditional pr documentation update flow"`

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -409,6 +409,7 @@ test("retryFeedbackItem serializes concurrent retry updates for the same PR", as
 
 test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and verifies audit trail", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem();
   const pr = await storage.addPR({
     number: 106,
@@ -532,9 +533,10 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(fixRunLog);
   assert.equal(
     fixRunLog.message,
-    "Babysitter preparing fix run with 1 comment task(s), 0 status task(s), and 1 GitHub follow-up task(s) using codex",
+    "Babysitter preparing fix run with 1 comment task(s), 0 status task(s), 0 documentation task(s), and 1 GitHub follow-up task(s) using codex",
   );
   assert.equal(fixRunLog.metadata?.followUpTasks, 1);
+  assert.equal(fixRunLog.metadata?.docsTasks, 0);
   assert.deepEqual(postedFollowUps, [
     {
       id: "gh-review-comment-1",
@@ -546,7 +548,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(logs.some((log) => log.phase === "github.followup" && log.message.includes("GitHub follow-up complete for gh-review-comment-1")));
   assert.ok(logs.some((log) => log.phase === "verify.github" && log.message.includes("GitHub audit trail verified")));
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("Babysitter run complete")));
-  assert.match(receivedPrompt, /commit it and push it to origin HEAD:feature\/verbose/i);
+  assert.match(receivedPrompt, /If you changed files, commit and push to origin HEAD:feature\/verbose/i);
   assert.match(receivedPrompt, /GitHub follow-up replies and review-thread resolution will be handled by the babysitter/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.match(receivedPrompt, /FEEDBACK_SUMMARY_START/);
@@ -558,6 +560,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
 
 test("babysitPR centralizes status replies, logs best-effort failures, and updates replies in parallel", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const firstItem = makeFeedbackItem();
   const secondItem = makeFeedbackItem({
     id: "gh-review-comment-2",
@@ -610,7 +613,7 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
         sourceUrl: "https://github.com/octo/example/pull/42#discussion_r3",
         threadId: firstItem.threadId,
         threadResolved: true,
-        createdAt: "2026-03-15T10:02:00.000Z",
+        createdAt: new Date().toISOString(),
         decision: null,
         decisionReason: null,
         action: null,
@@ -625,7 +628,7 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
         sourceUrl: "https://github.com/octo/example/pull/42#discussion_r4",
         threadId: secondItem.threadId,
         threadResolved: true,
-        createdAt: "2026-03-15T10:03:00.000Z",
+        createdAt: new Date().toISOString(),
         decision: null,
         decisionReason: null,
         action: null,
@@ -726,6 +729,7 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
 
 test("babysitPR marks the run as error when app-owned GitHub follow-up fails", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem();
   const pr = await storage.addPR({
     number: 106,
@@ -806,6 +810,7 @@ test("babysitPR marks the run as error when app-owned GitHub follow-up fails", a
 
 test("babysitPR treats audit-trail replies as non-actionable follow-up comments", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const originalItem = makeFeedbackItem({
     decision: "accept",
     decisionReason: "Previously addressed",
@@ -891,6 +896,7 @@ test("babysitPR treats audit-trail replies as non-actionable follow-up comments"
 
 test("babysitPR does not auto-ignore audit-trail replies when referenced timestamps are invalid", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const originalItem = makeFeedbackItem({
     decision: "accept",
     decisionReason: "Previously addressed",
@@ -981,6 +987,7 @@ test("babysitPR does not auto-ignore audit-trail replies when referenced timesta
 
 test("babysitPR marks accepted pending items as resolved after a successful run", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem({ status: "pending", decision: null });
   const pr = await storage.addPR({
     number: 106,
@@ -1062,6 +1069,7 @@ test("babysitPR marks accepted pending items as resolved after a successful run"
 
 test("babysitPR marks claimed items as warning when audit trail verification fails but branch moved", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem({ status: "pending", decision: null });
   const pr = await storage.addPR({
     number: 106,
@@ -1124,6 +1132,7 @@ test("babysitPR marks claimed items as warning when audit trail verification fai
 
 test("babysitPR picks up manually-queued items and resolves them without re-evaluating", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const queuedItem = makeFeedbackItem({
     status: "queued",
     decision: "accept",
@@ -1312,6 +1321,7 @@ test("babysitPR does not pull rejected or resolved items into in_progress", asyn
 
 test("babysitPR skips run when no items are pending or queued", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const rejectedItem = makeFeedbackItem({ status: "rejected", decision: "reject" });
   const pr = await storage.addPR({
     number: 106,
@@ -1369,8 +1379,642 @@ test("babysitPR skips run when no items are pending or queued", async () => {
   delete process.env.CODEFACTORY_HOME;
 });
 
+test("babysitPR suppresses docs assessment and docs remediation when autoUpdateDocs is disabled", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs toggle off",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "needed",
+      summary: "README should be updated",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let evaluateCalls = 0;
+  let applyCalled = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => undefined,
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => {
+        evaluateCalls += 1;
+        return { needsFix: true, reason: "Should not run when docs automation is disabled" };
+      },
+      applyFixesWithAgent: async () => {
+        applyCalled = true;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(evaluateCalls, 0);
+  assert.equal(applyCalled, false);
+  assert.equal(updated?.status, "watching");
+  assert.ok(!logs.some((log) => log.phase === "evaluate.docs"));
+});
+
+test("babysitPR reuses same-SHA docsAssessment needed without reassessing", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Cached docs needed",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "needed",
+      summary: "README and configuration docs should be updated",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let evaluateCalls = 0;
+  let applyCalled = false;
+  let capturedPrompt = "";
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => {
+          evaluateCalls += 1;
+          return { needsFix: false, reason: "Should not reassess for same SHA" };
+        },
+        applyFixesWithAgent: async ({ prompt }) => {
+          applyCalled = true;
+          capturedPrompt = prompt;
+          const output = [
+            "DOCS_SUMMARY_START changed",
+            "Updated README and configuration docs.",
+            "DOCS_SUMMARY_END",
+          ].join("\n");
+          return { code: 0, stdout: `${output}\n`, stderr: "" };
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const logs = await storage.getLogs(pr.id);
+    assert.equal(evaluateCalls, 0);
+    assert.equal(applyCalled, true);
+    assert.match(capturedPrompt, /Approved documentation tasks:/);
+    assert.match(capturedPrompt, /README and configuration docs should be updated/);
+    assert.match(capturedPrompt, /DOCS_SUMMARY_START <changed\|no_change>/);
+    assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("(needed)")));
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR reuses same-SHA docsAssessment not_needed and skips agent work", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Cached docs not needed",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "not_needed",
+      summary: "No docs changes required",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let evaluateCalls = 0;
+  let applyCalled = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => undefined,
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => {
+        evaluateCalls += 1;
+        return { needsFix: true, reason: "Should not run for not_needed same SHA" };
+      },
+      applyFixesWithAgent: async () => {
+        applyCalled = true;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(evaluateCalls, 0);
+  assert.equal(applyCalled, false);
+  assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("(not_needed)")));
+});
+
+test("babysitPR reassesses docs when the head SHA changes", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Head moved docs reassessment",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "not_needed",
+      summary: "No docs changes required for the previous head",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let evaluateCalls = 0;
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "def456" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => {
+          evaluateCalls += 1;
+          return { needsFix: false, reason: "Docs are still accurate for the new head SHA" };
+        },
+        applyFixesWithAgent: async () => {
+          throw new Error("Should not run the agent when reassessment returns not_needed");
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    assert.equal(evaluateCalls, 1);
+    assert.equal(updated?.docsAssessment?.headSha, "def456");
+    assert.equal(updated?.docsAssessment?.status, "not_needed");
+    assert.match(updated?.docsAssessment?.summary || "", /new head SHA/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR retries docs assessment for same-SHA failed state", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Retry failed docs assessment",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "failed",
+      summary: "Previous docs evaluation timed out",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let evaluateCalls = 0;
+  let applyCalled = false;
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => {
+          evaluateCalls += 1;
+          return { needsFix: false, reason: "No docs updates required after retry" };
+        },
+        applyFixesWithAgent: async () => {
+          applyCalled = true;
+          return { code: 0, stdout: "", stderr: "" };
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    assert.equal(evaluateCalls, 1);
+    assert.equal(applyCalled, false);
+    assert.equal(updated?.docsAssessment?.headSha, "abc123");
+    assert.equal(updated?.docsAssessment?.status, "not_needed");
+    assert.match(updated?.docsAssessment?.summary || "", /No docs updates required/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR runs agent for docs-only work when docs assessment says needed", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs-only remediation",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let evaluateCalls = 0;
+  let applyCalled = false;
+  let capturedPrompt = "";
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => {
+          evaluateCalls += 1;
+          return { needsFix: true, reason: "README and API docs need updates" };
+        },
+        applyFixesWithAgent: async ({ prompt }) => {
+          applyCalled = true;
+          capturedPrompt = prompt;
+          const output = [
+            "DOCS_SUMMARY_START changed",
+            "Updated README and API docs.",
+            "DOCS_SUMMARY_END",
+          ].join("\n");
+          return { code: 0, stdout: `${output}\n`, stderr: "" };
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    assert.equal(evaluateCalls, 1);
+    assert.equal(applyCalled, true);
+    assert.equal(updated?.docsAssessment?.status, "needed");
+    assert.match(capturedPrompt, /Approved documentation tasks:/);
+    assert.match(capturedPrompt, /README and API docs need updates/);
+    assert.match(capturedPrompt, /DOCS_SUMMARY_START <changed\|no_change>/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR allows docs no_change outcome after inspection", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs no-change outcome",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    docsAssessment: {
+      headSha: "abc123",
+      status: "needed",
+      summary: "README may need an update",
+      assessedAt: "2026-03-28T10:00:00.000Z",
+    },
+  });
+
+  let applyCalls = 0;
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => {
+          throw new Error("Should not reassess for same SHA");
+        },
+        applyFixesWithAgent: async () => {
+          applyCalls += 1;
+          const output = [
+            "DOCS_SUMMARY_START no_change",
+            "The existing README already explains this behavior accurately.",
+            "DOCS_SUMMARY_END",
+          ].join("\n");
+          return { code: 0, stdout: `${output}\n`, stderr: "" };
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "abc123", remoteHeadSha: "abc123" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    const logs = await storage.getLogs(pr.id);
+    assert.equal(applyCalls, 1);
+    assert.equal(updated?.status, "watching");
+    assert.equal(updated?.docsAssessment?.status, "not_needed");
+    assert.equal(updated?.docsAssessment?.headSha, "abc123");
+    assert.match(updated?.docsAssessment?.summary || "", /already explains this behavior accurately/);
+    assert.ok(logs.some((log) => log.phase === "verify.docs" && log.message.includes("no_change")));
+    assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("(not_needed)")));
+    assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("no necessary fixes identified")));
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR continues comment remediation when docs assessment fails", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs assessment failure isolation",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let feedbackFetchCount = 0;
+  let applyCalled = false;
+  const followUp = makeFeedbackItem({
+    id: "gh-review-comment-2",
+    author: "code-factory",
+    body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    sourceId: "2",
+    sourceNodeId: "PRRC_kwDO_followup",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
+    threadId: existingItem.threadId,
+    threadResolved: true,
+    createdAt: new Date().toISOString(),
+    auditToken: "codefactory-feedback:gh-review-comment-2",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => {
+          feedbackFetchCount += 1;
+          if (feedbackFetchCount === 1) {
+            return [existingItem];
+          }
+          return [{ ...existingItem, threadResolved: true }, followUp];
+        },
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async ({ prompt }) => {
+          if (prompt.includes("requires repository documentation updates")) {
+            throw new Error("docs assessment exploded");
+          }
+          return { needsFix: true, reason: "Comment requires a code change" };
+        },
+        applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
+          applyCalled = true;
+          const output = [
+            "FEEDBACK_SUMMARY_START codefactory-feedback:gh-review-comment-1",
+            "Applied requested rename.",
+            "FEEDBACK_SUMMARY_END",
+          ].join("\n");
+          onStdoutChunk?.(`${output}\n`);
+          onStderrChunk?.("");
+          return { code: 0, stdout: `${output}\n`, stderr: "" };
+        },
+        runCommand: makeGitRunCommand({ localHeadSha: "def456", remoteHeadSha: "def456" }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    const logs = await storage.getLogs(pr.id);
+    assert.equal(applyCalled, true);
+    assert.equal(updated?.status, "watching");
+    assert.equal(updated?.docsAssessment?.status, "failed");
+    assert.match(updated?.docsAssessment?.summary || "", /docs assessment exploded/);
+    assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("Documentation assessment failed")));
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
 test("babysitPR retries accepted in-progress feedback items that still need GitHub follow-up without rerunning the agent", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem({
     decision: "accept",
     decisionReason: "Already fixed in a previous run",
@@ -1708,6 +2352,7 @@ test("resumeInterruptedRuns skips prompt replay when the PR head already moved",
 
 test("babysitPR resolves lingering review threads without reposting an existing audit trail", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem({
     decision: "accept",
     decisionReason: "Already fixed in a previous run",
@@ -1821,6 +2466,7 @@ test("babysitPR resolves lingering review threads without reposting an existing 
 
 test("babysitPR reposts GitHub follow-up when an earlier audit trail used the wrong thread", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem({
     decision: "accept",
     decisionReason: "Already fixed in a previous run",
@@ -2132,6 +2778,7 @@ test("babysitPR pushes a clean base merge when GitHub mergeability is stale", as
 
 test("babysitPR skips conflict resolution when PR is mergeable", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem();
   const pr = await storage.addPR({
     number: 106,
@@ -2308,7 +2955,7 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
 
 test("babysitPR skips conflict resolution when autoResolveMergeConflicts is disabled", async () => {
   const storage = new MemStorage();
-  await storage.updateConfig({ autoResolveMergeConflicts: false });
+  await storage.updateConfig({ autoResolveMergeConflicts: false, autoUpdateDocs: false });
   const pr = await storage.addPR({
     number: 107,
     title: "Conflict skip PR",

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -207,6 +207,71 @@ function buildStatusEvaluationPrompt(params: {
   ].join("\n");
 }
 
+function truncateForPrompt(input: string, maxChars: number): string {
+  if (input.length <= maxChars) {
+    return input;
+  }
+
+  return `${input.slice(0, maxChars)}\n... (truncated)`;
+}
+
+function buildDocumentationAssessmentPrompt(params: {
+  pr: PR;
+  pullSummary: GitHubPullSummary;
+  changedFiles: string;
+  diffStat: string;
+  diffPreview: string;
+}): string {
+  const { pr, pullSummary, changedFiles, diffStat, diffPreview } = params;
+
+  return [
+    "You are deciding whether a pull request requires repository documentation updates.",
+    "Return JSON only.",
+    `Repository: ${pr.repo}`,
+    `PR: #${pr.number}`,
+    `PR title: ${pr.title}`,
+    `Base branch: ${pullSummary.baseRef}`,
+    `Head branch: ${pullSummary.headRef}`,
+    "",
+    "Changed files (git diff --name-only origin/base...HEAD):",
+    truncateForPrompt(changedFiles || "None", 4000),
+    "",
+    "Diff stat (git diff --stat origin/base...HEAD):",
+    truncateForPrompt(diffStat || "None", 4000),
+    "",
+    "Unified diff excerpt (git diff --unified=0 origin/base...HEAD):",
+    truncateForPrompt(diffPreview || "None", 12000),
+    "",
+    "Decision rule:",
+    "- needsFix=true only when docs should be updated in this PR branch.",
+    "- needsFix=false when current docs are already accurate for these changes.",
+    "- Consider README, setup docs, API docs, configuration docs, and operator docs based on repo conventions.",
+    "- reason must briefly explain what docs should change (or why no docs change is needed).",
+  ].join("\n");
+}
+
+function getCurrentHeadDocsAssessment(pr: PR, headSha: string): NonNullable<PR["docsAssessment"]> | null {
+  const assessment = pr.docsAssessment;
+  if (!assessment || assessment.headSha !== headSha) {
+    return null;
+  }
+
+  return assessment;
+}
+
+function shouldAssessDocsForHead(pr: PR, headSha: string, enabled: boolean): boolean {
+  if (!enabled) {
+    return false;
+  }
+
+  const existing = getCurrentHeadDocsAssessment(pr, headSha);
+  if (!existing) {
+    return true;
+  }
+
+  return existing.status === "failed";
+}
+
 function buildConflictResolutionPrompt(params: {
   pr: PR;
   pullSummary: GitHubPullSummary;
@@ -250,8 +315,9 @@ function buildAgentFixPrompt(params: {
   remoteName: string;
   commentTasks: FeedbackItem[];
   statusTasks: { context: string; description: string; targetUrl: string | null }[];
+  docsTaskSummary: string | null;
 }): string {
-  const { pr, pullSummary, remoteName, commentTasks, statusTasks } = params;
+  const { pr, pullSummary, remoteName, commentTasks, statusTasks, docsTaskSummary } = params;
 
   const commentSection = commentTasks.length
     ? commentTasks
@@ -276,6 +342,16 @@ function buildAgentFixPrompt(params: {
         .join("\n")
     : "None";
 
+  const docsSection = docsTaskSummary
+    ? [
+        "Documentation updates are required for this PR.",
+        `Assessment summary: ${docsTaskSummary}`,
+        "Update the appropriate repository documentation for these changes.",
+        "Choose the right docs files for this repository (for example README, docs pages, API/config/operator docs).",
+        "If, after inspection, the repository documentation is already accurate or there is no appropriate docs target, leave docs unchanged and report that using the docs summary block with `no_change`.",
+      ].join("\n")
+    : "None";
+
   return [
     `You are acting as an autonomous PR babysitter for ${pr.repo} PR #${pr.number}.`,
     `PR URL: ${pr.url}`,
@@ -297,14 +373,21 @@ function buildAgentFixPrompt(params: {
     "Approved status-check tasks:",
     statusSection,
     "",
+    "Approved documentation tasks:",
+    docsSection,
+    "",
     "When done:",
     "1) Run the relevant verification for your changes.",
-    `2) If you changed code, commit it and push it to ${remoteName} HEAD:${pullSummary.headRef}.`,
+    `2) If you changed files, commit and push to ${remoteName} HEAD:${pullSummary.headRef}.`,
     "3) For each feedback item you addressed or were blocked on, emit a summary block in the following format:",
     "   FEEDBACK_SUMMARY_START <auditToken>",
     "   <A concise 1-2 sentence summary of what you did or why you were blocked>",
     "   FEEDBACK_SUMMARY_END",
     "   Include one block per audit token. These summaries will be posted as follow-up comments on the PR.",
+    "4) If documentation tasks were assigned, emit exactly one docs summary block in the following format:",
+    "   DOCS_SUMMARY_START <changed|no_change>",
+    "   <A concise 1-2 sentence summary of the docs you updated, or why no docs changes were necessary after inspection>",
+    "   DOCS_SUMMARY_END",
   ].join("\n");
 }
 
@@ -318,6 +401,12 @@ function extractMentionedAuditTokens(body: string): string[] {
 }
 
 const FEEDBACK_SUMMARY_BLOCK = /FEEDBACK_SUMMARY_START\s+(codefactory-feedback:[^\s]+)\s*\n([\s\S]*?)FEEDBACK_SUMMARY_END/g;
+const DOCS_SUMMARY_BLOCK = /DOCS_SUMMARY_START\s+(changed|no_change)\s*\n([\s\S]*?)DOCS_SUMMARY_END/;
+
+type DocsTaskOutcome = {
+  outcome: "changed" | "no_change";
+  summary: string;
+};
 
 function extractAgentSummaries(agentOutput: string): Map<string, string> {
   const summaries = new Map<string, string>();
@@ -331,6 +420,24 @@ function extractAgentSummaries(agentOutput: string): Map<string, string> {
     }
   }
   return summaries;
+}
+
+function extractDocsTaskOutcome(agentOutput: string): DocsTaskOutcome | null {
+  const match = DOCS_SUMMARY_BLOCK.exec(agentOutput);
+  if (!match) {
+    return null;
+  }
+
+  const outcome = match[1];
+  const summary = match[2]?.trim();
+  if (!summary || (outcome !== "changed" && outcome !== "no_change")) {
+    return null;
+  }
+
+  return {
+    outcome,
+    summary,
+  };
 }
 
 function isAutomationAuditTrailFollowUp(item: FeedbackItem, feedbackItems: FeedbackItem[]): boolean {
@@ -1411,9 +1518,33 @@ export class PRBabysitter {
       }
       const shouldRunForcedReplay = Boolean(forcedFixPrompt && !skipForcedReplay);
       const disableAgentExecution = Boolean(forcedFixPrompt && skipForcedReplay);
-      const hasAgentWork = !disableAgentExecution && (effectiveCommentTasks.length > 0 || statusTasks.length > 0 || shouldRunForcedReplay);
+      const hasCommentOrStatusAgentWork = !disableAgentExecution && (effectiveCommentTasks.length > 0 || statusTasks.length > 0 || shouldRunForcedReplay);
+      const currentHeadDocsAssessment = getCurrentHeadDocsAssessment(pr, pullSummary.headSha);
+      const docsAssessmentNeeded = !disableAgentExecution
+        && !shouldRunForcedReplay
+        && shouldAssessDocsForHead(pr, pullSummary.headSha, config.autoUpdateDocs);
+      let docsTaskSummary = config.autoUpdateDocs && currentHeadDocsAssessment?.status === "needed"
+        ? currentHeadDocsAssessment.summary
+        : null;
+      let hasDocsTask = Boolean(docsTaskSummary);
+      const needsWorktree = hasCommentOrStatusAgentWork || hasConflicts || docsAssessmentNeeded || hasDocsTask;
 
-      if (!hasAgentWork && followUpTasks.length === 0 && !hasConflicts) {
+      if (config.autoUpdateDocs && currentHeadDocsAssessment && !docsAssessmentNeeded) {
+        await queueLog(
+          pr.id,
+          "info",
+          `Documentation assessment already recorded for ${pullSummary.headSha.slice(0, 7)} (${currentHeadDocsAssessment.status})`,
+          {
+            phase: "evaluate.docs",
+            metadata: {
+              headSha: pullSummary.headSha,
+              status: currentHeadDocsAssessment.status,
+            },
+          },
+        );
+      }
+
+      if (!needsWorktree && followUpTasks.length === 0 && !hasConflicts) {
         await queueLog(pr.id, "info", `Babysitter checked PR #${pr.number}; no necessary fixes identified`, {
           phase: "run",
         });
@@ -1434,6 +1565,7 @@ export class PRBabysitter {
       branchMoved = false;
       let remoteNameForLogs: string | null = null;
       let agentSummaries = new Map<string, string>();
+      let docsTaskOutcome: DocsTaskOutcome | null = null;
 
       if (hasConflicts) {
         await queueLog(pr.id, "info", `PR #${pr.number} has merge conflicts with base branch ${pullSummary.baseRef}`, {
@@ -1442,16 +1574,18 @@ export class PRBabysitter {
         });
       }
 
-      if (hasAgentWork || hasConflicts) {
+      if (needsWorktree || hasConflicts) {
         await queueLog(
           pr.id,
           "info",
-          `Babysitter preparing fix run with ${effectiveCommentTasks.length} comment task(s), ${statusTasks.length} status task(s), and ${followUpTasks.length} GitHub follow-up task(s)${hasConflicts ? ", plus merge conflict resolution" : ""}${shouldRunForcedReplay ? ", with forced prompt replay" : ""} using ${agent}`,
+          `Babysitter preparing fix run with ${effectiveCommentTasks.length} comment task(s), ${statusTasks.length} status task(s), ${hasDocsTask ? 1 : 0} documentation task(s), and ${followUpTasks.length} GitHub follow-up task(s)${docsAssessmentNeeded ? ", with documentation assessment" : ""}${hasConflicts ? ", plus merge conflict resolution" : ""}${shouldRunForcedReplay ? ", with forced prompt replay" : ""} using ${agent}`,
           {
             phase: "run",
             metadata: {
               commentTasks: effectiveCommentTasks.length,
               statusTasks: statusTasks.length,
+              docsTasks: hasDocsTask ? 1 : 0,
+              docsAssessmentNeeded,
               followUpTasks: followUpTasks.length,
               hasConflicts,
               shouldRunForcedReplay,
@@ -1500,6 +1634,140 @@ export class PRBabysitter {
           await queueLog(pr.id, "info", "Git identity ready", {
             phase: "git.identity",
           });
+
+          if (docsAssessmentNeeded) {
+            await queueLog(pr.id, "info", "Documentation assessment started", {
+              phase: "evaluate.docs",
+              metadata: {
+                headSha: pullSummary.headSha,
+              },
+            });
+
+            try {
+              const baseFetchForDocs = await runLoggedCommand({
+                currentPrId: pr.id,
+                command: "git",
+                args: ["fetch", "origin", pullSummary.baseRef],
+                cwd: worktreePath,
+                timeoutMs: 120000,
+                phase: "evaluate.docs",
+                successMessage: `Fetched origin/${pullSummary.baseRef} for docs assessment`,
+              });
+              if (baseFetchForDocs.code !== 0) {
+                throw new Error(`Failed to fetch origin/${pullSummary.baseRef} for docs assessment: ${summarizeCommandFailure(baseFetchForDocs)}`);
+              }
+
+              const changedFilesResult = await runLoggedCommand({
+                currentPrId: pr.id,
+                command: "git",
+                args: ["diff", "--name-only", `origin/${pullSummary.baseRef}...HEAD`],
+                cwd: worktreePath,
+                timeoutMs: 10000,
+                phase: "evaluate.docs",
+                successMessage: "Collected changed files for docs assessment",
+              });
+              if (changedFilesResult.code !== 0) {
+                throw new Error(`Failed to collect changed files for docs assessment: ${summarizeCommandFailure(changedFilesResult)}`);
+              }
+
+              const diffStatResult = await runLoggedCommand({
+                currentPrId: pr.id,
+                command: "git",
+                args: ["diff", "--stat", `origin/${pullSummary.baseRef}...HEAD`],
+                cwd: worktreePath,
+                timeoutMs: 10000,
+                phase: "evaluate.docs",
+                successMessage: "Collected diff stat for docs assessment",
+              });
+              if (diffStatResult.code !== 0) {
+                throw new Error(`Failed to collect diff stat for docs assessment: ${summarizeCommandFailure(diffStatResult)}`);
+              }
+
+              const diffPreviewResult = await runLoggedCommand({
+                currentPrId: pr.id,
+                command: "git",
+                args: ["diff", "--no-color", "--unified=0", `origin/${pullSummary.baseRef}...HEAD`],
+                cwd: worktreePath,
+                timeoutMs: 10000,
+                phase: "evaluate.docs",
+                successMessage: "Collected diff preview for docs assessment",
+              });
+              if (diffPreviewResult.code !== 0) {
+                throw new Error(`Failed to collect diff preview for docs assessment: ${summarizeCommandFailure(diffPreviewResult)}`);
+              }
+
+              const docsPrompt = buildDocumentationAssessmentPrompt({
+                pr,
+                pullSummary,
+                changedFiles: changedFilesResult.stdout.trim(),
+                diffStat: diffStatResult.stdout.trim(),
+                diffPreview: diffPreviewResult.stdout.trim(),
+              });
+              await queueLog(pr.id, "info", `Evaluating documentation needs with ${agent}`, {
+                phase: "evaluate.docs",
+                metadata: {
+                  agent,
+                  prompt: docsPrompt,
+                },
+              });
+
+              const docsEvaluation = await this.runtime.evaluateFixNecessityWithAgent({
+                agent,
+                cwd: worktreePath,
+                prompt: docsPrompt,
+              });
+
+              const docsAssessment = {
+                headSha: pullSummary.headSha,
+                status: docsEvaluation.needsFix ? "needed" as const : "not_needed" as const,
+                summary: docsEvaluation.reason,
+                assessedAt: new Date().toISOString(),
+              };
+              const docsUpdatedPR = await this.storage.updatePR(pr.id, {
+                docsAssessment,
+              });
+              if (docsUpdatedPR) {
+                pr = docsUpdatedPR;
+              }
+
+              hasDocsTask = docsEvaluation.needsFix;
+              docsTaskSummary = docsEvaluation.needsFix ? docsEvaluation.reason : null;
+
+              await queueLog(pr.id, "info", docsEvaluation.needsFix
+                ? `Documentation updates required: ${docsEvaluation.reason}`
+                : `Documentation updates not required: ${docsEvaluation.reason}`, {
+                phase: "evaluate.docs",
+                metadata: {
+                  decision: docsEvaluation.needsFix ? "needed" : "not_needed",
+                  headSha: pullSummary.headSha,
+                },
+              });
+            } catch (error) {
+              const failureMessage = summarizeUnknownError(error);
+              const docsAssessment = {
+                headSha: pullSummary.headSha,
+                status: "failed" as const,
+                summary: failureMessage,
+                assessedAt: new Date().toISOString(),
+              };
+              const docsUpdatedPR = await this.storage.updatePR(pr.id, {
+                docsAssessment,
+              });
+              if (docsUpdatedPR) {
+                pr = docsUpdatedPR;
+              }
+
+              hasDocsTask = false;
+              docsTaskSummary = null;
+
+              await queueLog(pr.id, "warn", `Documentation assessment failed: ${failureMessage}`, {
+                phase: "evaluate.docs",
+                metadata: {
+                  headSha: pullSummary.headSha,
+                },
+              });
+            }
+          }
 
           if (hasConflicts) {
             await queueLog(pr.id, "info", `Fetching base branch origin/${pullSummary.baseRef} for merge`, {
@@ -1642,7 +1910,7 @@ export class PRBabysitter {
             }
           }
 
-          if (shouldRunForcedReplay || effectiveCommentTasks.length > 0 || statusTasks.length > 0) {
+          if (shouldRunForcedReplay || effectiveCommentTasks.length > 0 || statusTasks.length > 0 || hasDocsTask) {
             const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info");
             const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "warn");
             const githubToken = await this.github.resolveGitHubAuthToken(config);
@@ -1660,6 +1928,7 @@ export class PRBabysitter {
               remoteName,
               commentTasks: effectiveCommentTasks,
               statusTasks,
+              docsTaskSummary,
             });
 
             await updateRunRecord({
@@ -1705,10 +1974,15 @@ export class PRBabysitter {
 
             // Extract per-feedback-item summaries from agent output.
             agentSummaries = extractAgentSummaries(applyResult.stdout);
+            docsTaskOutcome = extractDocsTaskOutcome(applyResult.stdout);
 
             await queueLog(pr.id, "info", `${agent} completed successfully`, {
               phase: "agent",
-              metadata: { code: applyResult.code, extractedSummaries: agentSummaries.size },
+              metadata: {
+                code: applyResult.code,
+                extractedSummaries: agentSummaries.size,
+                docsTaskOutcome: docsTaskOutcome?.outcome ?? null,
+              },
             });
             await updateRunRecord({
               phase: "run.agent-finished",
@@ -1785,8 +2059,30 @@ export class PRBabysitter {
             throw new Error("Agent did not update the PR head branch for accepted failing status tasks");
           }
 
+          if (hasDocsTask && !docsTaskOutcome) {
+            throw new Error("Agent did not report documentation task outcome");
+          }
+
+          if (hasDocsTask && !branchMoved && docsTaskOutcome?.outcome !== "no_change") {
+            throw new Error("Agent did not update the PR head branch for required documentation tasks");
+          }
+
           if (hasConflicts && !branchMoved) {
             throw new Error("Agent did not push conflict resolution to the PR head branch");
+          }
+
+          if (hasDocsTask && docsTaskOutcome?.outcome === "no_change") {
+            const docsUpdatedPR = await this.storage.updatePR(pr.id, {
+              docsAssessment: {
+                headSha: pullSummary.headSha,
+                status: "not_needed",
+                summary: docsTaskOutcome.summary,
+                assessedAt: new Date().toISOString(),
+              },
+            });
+            if (docsUpdatedPR) {
+              pr = docsUpdatedPR;
+            }
           }
 
           headShaForFollowUp = localHeadSha;
@@ -1800,8 +2096,19 @@ export class PRBabysitter {
               branchMoved,
               localCommitCreated,
               remoteName,
+              docsTaskOutcome: docsTaskOutcome?.outcome ?? null,
             },
           });
+
+          if (docsTaskOutcome) {
+            await queueLog(pr.id, "info", `Documentation task outcome: ${docsTaskOutcome.outcome} - ${docsTaskOutcome.summary}`, {
+              phase: "verify.docs",
+              metadata: {
+                outcome: docsTaskOutcome.outcome,
+                branchMoved,
+              },
+            });
+          }
         } finally {
           try {
             await queueLog(pr.id, "info", "Cleaning up worktree", {

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -12,6 +12,8 @@ describe("DEFAULT_CONFIG", () => {
       "batchWindowMs",
       "pollIntervalMs",
       "maxChangesPerRun",
+      "autoResolveMergeConflicts",
+      "autoUpdateDocs",
       "watchedRepos",
       "trustedReviewers",
       "ignoredBots",
@@ -71,5 +73,9 @@ describe("DEFAULT_CONFIG", () => {
       validAgents.includes(DEFAULT_CONFIG.codingAgent),
       `codingAgent should be one of ${validAgents.join(", ")}, got ${DEFAULT_CONFIG.codingAgent}`,
     );
+  });
+
+  it("enables docs auto-update by default", () => {
+    assert.equal(DEFAULT_CONFIG.autoUpdateDocs, true);
   });
 });

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIG: Config = {
   pollIntervalMs: 120000,
   maxChangesPerRun: 20,
   autoResolveMergeConflicts: true,
+  autoUpdateDocs: true,
   watchedRepos: [],
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -22,6 +22,8 @@ const config: Config = {
   batchWindowMs: 300000,
   pollIntervalMs: 120000,
   maxChangesPerRun: 20,
+  autoResolveMergeConflicts: true,
+  autoUpdateDocs: true,
   watchedRepos: [],
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -309,7 +309,7 @@ const TOOLS: Tool[] = [
     description:
       "Partially update Code Factory configuration. All fields are optional; only provided " +
       "fields are changed. Available fields: githubToken, codingAgent, maxTurns, " +
-      "batchWindowMs, pollIntervalMs, maxChangesPerRun, autoResolveMergeConflicts, " +
+      "batchWindowMs, pollIntervalMs, maxChangesPerRun, autoResolveMergeConflicts, autoUpdateDocs, " +
       "watchedRepos, trustedReviewers, ignoredBots.",
     inputSchema: {
       type: "object",
@@ -321,6 +321,7 @@ const TOOLS: Tool[] = [
         pollIntervalMs: { type: "number" },
         maxChangesPerRun: { type: "number" },
         autoResolveMergeConflicts: { type: "boolean" },
+        autoUpdateDocs: { type: "boolean" },
         watchedRepos: { type: "array", items: { type: "string" } },
         trustedReviewers: { type: "array", items: { type: "string" } },
         ignoredBots: { type: "array", items: { type: "string" } },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -328,6 +328,7 @@ describe("MemStorage", () => {
       const config = await storage.getConfig();
       assert.equal(config.codingAgent, DEFAULT_CONFIG.codingAgent);
       assert.equal(config.maxTurns, DEFAULT_CONFIG.maxTurns);
+      assert.equal(config.autoUpdateDocs, true);
       assert.deepEqual(config.watchedRepos, []);
     });
   });

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import type { SQLInputValue } from "node:sqlite";
-import { feedbackStatusEnum } from "@shared/schema";
+import { docsAssessmentSchema, feedbackStatusEnum } from "@shared/schema";
 import type { AgentRun, AgentRunStatus, Config, FeedbackItem, LogEntry, PR, PRQuestion, RuntimeState, SocialChangelog } from "@shared/schema";
 import {
   applyConfigUpdate,
@@ -27,6 +27,7 @@ type ConfigRow = {
   poll_interval_ms: number;
   max_changes_per_run: number;
   auto_resolve_merge_conflicts: number;
+  auto_update_docs: number;
   trusted_reviewers_json: string;
   ignored_bots_json: string;
 };
@@ -63,6 +64,7 @@ type PRRow = {
   tests_passed: number | null;
   lint_passed: number | null;
   last_checked: string | null;
+  docs_assessment_json: string | null;
   added_at: string;
 };
 
@@ -290,6 +292,8 @@ export class SqliteStorage implements IStorage {
         batch_window_ms INTEGER NOT NULL,
         poll_interval_ms INTEGER NOT NULL,
         max_changes_per_run INTEGER NOT NULL,
+        auto_resolve_merge_conflicts INTEGER NOT NULL DEFAULT 1,
+        auto_update_docs INTEGER NOT NULL DEFAULT 1,
         trusted_reviewers_json TEXT NOT NULL,
         ignored_bots_json TEXT NOT NULL
       );
@@ -313,6 +317,7 @@ export class SqliteStorage implements IStorage {
         tests_passed INTEGER,
         lint_passed INTEGER,
         last_checked TEXT,
+        docs_assessment_json TEXT,
         added_at TEXT NOT NULL,
         UNIQUE(repo, number)
       );
@@ -419,6 +424,8 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("feedback_items", "status", "TEXT NOT NULL DEFAULT 'pending'");
     this.ensureColumn("feedback_items", "status_reason", "TEXT");
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("prs", "docs_assessment_json", "TEXT");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -461,6 +468,7 @@ export class SqliteStorage implements IStorage {
       pollIntervalMs: row.poll_interval_ms,
       maxChangesPerRun: row.max_changes_per_run,
       autoResolveMergeConflicts: Boolean(row.auto_resolve_merge_conflicts),
+      autoUpdateDocs: Boolean(row.auto_update_docs),
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
       ignoredBots: JSON.parse(row.ignored_bots_json),
@@ -484,9 +492,10 @@ export class SqliteStorage implements IStorage {
           poll_interval_ms,
           max_changes_per_run,
           auto_resolve_merge_conflicts,
+          auto_update_docs,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           coding_agent = excluded.coding_agent,
@@ -496,6 +505,7 @@ export class SqliteStorage implements IStorage {
           poll_interval_ms = excluded.poll_interval_ms,
           max_changes_per_run = excluded.max_changes_per_run,
           auto_resolve_merge_conflicts = excluded.auto_resolve_merge_conflicts,
+          auto_update_docs = excluded.auto_update_docs,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
           ignored_bots_json = excluded.ignored_bots_json
       `,
@@ -508,6 +518,7 @@ export class SqliteStorage implements IStorage {
         config.pollIntervalMs,
         config.maxChangesPerRun,
         Number(config.autoResolveMergeConflicts),
+        Number(config.autoUpdateDocs),
         JSON.stringify(config.trustedReviewers),
         JSON.stringify(config.ignoredBots),
       );
@@ -541,8 +552,21 @@ export class SqliteStorage implements IStorage {
       testsPassed: row.tests_passed === null ? null : Boolean(row.tests_passed),
       lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
       lastChecked: row.last_checked,
+      docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
       addedAt: row.added_at,
     };
+  }
+
+  private parseDocsAssessment(raw: string | null): PR["docsAssessment"] {
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return docsAssessmentSchema.parse(JSON.parse(raw));
+    } catch {
+      return null;
+    }
   }
 
   private parseRuntimeStateRow(row: RuntimeStateRow | undefined): RuntimeState {
@@ -663,7 +687,7 @@ export class SqliteStorage implements IStorage {
   async getPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, added_at
+             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY datetime(added_at) DESC
@@ -677,7 +701,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, added_at
+             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY datetime(added_at) DESC
@@ -691,7 +715,7 @@ export class SqliteStorage implements IStorage {
   async getPR(id: string): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, added_at
+             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
       FROM prs
       WHERE id = ?
     `, id);
@@ -707,7 +731,7 @@ export class SqliteStorage implements IStorage {
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, added_at
+             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
       FROM prs
       WHERE repo = ? AND number = ?
     `, repo, number);
@@ -727,8 +751,8 @@ export class SqliteStorage implements IStorage {
       this.run(`
         INSERT INTO prs (
           id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-          tests_passed, lint_passed, last_checked, added_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         full.id,
         full.number,
@@ -744,6 +768,7 @@ export class SqliteStorage implements IStorage {
         full.testsPassed === null ? null : Number(full.testsPassed),
         full.lintPassed === null ? null : Number(full.lintPassed),
         full.lastChecked,
+        full.docsAssessment ? JSON.stringify(full.docsAssessment) : null,
         full.addedAt,
       );
 
@@ -764,7 +789,7 @@ export class SqliteStorage implements IStorage {
       this.run(`
         UPDATE prs
         SET number = ?, title = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
-            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?
+            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?, docs_assessment_json = ?
         WHERE id = ?
       `,
         updated.number,
@@ -780,6 +805,7 @@ export class SqliteStorage implements IStorage {
         updated.testsPassed === null ? null : Number(updated.testsPassed),
         updated.lintPassed === null ? null : Number(updated.lintPassed),
         updated.lastChecked,
+        updated.docsAssessment ? JSON.stringify(updated.docsAssessment) : null,
         id,
       );
 
@@ -923,7 +949,7 @@ export class SqliteStorage implements IStorage {
   async getConfig(): Promise<Config> {
     const row = this.get<ConfigRow>(`
       SELECT github_token, coding_agent, model, max_turns, batch_window_ms,
-             poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts,
+             poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_update_docs,
              trusted_reviewers_json, ignored_bots_json
       FROM config
       WHERE id = 1

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -58,6 +58,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const first = new SqliteStorage(root);
   await first.updateConfig({
     pollIntervalMs: 45000,
+    autoUpdateDocs: false,
     watchedRepos: ["alex-morgan-o/lolodex"],
   });
   await first.updateRuntimeState({
@@ -111,6 +112,12 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     rejected: 0,
     flagged: 0,
     lastChecked: "2026-03-15T07:31:00.000Z",
+    docsAssessment: {
+      headSha: "abc123",
+      status: "needed",
+      summary: "README and configuration docs should reflect the behavior change",
+      assessedAt: "2026-03-28T12:00:00.000Z",
+    },
   });
   await first.addLog(pr.id, "info", "Agent started", {
     runId: "run-1",
@@ -142,6 +149,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const logs = await second.getLogs(pr.id);
 
   assert.equal(config.pollIntervalMs, 45000);
+  assert.equal(config.autoUpdateDocs, false);
   assert.deepEqual(config.watchedRepos, ["alex-morgan-o/lolodex"]);
   assert.equal(runtime.drainMode, true);
   assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
@@ -153,6 +161,9 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(reloadedPr?.feedbackItems[0]?.threadId, "PRRT_kwDO_thread");
   assert.equal(reloadedPr?.feedbackItems[0]?.auditToken, "codefactory-feedback:feedback-1");
   assert.equal(reloadedPr?.accepted, 1);
+  assert.equal(reloadedPr?.docsAssessment?.headSha, "abc123");
+  assert.equal(reloadedPr?.docsAssessment?.status, "needed");
+  assert.match(reloadedPr?.docsAssessment?.summary || "", /README/);
   assert.equal(reloadedPr?.feedbackItems[0]?.status, "resolved");
   assert.equal(reloadedPr?.feedbackItems[0]?.statusReason, "GitHub audit trail verified");
   assert.equal(run?.status, "running");
@@ -174,6 +185,7 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
   try {
     await storage.updateConfig({
       githubToken: "tok_123",
+      autoUpdateDocs: false,
       watchedRepos: ["alex-morgan-o/lolodex"],
       trustedReviewers: ["octocat"],
       ignoredBots: ["custom[bot]"],

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,6 +44,17 @@ export const feedbackItemSchema = z.object({
 });
 export type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 
+export const docsAssessmentStatusEnum = z.enum(["needed", "not_needed", "failed"]);
+export type DocsAssessmentStatus = z.infer<typeof docsAssessmentStatusEnum>;
+
+export const docsAssessmentSchema = z.object({
+  headSha: z.string(),
+  status: docsAssessmentStatusEnum,
+  summary: z.string(),
+  assessedAt: z.string(),
+});
+export type DocsAssessment = z.infer<typeof docsAssessmentSchema>;
+
 export const prSchema = z.object({
   id: z.string(),
   number: z.number(),
@@ -60,6 +71,7 @@ export const prSchema = z.object({
   testsPassed: z.boolean().nullable(),
   lintPassed: z.boolean().nullable(),
   lastChecked: z.string().nullable(),
+  docsAssessment: docsAssessmentSchema.nullable().optional(),
   addedAt: z.string(),
 });
 export type PR = z.infer<typeof prSchema>;
@@ -159,6 +171,7 @@ export const configSchema = z.object({
   pollIntervalMs: z.number(),
   maxChangesPerRun: z.number(),
   autoResolveMergeConflicts: z.boolean(),
+  autoUpdateDocs: z.boolean(),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
   ignoredBots: z.array(z.string()),

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,14 @@
 # Lessons Learned
 
+## 2026-03-28 - Design product features around user repositories, not this repo's own workflow
+- Pattern: I framed a new PR-documentation feature as if it were about Code Factory's own repository and CI/docs pipeline, when the user intended a product capability that agents apply to any tracked repository.
+- Rule: When designing or implementing Code Factory behavior, default to repository-agnostic product semantics unless the user explicitly scopes the request to this repo's own operations.
+- Prevention checklist:
+  - Restate whether a request targets Code Factory's product behavior or this repository's internal workflow before proposing a design.
+  - Validate that prompt contracts, defaults, and storage shape make sense for arbitrary user repositories, not just `README.md` or docs layout in this repo.
+  - Avoid deriving product requirements from this repo's local docs/build pipeline unless the user explicitly wants repo-specific behavior.
+  - Check whether the feature needs to generalize across heterogeneous repositories before choosing fixed file paths or heuristics.
+
 ## 2026-03-15 - Keep PR automation in app-owned `~/.codefactory`
 - Pattern: I described PR workspace isolation too loosely and pointed it at a repo-local `.codefactory` directory instead of the app-owned `~/.codefactory` workspace, and I omitted the required checkout-plus-worktree flow.
 - Rule: When implementing PR automation, default to a clean repository checkout in `~/.codefactory`, fetch and check out the PR there, and create agent worktrees from that app-owned clone rather than from the user's working copy.


### PR DESCRIPTION
## Summary
- add a global auto-update docs toggle and persist per-PR documentation assessment state
- assess docs needs for each new PR head SHA using repo diff context, then assign docs remediation only when the agent judges it is needed
- expose the toggle in the dashboard and settings UI and add regression coverage for docs-needed, docs-not-needed, retry, and no-change convergence paths

## Testing
- node --test --import tsx server/*.test.ts
- npm run check
- npm run build