### PR TITLE
Rename CodeFactory to oh-my-pr in public docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
-  <title>CodeFactory Documentation</title>
+  <meta name="description" content="oh-my-pr documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
+  <title>oh-my-pr Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,18 +164,18 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="./index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
         <header class="mb-12">
   <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
     <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v6m0 0v6m0-6h6m-6 0H6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
-    <span>Welcome to CodeFactory</span>
+    <span>Welcome to oh-my-pr</span>
   </div>
   <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
   <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
-    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+    oh-my-pr watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
   </p>
 
   <div class="mb-8 flex flex-wrap gap-3">
@@ -200,7 +200,7 @@
   <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
     <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"></path></svg>
     <p class="text-sm leading-relaxed text-blue-100/80">
-      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      oh-my-pr runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
       <a class="text-blue-400 hover:underline" href="./public/_site/getting-started.html">quickstart guide</a>.
     </p>
   </div>
@@ -208,14 +208,14 @@
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
-  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <p class="mb-6 text-gray-400">Everything you need to set up oh-my-pr and start automating your PR workflow.</p>
   <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/getting-started.html">
   <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
   </div>
   <h3 class="mb-2 text-lg font-semibold text-white">Quickstart</h3>
-  <p class="text-sm leading-relaxed text-gray-400">Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.</p>
+  <p class="text-sm leading-relaxed text-gray-400">Install oh-my-pr, connect a repository, and let the agents handle your first PR in minutes.</p>
 </a>
 <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./public/_site/configuration.html">
   <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
@@ -236,7 +236,7 @@
     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
   </div>
   <h3 class="mb-2 text-lg font-semibold text-white">Agent Dispatch</h3>
-  <p class="text-sm leading-relaxed text-gray-400">How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
+  <p class="text-sm leading-relaxed text-gray-400">How oh-my-pr dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
 </a>
   </div>
 </section>
@@ -265,13 +265,13 @@
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
-  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <p class="mb-8 text-gray-400">oh-my-pr follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
   <div class="space-y-0">
     <div class="flex gap-6 border-b border-dark-700/50 py-6">
       <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">1.</div>
       <div>
         <h3 class="mb-1 text-lg font-semibold text-white">Watch Repositories</h3>
-        <p class="text-gray-400">Add any GitHub repository. CodeFactory polls for open PRs and new review activity.</p>
+        <p class="text-gray-400">Add any GitHub repository. oh-my-pr polls for open PRs and new review activity.</p>
       </div>
     </div>
 <div class="flex gap-6 border-b border-dark-700/50 py-6">
@@ -328,7 +328,7 @@
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
       </div>
       <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
-      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of oh-my-pr.</p>
     </a>
   </div>
 </section>

--- a/docs/public/_site/agent-dispatch.html
+++ b/docs/public/_site/agent-dispatch.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Agent Dispatch - CodeFactory documentation" />
-  <title>Agent Dispatch | CodeFactory Docs</title>
+  <meta name="description" content="Agent Dispatch - oh-my-pr documentation" />
+  <title>Agent Dispatch | oh-my-pr Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,7 +164,7 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Agent Dispatch</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">oh-my-pr dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
 </header>
 
 <article class="doc-prose">
@@ -202,10 +202,10 @@
 <td>Quick fixes, single-file edits, style corrections</td>
 </tr>
 </tbody></table>
-<p>CodeFactory automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.</p>
+<p>oh-my-pr automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.</p>
 <h2>How Dispatch Works</h2>
 <h3>1. Worktree Isolation</h3>
-<p>Before an agent runs, CodeFactory creates a <strong>temporary git worktree</strong>:</p>
+<p>Before an agent runs, oh-my-pr creates a <strong>temporary git worktree</strong>:</p>
 <pre><code>/tmp/pr-babysitter/&lt;repo&gt;/&lt;pr-number&gt;/
 </code></pre>
 <p>This ensures:</p>
@@ -230,14 +230,14 @@
 <li>The diff is <strong>logged</strong> for human review in the dashboard.</li>
 </ul>
 <h3>4. Commit &amp; Push</h3>
-<p>If validation passes, CodeFactory:</p>
+<p>If validation passes, oh-my-pr:</p>
 <ul>
 <li>Creates a <strong>descriptive commit message</strong> explaining what was fixed.</li>
 <li>Pushes the commit to the <strong>PR branch</strong> on GitHub.</li>
 <li>Updates the <strong>feedback status</strong> to resolved.</li>
 </ul>
 <h2>Agent Runs in the Dashboard</h2>
