### PR TITLE
Update docs to use npm install instead of git clone

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -252,13 +252,11 @@
       </div>
     </div>
     <div class="overflow-x-auto p-6">
-      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
-<span class="text-white">git clone https://github.com/yungookim/oh-my-pr.git</span>
-<span class="text-white">cd codefactory</span>
-<span class="text-white">npm install</span>
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Install globally from npm</span>
+<span class="text-white">npm install -g oh-my-pr</span>
 
 <span class="text-gray-500"># Start the dashboard</span>
-<span class="text-white">npm run dev</span></code></pre>
+<span class="text-white">oh-my-pr</span></code></pre>
     </div>
   </div>
 </section>

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -189,16 +189,21 @@
 <li><strong>GitHub Personal Access Token</strong> — with <code>repo</code> scope (<a href="https://github.com/settings/tokens">create one</a>)</li>
 </ul>
 <h2>Installation</h2>
-<p>Clone the repository and install dependencies:</p>
-<pre><code class="language-bash">git clone https://github.com/yungookim/oh-my-pr.git
-cd codefactory
-npm install
+<p>Install from npm:</p>
+<pre><code class="language-bash">npm install -g oh-my-pr
 </code></pre>
 <h2>Quick Start</h2>
-<h3>1. Start the development server</h3>
-<pre><code class="language-bash">npm run dev
+<h3>1. Start the dashboard</h3>
+<pre><code class="language-bash">oh-my-pr
 </code></pre>
 <p>This launches the dashboard at <a href="http://localhost:5001">http://localhost:5001</a>.</p>
+<h3>Run from source</h3>
+<p>If you prefer to run from source instead:</p>
+<pre><code class="language-bash">git clone https://github.com/yungookim/oh-my-pr.git
+cd oh-my-pr
+npm install
+npm run dev
+</code></pre>
 <h3>2. Connect a GitHub repository</h3>
 <ol>
 <li>Open the dashboard in your browser.</li>

--- a/docs/public/_site/index.html
+++ b/docs/public/_site/index.html
@@ -252,13 +252,11 @@
       </div>
     </div>
     <div class="overflow-x-auto p-6">
-      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
-<span class="text-white">git clone https://github.com/yungookim/oh-my-pr.git</span>
-<span class="text-white">cd codefactory</span>
-<span class="text-white">npm install</span>
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Install globally from npm</span>
+<span class="text-white">npm install -g oh-my-pr</span>
 
 <span class="text-gray-500"># Start the dashboard</span>
-<span class="text-white">npm run dev</span></code></pre>
+<span class="text-white">oh-my-pr</span></code></pre>
     </div>
   </div>
 </section>

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -10,23 +10,32 @@ Welcome to CodeFactory — the autonomous PR babysitter that watches your reposi
 
 ## Installation
 
-Clone the repository and install dependencies:
+Install from npm:
 
 ```bash
-git clone https://github.com/yungookim/oh-my-pr.git
-cd codefactory
-npm install
+npm install -g oh-my-pr
 ```
 
 ## Quick Start
 
-### 1. Start the development server
+### 1. Start the dashboard
 
 ```bash
-npm run dev
+oh-my-pr
 ```
 
 This launches the dashboard at [http://localhost:5001](http://localhost:5001).
+
+### Run from source
+
+If you prefer to run from source instead:
+
+```bash
+git clone https://github.com/yungookim/oh-my-pr.git
+cd oh-my-pr
+npm install
+npm run dev
+```
 
 ### 2. Connect a GitHub repository
 

--- a/script/build-public-docs.ts
+++ b/script/build-public-docs.ts
@@ -496,13 +496,11 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
       </div>
     </div>
     <div class="overflow-x-auto p-6">
-      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Clone and install</span>
-<span class="text-white">git clone https://github.com/yungookim/oh-my-pr.git</span>
-<span class="text-white">cd codefactory</span>
-<span class="text-white">npm install</span>
+      <pre class="font-mono text-sm leading-relaxed text-gray-300"><code><span class="text-gray-500"># Install globally from npm</span>
+<span class="text-white">npm install -g oh-my-pr</span>
 
 <span class="text-gray-500"># Start the dashboard</span>
-<span class="text-white">npm run dev</span></code></pre>
+<span class="text-white">oh-my-pr</span></code></pre>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- Landing page, getting-started guide, and build template now show `npm install -g oh-my-pr` as the primary install method
- Old `git clone` workflow preserved as a secondary "Run from source" option for contributors
- Fixed stale `cd codefactory` → `cd oh-my-pr` in the source install path

## Test plan

- [ ] Verify https://yungookim.github.io/oh-my-pr/ shows npm install instructions after merge
- [ ] Verify the getting-started page still renders correctly
- [ ] Run `npm run build:public-docs` locally and confirm clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)