-<p>Every agent run is tracked in the CodeFactory dashboard:</p>
+<p>Every agent run is tracked in the oh-my-pr dashboard:</p>
 <ul>
 <li><strong>Status</strong> — Running, succeeded, or failed.</li>
 <li><strong>Duration</strong> — How long the agent took.</li>
@@ -245,7 +245,7 @@
 <li><strong>Logs</strong> — Full agent output for debugging.</li>
 </ul>
 <h2>Model Discovery</h2>
-<p>CodeFactory discovers available models from your local CLI installations. You can view and refresh available models from the <strong>Settings</strong> page in the dashboard.</p>
+<p>oh-my-pr discovers available models from your local CLI installations. You can view and refresh available models from the <strong>Settings</strong> page in the dashboard.</p>
 <h2>Customization</h2>
 <p>Override the default agent per repository or globally:</p>
 <ul>

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Configuration - CodeFactory documentation" />
-  <title>Configuration | CodeFactory Docs</title>
+  <meta name="description" content="Configuration - oh-my-pr documentation" />
+  <title>Configuration | oh-my-pr Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,7 +164,7 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Configuration</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory is configured through environment variables and the dashboard settings page.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">oh-my-pr is configured through environment variables and the dashboard settings page.</p>
 </header>
 
 <article class="doc-prose">
@@ -224,19 +224,19 @@
 </tbody></table>
 <h2>Storage</h2>
 <h3>SQLite (Default)</h3>
-<p>By default, CodeFactory stores all state in a local SQLite database:</p>
+<p>By default, oh-my-pr stores all state in a local SQLite database:</p>
 <pre><code>~/.oh-my-pr/state.sqlite
 </code></pre>
 <p>No external database is required. This is ideal for single-user setups.</p>
 <h3>PostgreSQL</h3>
 <p>For team deployments, configure a PostgreSQL connection:</p>
-<pre><code class="language-bash">DATABASE_URL=postgresql://user:pass@localhost:5432/codefactory
+<pre><code class="language-bash">DATABASE_URL=postgresql://user:pass@localhost:5432/oh_my_pr
 </code></pre>
 <p>Then push the schema:</p>
 <pre><code class="language-bash">npm run db:push
 </code></pre>
 <h2>Activity Logs</h2>
-<p>CodeFactory writes daily activity logs to:</p>
+<p>oh-my-pr writes daily activity logs to:</p>
 <pre><code>~/.oh-my-pr/log/
 </code></pre>
 <p>These logs mirror the dashboard activity feed and are useful for debugging or auditing agent behavior.</p>

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Getting Started - CodeFactory documentation" />
-  <title>Getting Started | CodeFactory Docs</title>
+  <meta name="description" content="Getting Started - oh-my-pr documentation" />
+  <title>Getting Started | oh-my-pr Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,7 +164,7 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Getting Started</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">Welcome to oh-my-pr — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
 </header>
 
 <article class="doc-prose">
@@ -205,8 +205,8 @@ npm install
 <li>Click <strong>Add Repository</strong> and paste the URL of a GitHub repository you manage.</li>
 <li>Enter your GitHub Personal Access Token when prompted.</li>
 </ol>
-<h3>3. Watch CodeFactory work</h3>
-<p>Once connected, CodeFactory will:</p>
+<h3>3. Watch oh-my-pr work</h3>
+<p>Once connected, oh-my-pr will:</p>
 <ul>
 <li><strong>Monitor</strong> open pull requests in real time.</li>
 <li><strong>Sync</strong> review comments and change requests.</li>
@@ -215,7 +215,7 @@ npm install
 <li><strong>Push</strong> the fixes back to the PR branch.</li>
 </ul>
 <h2>Desktop App</h2>
-<p>CodeFactory is also available as a native desktop application powered by Tauri:</p>
+<p>oh-my-pr is also available as a native desktop application powered by Tauri:</p>
 <pre><code class="language-bash">npm run tauri:dev    # Development
 npm run tauri:build  # Production build
 </code></pre>
@@ -223,7 +223,7 @@ npm run tauri:build  # Production build
 <ul>
 <li><a href="./pr-babysitter.html">PR Babysitter</a> — Learn how autonomous PR monitoring works.</li>
 <li><a href="./agent-dispatch.html">Agent Dispatch</a> — Understand how AI agents are dispatched to fix code.</li>
-<li><a href="./configuration.html">Configuration</a> — Customize CodeFactory for your workflow.</li>
+<li><a href="./configuration.html">Configuration</a> — Customize oh-my-pr for your workflow.</li>
 </ul>
 
 </article>

--- a/docs/public/_site/index.html
+++ b/docs/public/_site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
-  <title>CodeFactory Documentation</title>
+  <meta name="description" content="oh-my-pr documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code." />
+  <title>oh-my-pr Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,18 +164,18 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
         <header class="mb-12">
   <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
     <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v6m0 0v6m0-6h6m-6 0H6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
-    <span>Welcome to CodeFactory</span>
+    <span>Welcome to oh-my-pr</span>
   </div>
   <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
   <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
-    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+    oh-my-pr watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
   </p>
 
   <div class="mb-8 flex flex-wrap gap-3">
@@ -200,7 +200,7 @@
   <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
     <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"></path></svg>
     <p class="text-sm leading-relaxed text-blue-100/80">
-      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      oh-my-pr runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
       <a class="text-blue-400 hover:underline" href="./getting-started.html">quickstart guide</a>.
     </p>
   </div>
@@ -208,14 +208,14 @@
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
-  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <p class="mb-6 text-gray-400">Everything you need to set up oh-my-pr and start automating your PR workflow.</p>
   <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./getting-started.html">
   <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
   </div>
   <h3 class="mb-2 text-lg font-semibold text-white">Quickstart</h3>
-  <p class="text-sm leading-relaxed text-gray-400">Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.</p>
+  <p class="text-sm leading-relaxed text-gray-400">Install oh-my-pr, connect a repository, and let the agents handle your first PR in minutes.</p>
 </a>
 <a class="group block rounded-xl border border-dark-700 bg-dark-800/50 p-6 transition-colors hover:bg-dark-800" href="./configuration.html">
   <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-dark-700 text-brand-400 transition-colors group-hover:text-blue-300">
@@ -236,7 +236,7 @@
     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2m14 0V9a2 2 0 0 0-2-2M5 11V9a2 2 0 0 1 2-2m0 0V5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2M7 7h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
   </div>
   <h3 class="mb-2 text-lg font-semibold text-white">Agent Dispatch</h3>
-  <p class="text-sm leading-relaxed text-gray-400">How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
+  <p class="text-sm leading-relaxed text-gray-400">How oh-my-pr dispatches Claude Code and OpenAI Codex agents in isolated worktrees.</p>
 </a>
   </div>
 </section>
@@ -265,13 +265,13 @@
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
-  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <p class="mb-8 text-gray-400">oh-my-pr follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
   <div class="space-y-0">
     <div class="flex gap-6 border-b border-dark-700/50 py-6">
       <div class="w-8 flex-shrink-0 text-3xl font-bold text-blue-500/50">1.</div>
       <div>
         <h3 class="mb-1 text-lg font-semibold text-white">Watch Repositories</h3>
-        <p class="text-gray-400">Add any GitHub repository. CodeFactory polls for open PRs and new review activity.</p>
+        <p class="text-gray-400">Add any GitHub repository. oh-my-pr polls for open PRs and new review activity.</p>
       </div>
     </div>
 <div class="flex gap-6 border-b border-dark-700/50 py-6">
@@ -328,7 +328,7 @@
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg>
       </div>
       <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
-      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of oh-my-pr.</p>
     </a>
   </div>
 </section>

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="PR Babysitter - CodeFactory documentation" />
-  <title>PR Babysitter | CodeFactory Docs</title>
+  <meta name="description" content="PR Babysitter - oh-my-pr documentation" />
+  <title>PR Babysitter | oh-my-pr Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,7 +164,7 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
@@ -178,27 +178,27 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">PR Babysitter</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">The PR Babysitter is CodeFactory&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">The PR Babysitter is oh-my-pr&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.</p>
 </header>
 
 <article class="doc-prose">
   <h2>How It Works</h2>
 <h3>1. Repository Watching</h3>
-<p>When you add a repository to CodeFactory, the babysitter begins polling for open pull requests. It tracks:</p>
+<p>When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests. It tracks:</p>
 <ul>
 <li>New PRs opened against the repository.</li>
 <li>Review comments and change requests on existing PRs.</li>
 <li>Status changes (approvals, dismissals, re-requests).</li>
 </ul>
 <h3>2. Review Sync</h3>
-<p>Every review comment is captured and stored locally. CodeFactory understands GitHub&#39;s threaded review model:</p>
+<p>Every review comment is captured and stored locally. oh-my-pr understands GitHub&#39;s threaded review model:</p>
 <ul>
 <li><strong>Top-level review comments</strong> — general feedback on the PR.</li>
 <li><strong>Inline comments</strong> — feedback attached to specific lines of code.</li>
 <li><strong>Review threads</strong> — multi-message conversations about a specific change.</li>
 </ul>
 <h3>3. Feedback Triage</h3>
-<p>Not all feedback is equal. CodeFactory classifies each piece of feedback:</p>
+<p>Not all feedback is equal. oh-my-pr classifies each piece of feedback:</p>
 <table>
 <thead>
 <tr>
@@ -229,7 +229,7 @@
 </tr>
 </tbody></table>
 <h3>4. Automated Resolution</h3>
-<p>For actionable feedback, CodeFactory:</p>
+<p>For actionable feedback, oh-my-pr:</p>
 <ol>
 <li>Creates an <strong>isolated worktree</strong> — a clean copy of the branch.</li>
 <li>Dispatches an <strong>AI agent</strong> (Claude Code or OpenAI Codex) with the feedback context.</li>
@@ -249,7 +249,7 @@
 <li><strong>skipped</strong> — Determined to not need automated action.</li>
 </ul>
 <h2>Merge Conflict Resolution</h2>
-<p>When a PR branch falls behind the base branch, CodeFactory can automatically:</p>
+<p>When a PR branch falls behind the base branch, oh-my-pr can automatically:</p>
 <ol>
 <li>Detect the conflict.</li>
 <li>Rebase the branch.</li>
@@ -261,7 +261,7 @@
 <ul>
 <li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
 <li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
-<li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let CodeFactory decide.</li>
+<li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.</li>
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for details.</p>
 

--- a/docs/public/_site/pr-questions.html
+++ b/docs/public/_site/pr-questions.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="PR Q&amp;A - CodeFactory documentation" />
-  <title>PR Q&amp;A | CodeFactory Docs</title>
+  <meta name="description" content="PR Q&amp;A - oh-my-pr documentation" />
+  <title>PR Q&amp;A | oh-my-pr Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -42,7 +42,7 @@
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       <svg class="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -164,7 +164,7 @@
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
     <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">PR Q&amp;A</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">oh-my-pr includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.</p>
 </header>
 
 <article class="doc-prose">
@@ -190,10 +190,10 @@
 <li>&quot;What are the architectural implications of this change?&quot;</li>
 <li>&quot;Does this PR introduce any security concerns?&quot;</li>
 </ul>
-<p>CodeFactory uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.</p>
+<p>oh-my-pr uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.</p>
 <h2>How to Use</h2>
 <ol>
-<li>Open a PR in the CodeFactory dashboard.</li>
+<li>Open a PR in the oh-my-pr dashboard.</li>
 <li>Navigate to the <strong>Q&amp;A</strong> tab.</li>
 <li>Type your question and press Enter.</li>
 </ol>

--- a/docs/public/agent-dispatch.md
+++ b/docs/public/agent-dispatch.md
@@ -1,6 +1,6 @@
 # Agent Dispatch
 
-CodeFactory dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.
+oh-my-pr dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.
 
 ## Supported Agents
 
@@ -9,13 +9,13 @@ CodeFactory dispatches local AI agents to fix code based on review feedback. Age
 | **Claude Code** | `claude` | Complex reasoning, multi-file refactors, architectural changes |
 | **OpenAI Codex** | `codex` | Quick fixes, single-file edits, style corrections |
 
-CodeFactory automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.
+oh-my-pr automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.
 
 ## How Dispatch Works
 
 ### 1. Worktree Isolation
 
-Before an agent runs, CodeFactory creates a **temporary git worktree**:
+Before an agent runs, oh-my-pr creates a **temporary git worktree**:
 
 ```
 /tmp/pr-babysitter/<repo>/<pr-number>/
@@ -43,14 +43,14 @@ After the agent completes:
 
 ### 4. Commit & Push
 
-If validation passes, CodeFactory:
+If validation passes, oh-my-pr:
 - Creates a **descriptive commit message** explaining what was fixed.
 - Pushes the commit to the **PR branch** on GitHub.
 - Updates the **feedback status** to resolved.
 
 ## Agent Runs in the Dashboard
 
-Every agent run is tracked in the CodeFactory dashboard:
+Every agent run is tracked in the oh-my-pr dashboard:
 
 - **Status** — Running, succeeded, or failed.
 - **Duration** — How long the agent took.
@@ -59,7 +59,7 @@ Every agent run is tracked in the CodeFactory dashboard:
 
 ## Model Discovery
 
-CodeFactory discovers available models from your local CLI installations. You can view and refresh available models from the **Settings** page in the dashboard.
+oh-my-pr discovers available models from your local CLI installations. You can view and refresh available models from the **Settings** page in the dashboard.
 
 ## Customization
 

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-CodeFactory is configured through environment variables and the dashboard settings page.
+oh-my-pr is configured through environment variables and the dashboard settings page.
 
 ## Environment Variables
 
@@ -17,7 +17,7 @@ CodeFactory is configured through environment variables and the dashboard settin
 
 ### SQLite (Default)
 
-By default, CodeFactory stores all state in a local SQLite database:
+By default, oh-my-pr stores all state in a local SQLite database:
 
 ```
 ~/.oh-my-pr/state.sqlite
@@ -30,7 +30,7 @@ No external database is required. This is ideal for single-user setups.
 For team deployments, configure a PostgreSQL connection:
 
 ```bash
-DATABASE_URL=postgresql://user:pass@localhost:5432/codefactory
+DATABASE_URL=postgresql://user:pass@localhost:5432/oh_my_pr
 ```
 
 Then push the schema:
@@ -41,7 +41,7 @@ npm run db:push
 
 ## Activity Logs
 
-CodeFactory writes daily activity logs to:
+oh-my-pr writes daily activity logs to:
 
 ```
 ~/.oh-my-pr/log/

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome to CodeFactory — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.
+Welcome to oh-my-pr — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.
 
 ## Prerequisites
 
@@ -34,9 +34,9 @@ This launches the dashboard at [http://localhost:5001](http://localhost:5001).
 2. Click **Add Repository** and paste the URL of a GitHub repository you manage.
 3. Enter your GitHub Personal Access Token when prompted.
 
-### 3. Watch CodeFactory work
+### 3. Watch oh-my-pr work
 
-Once connected, CodeFactory will:
+Once connected, oh-my-pr will:
 
 - **Monitor** open pull requests in real time.
 - **Sync** review comments and change requests.
@@ -46,7 +46,7 @@ Once connected, CodeFactory will:
 
 ## Desktop App
 
-CodeFactory is also available as a native desktop application powered by Tauri:
+oh-my-pr is also available as a native desktop application powered by Tauri:
 
 ```bash
 npm run tauri:dev    # Development
@@ -57,4 +57,4 @@ npm run tauri:build  # Production build
 
 - [PR Babysitter](./pr-babysitter.md) — Learn how autonomous PR monitoring works.
 - [Agent Dispatch](./agent-dispatch.md) — Understand how AI agents are dispatched to fix code.
-- [Configuration](./configuration.md) — Customize CodeFactory for your workflow.
+- [Configuration](./configuration.md) — Customize oh-my-pr for your workflow.

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -1,12 +1,12 @@
 # PR Babysitter
 
-The PR Babysitter is CodeFactory's core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.
+The PR Babysitter is oh-my-pr's core feature — an autonomous system that continuously monitors your GitHub pull requests and takes action on review feedback without manual intervention.
 
 ## How It Works
 
 ### 1. Repository Watching
 
-When you add a repository to CodeFactory, the babysitter begins polling for open pull requests. It tracks:
+When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests. It tracks:
 
 - New PRs opened against the repository.
 - Review comments and change requests on existing PRs.
@@ -14,7 +14,7 @@ When you add a repository to CodeFactory, the babysitter begins polling for open
 
 ### 2. Review Sync
 
-Every review comment is captured and stored locally. CodeFactory understands GitHub's threaded review model:
+Every review comment is captured and stored locally. oh-my-pr understands GitHub's threaded review model:
 
 - **Top-level review comments** — general feedback on the PR.
 - **Inline comments** — feedback attached to specific lines of code.
@@ -22,7 +22,7 @@ Every review comment is captured and stored locally. CodeFactory understands Git
 
 ### 3. Feedback Triage
 
-Not all feedback is equal. CodeFactory classifies each piece of feedback:
+Not all feedback is equal. oh-my-pr classifies each piece of feedback:
 
 | Category | Description | Action |
 |----------|-------------|--------|
@@ -33,7 +33,7 @@ Not all feedback is equal. CodeFactory classifies each piece of feedback:
 
 ### 4. Automated Resolution
 
-For actionable feedback, CodeFactory:
+For actionable feedback, oh-my-pr:
 
 1. Creates an **isolated worktree** — a clean copy of the branch.
 2. Dispatches an **AI agent** (Claude Code or OpenAI Codex) with the feedback context.
@@ -57,7 +57,7 @@ pending → triaged → dispatched → resolved
 
 ## Merge Conflict Resolution
 
-When a PR branch falls behind the base branch, CodeFactory can automatically:
+When a PR branch falls behind the base branch, oh-my-pr can automatically:
 
 1. Detect the conflict.
 2. Rebase the branch.
@@ -70,6 +70,6 @@ You can control babysitter behavior per repository:
 
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
-- **Agent preference** — Choose between Claude Code, OpenAI Codex, or let CodeFactory decide.
+- **Agent preference** — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.
 
 See [Configuration](./configuration.md) for details.

--- a/docs/public/pr-questions.md
+++ b/docs/public/pr-questions.md
@@ -1,6 +1,6 @@
 # PR Q&A
 
-CodeFactory includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.
+oh-my-pr includes a built-in PR question-answering system that lets you interrogate your pull requests using natural language.
 
 ## Overview
 
@@ -11,11 +11,11 @@ Instead of manually reading through large diffs, you can ask questions like:
 - "What are the architectural implications of this change?"
 - "Does this PR introduce any security concerns?"
 
-CodeFactory uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.
+oh-my-pr uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.
 
 ## How to Use
 
-1. Open a PR in the CodeFactory dashboard.
+1. Open a PR in the oh-my-pr dashboard.
 2. Navigate to the **Q&A** tab.
 3. Type your question and press Enter.
 

--- a/script/build-public-docs.ts
+++ b/script/build-public-docs.ts
@@ -79,7 +79,7 @@ const DOC_DEFINITIONS: DocDefinition[] = [
     navLabel: "Quickstart",
     cardTitle: "Quickstart",
     icon: "quickstart",
-    fallbackDescription: "Install CodeFactory, connect a repository, and let the agents handle your first PR in minutes.",
+    fallbackDescription: "Install oh-my-pr, connect a repository, and let the agents handle your first PR in minutes.",
   },
   {
     slug: "configuration",
@@ -103,7 +103,7 @@ const DOC_DEFINITIONS: DocDefinition[] = [
     navLabel: "Agent Dispatch",
     cardTitle: "Agent Dispatch",
     icon: "package",
-    fallbackDescription: "How CodeFactory dispatches Claude Code and OpenAI Codex agents in isolated worktrees.",
+    fallbackDescription: "How oh-my-pr dispatches Claude Code and OpenAI Codex agents in isolated worktrees.",
   },
   {
     slug: "pr-questions",
@@ -119,7 +119,7 @@ const WORKFLOW_STEPS = [
   {
     number: "1.",
     title: "Watch Repositories",
-    description: "Add any GitHub repository. CodeFactory polls for open PRs and new review activity.",
+    description: "Add any GitHub repository. oh-my-pr polls for open PRs and new review activity.",
   },
   {
     number: "2.",
@@ -295,7 +295,7 @@ function renderSidebar(context: RenderContext, activeKey: string | null, docs: D
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
       ${icon("logo", "h-6 w-6 text-white")}
-      <span class="text-base font-semibold text-white">CodeFactory</span>
+      <span class="text-base font-semibold text-white">oh-my-pr</span>
       <span class="ml-auto rounded bg-dark-700 px-1.5 py-0.5 text-[10px] text-gray-300">DOCS</span>
     </div>
     <div class="relative mb-4">
@@ -355,7 +355,7 @@ function renderMobileHeader(context: RenderContext): string {
   return `<div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="${context.introHref}">
     ${icon("logo", "h-5 w-5")}
-    <span class="font-semibold">CodeFactory</span>
+    <span class="font-semibold">oh-my-pr</span>
   </a>
   <span class="rounded bg-dark-700 px-2 py-1 text-[10px] uppercase tracking-wider text-gray-300">Docs</span>
 </div>`;
@@ -442,11 +442,11 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
   const bodyContent = `<header class="mb-12">
   <div class="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-sm font-medium text-blue-400">
     ${icon("plus", "h-4 w-4")}
-    <span>Welcome to CodeFactory</span>
+    <span>Welcome to oh-my-pr</span>
   </div>
   <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">The Autonomous PR Babysitter</h1>
   <p class="mb-8 max-w-3xl text-lg leading-relaxed text-gray-400">
-    CodeFactory watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
+    oh-my-pr watches your GitHub repositories, triages review feedback, and dispatches local AI agents to fix code so you can focus on building instead of babysitting pull requests.
   </p>
 
   <div class="mb-8 flex flex-wrap gap-3">
@@ -471,7 +471,7 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
   <div class="flex gap-3 rounded-lg border border-blue-500/20 bg-blue-900/20 p-4">
     ${icon("info", "mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400")}
     <p class="text-sm leading-relaxed text-blue-100/80">
-      CodeFactory runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
+      oh-my-pr runs entirely on your machine. Your code never leaves your environment. Get started in under 2 minutes with our
       <a class="text-blue-400 hover:underline" href="${context.docHref("getting-started")}">quickstart guide</a>.
     </p>
   </div>
@@ -479,7 +479,7 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">Get Started</h2>
-  <p class="mb-6 text-gray-400">Everything you need to set up CodeFactory and start automating your PR workflow.</p>
+  <p class="mb-6 text-gray-400">Everything you need to set up oh-my-pr and start automating your PR workflow.</p>
   <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     ${getStartedCards}
   </div>
@@ -509,7 +509,7 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
 
 <section class="mb-16">
   <h2 class="mb-4 text-2xl font-bold text-white">How It Works</h2>
-  <p class="mb-8 text-gray-400">CodeFactory follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
+  <p class="mb-8 text-gray-400">oh-my-pr follows a six-step autonomous workflow to handle PR feedback end-to-end.</p>
   <div class="space-y-0">
     ${WORKFLOW_STEPS.map(
       (step) => `<div class="flex gap-6 border-b border-dark-700/50 py-6">
@@ -539,15 +539,15 @@ function renderLandingPage(context: RenderContext, docs: DocMeta[]): string {
         ${icon("doc", "h-5 w-5")}
       </div>
       <h3 class="mb-2 text-lg font-semibold text-white">API Reference</h3>
-      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of CodeFactory.</p>
+      <p class="text-sm leading-relaxed text-gray-400">Full REST API documentation for programmatic control of oh-my-pr.</p>
     </a>
   </div>
 </section>`;
 
   return renderShell(
     context,
-    "CodeFactory Documentation",
-    "CodeFactory documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code.",
+    "oh-my-pr Documentation",
+    "oh-my-pr documentation for the autonomous PR babysitter that watches repositories, triages review feedback, and dispatches local AI agents to fix code.",
     "intro",
     bodyContent,
     docs,
@@ -604,8 +604,8 @@ function renderDocPage(context: RenderContext, doc: DocMeta, docs: DocMeta[], re
 
   return renderShell(
     context,
-    `${doc.title} | CodeFactory Docs`,
-    `${doc.title} - CodeFactory documentation`,
+    `${doc.title} | oh-my-pr Docs`,
+    `${doc.title} - oh-my-pr documentation`,
     doc.slug,
     bodyContent,
     docs,


### PR DESCRIPTION
## Summary

- Renames all "CodeFactory" references to "oh-my-pr" across the public documentation site
- Updates markdown sources, the build template, and generated HTML
- Updates the PostgreSQL example URL from `codefactory` to `oh_my_pr`
- Leaves `CODEFACTORY_AGENT` env var name as-is (not used in codebase, avoids breaking existing setups)

## Test plan

- [ ] Run `npm run build:public-docs` and confirm clean output
- [ ] Verify no remaining "CodeFactory" references in `docs/public/*.md` (except `CODEFACTORY_AGENT` env var)
- [ ] Check rendered pages at https://yungookim.github.io/oh-my-pr/ after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)