### PR TITLE
fix: remove onboarding ai review setup

### DIFF
--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -4,6 +4,29 @@ import { useQuery } from "@tanstack/react-query";
 type OnboardingStatus = {
   githubConnected: boolean;
   githubError?: string;
+  repos: RepoOnboardingStatus[];
+};
+
+type RepoOnboardingStatus = {
+  repo: string;
+  accessible: boolean;
+  error?: string;
+};
+
+export function getOnboardingPanelState(status: OnboardingStatus) {
+  const inaccessibleRepos = status.githubConnected
+    ? status.repos.filter((repo) => !repo.accessible)
+    : [];
+  const hasIssues = !status.githubConnected || inaccessibleRepos.length > 0;
+  const summary = !status.githubConnected
+    ? "GitHub not connected"
+    : `${inaccessibleRepos.length} inaccessible repo${inaccessibleRepos.length === 1 ? "" : "s"}`;
+
+  return {
+    hasIssues,
+    inaccessibleRepos,
+    summary,
+  };
 };
 
 function InlineCode({ children }: { children: string }) {
@@ -102,7 +125,11 @@ export function OnboardingPanel() {
     refetchInterval: 30000,
   });
 
-  if (isLoading || !status || status.githubConnected || dismissed) return null;
+  if (isLoading || !status) return null;
+
+  const { hasIssues, inaccessibleRepos, summary } = getOnboardingPanelState(status);
+
+  if (!hasIssues || dismissed) return null;
 
   return (
     <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/5">
@@ -115,7 +142,7 @@ export function OnboardingPanel() {
           <span className="text-[11px] font-medium uppercase tracking-wider text-amber-400">
             Setup needed
           </span>
-          <span className="text-[11px] text-muted-foreground">GitHub not connected</span>
+          <span className="text-[11px] text-muted-foreground">{summary}</span>
           <span className="text-[10px] text-muted-foreground">{expanded ? "▲" : "▼"}</span>
         </button>
         <button
@@ -139,6 +166,33 @@ export function OnboardingPanel() {
             </div>
             <GitHubSetupSection />
           </div>
+
+          {status.githubConnected && inaccessibleRepos.length > 0 && (
+            <div className="space-y-4">
+              <div className="text-[11px] font-medium uppercase tracking-wider">
+                Repository access issues
+              </div>
+              <div className="space-y-3">
+                {inaccessibleRepos.map((repoStatus) => (
+                  <div key={repoStatus.repo} className="space-y-1">
+                    <div className="text-[11px] font-medium">
+                      <a
+                        href={`https://github.com/${repoStatus.repo}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-2"
+                      >
+                        {repoStatus.repo}
+                      </a>
+                    </div>
+                    <p className="text-[12px] text-destructive">
+                      Cannot access this repository: {repoStatus.error ?? "unknown error"}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -1,116 +1,10 @@
 import { useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { queryClient, apiRequest } from "@/lib/queryClient";
-
-type CodeReviewPresence = {
-  claude: boolean;
-  codex: boolean;
-  gemini: boolean;
-};
-
-type RepoOnboardingStatus = {
-  repo: string;
-  accessible: boolean;
-  error?: string;
-  codeReviews: CodeReviewPresence;
-};
+import { useQuery } from "@tanstack/react-query";
 
 type OnboardingStatus = {
   githubConnected: boolean;
   githubError?: string;
-  githubUser?: string;
-  repos: RepoOnboardingStatus[];
 };
-
-type InstallableTool = "claude" | "codex";
-type ReviewTool = InstallableTool | "gemini";
-
-const CLAUDE_WORKFLOW = `name: Claude Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  code-review:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: "Review this pull request for code quality, correctness, and security. Post your findings as review comments."
-`;
-
-const CODEX_WORKFLOW = `name: Codex Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  code-review:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: openai/codex-action@v1
-        with:
-          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
-          prompt: |
-            Review this pull request. Focus on:
-            - Code correctness and potential bugs
-            - Security issues
-            - Performance concerns
-            - Code style and readability
-            Post your review as GitHub PR review comments.
-`;
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="shrink-0 border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background"
-    >
-      {copied ? "copied" : "copy"}
-    </button>
-  );
-}
-
-function CodeBlock({ code }: { code: string }) {
-  return (
-    <div className="relative mt-1">
-      <div className="flex items-center justify-between border border-border bg-muted/30 px-2 py-1">
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">yaml</span>
-        <CopyButton text={code} />
-      </div>
-      <pre className="overflow-x-auto border border-t-0 border-border bg-muted/10 p-3 text-[11px] leading-relaxed">
-        <code>{code}</code>
-      </pre>
-    </div>
-  );
-}
 
 function InlineCode({ children }: { children: string }) {
   return (
@@ -199,267 +93,6 @@ function GitHubSetupSection() {
   );
 }
 
-function InstallButton({
-  repo,
-  tool,
-  onInstalled,
-}: {
-  repo: string;
-  tool: InstallableTool;
-  onInstalled: (url: string) => void;
-}) {
-  const installMutation = useMutation({
-    mutationFn: async () => {
-      const res = await apiRequest("POST", "/api/onboarding/install-review", { repo, tool });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error ?? "Installation failed");
-      }
-      return res.json() as Promise<{ path: string; url: string }>;
-    },
-    onSuccess: (data) => {
-      onInstalled(data.url);
-      // Refresh onboarding status so the tool shows as installed
-      void queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
-    },
-  });
-
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        onClick={() => installMutation.mutate()}
-        disabled={installMutation.isPending}
-        className="border border-foreground bg-foreground px-3 py-1 text-[11px] uppercase tracking-wider text-background transition-colors hover:bg-foreground/80 disabled:opacity-50"
-      >
-        {installMutation.isPending ? "Installing…" : "Install workflow"}
-      </button>
-      {installMutation.isError && (
-        <span className="text-[11px] text-destructive">
-          {installMutation.error instanceof Error ? installMutation.error.message : "Failed"}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function ReviewToolSetup({ tool, repo }: { tool: ReviewTool; repo: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const [installedUrl, setInstalledUrl] = useState<string | null>(null);
-
-  const labels: Record<ReviewTool, string> = {
-    claude: "Claude Code Review",
-    codex: "Codex Code Review",
-    gemini: "Gemini Code Review",
-  };
-
-  const descriptions: Record<ReviewTool, string> = {
-    claude: "Anthropic's Claude reviews PRs and posts inline comments via GitHub Actions.",
-    codex: "OpenAI's Codex reviews PRs and posts inline comments via GitHub Actions.",
-    gemini: "Google's Gemini reviews PRs automatically as a GitHub App — no workflow file needed.",
-  };
-
-  return (
-    <div className="border border-border">
-      <div className="flex items-center justify-between px-3 py-2">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex flex-1 items-center gap-2 text-left transition-colors hover:opacity-70"
-        >
-          <span className="text-[11px] font-medium">{labels[tool]}</span>
-          {installedUrl ? (
-            <span className="border border-green-600 px-1 py-0 text-[10px] uppercase tracking-wider text-green-500">installed</span>
-          ) : (
-            <span className="border border-border px-1 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">not installed</span>
-          )}
-          <span className="text-[10px] text-muted-foreground">{expanded ? "▲" : "▼"}</span>
-        </button>
-
-        {/* One-click install for Claude and Codex */}
-        {(tool === "claude" || tool === "codex") && !installedUrl && (
-          <InstallButton
-            repo={repo}
-            tool={tool}
-            onInstalled={(url) => setInstalledUrl(url)}
-          />
-        )}
-        {installedUrl && (
-          <a
-            href={installedUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[11px] text-green-500 underline underline-offset-2"
-          >
-            View →
-          </a>
-        )}
-      </div>
-
-      {expanded && (
-        <div className="border-t border-border px-3 py-3 space-y-3">
-          <p className="text-[12px] text-muted-foreground">{descriptions[tool]}</p>
-
-          {tool === "claude" && (
-            <div className="space-y-3">
-              <div className="border border-amber-500/30 bg-amber-500/5 p-2 text-[11px] text-muted-foreground">
-                The <strong>Install workflow</strong> button above creates the file in your repo automatically.
-                You still need to complete steps 1–2 below for the action to authenticate.
-              </div>
-              <Step number={1}>
-                Install the{" "}
-                <a href="https://github.com/apps/claude" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Claude GitHub App
-                </a>
-                {" "}to your repository. (Or run <InlineCode>/install-github-app</InlineCode> inside Claude Code.)
-              </Step>
-              <Step number={2}>
-                Add your Anthropic API key as a repository secret named <InlineCode>ANTHROPIC_API_KEY</InlineCode> in{" "}
-                <a
-                  href={`https://github.com/${repo}/settings/secrets/actions`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline underline-offset-2"
-                >
-                  {repo} › Settings › Secrets
-                </a>.
-              </Step>
-              <Step number={3}>
-                The workflow file will be created automatically when you click <strong>Install workflow</strong>. Or add it manually:
-                <CodeBlock code={CLAUDE_WORKFLOW} />
-              </Step>
-              <p className="text-[11px] text-muted-foreground">
-                Docs:{" "}
-                <a href="https://github.com/anthropics/claude-code-action" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  anthropics/claude-code-action
-                </a>
-                {" "}·{" "}
-                <a href="https://github.com/marketplace/actions/claude-code-action-official" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  GitHub Marketplace
-                </a>
-              </p>
-            </div>
-          )}
-
-          {tool === "codex" && (
-            <div className="space-y-3">
-              <div className="border border-amber-500/30 bg-amber-500/5 p-2 text-[11px] text-muted-foreground">
-                The <strong>Install workflow</strong> button above creates the file in your repo automatically.
-                You still need to add the secret in step 1 below.
-              </div>
-              <Step number={1}>
-                Add your OpenAI API key as a repository secret named <InlineCode>OPENAI_API_KEY</InlineCode> in{" "}
-                <a
-                  href={`https://github.com/${repo}/settings/secrets/actions`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline underline-offset-2"
-                >
-                  {repo} › Settings › Secrets
-                </a>.
-              </Step>
-              <Step number={2}>
-                The workflow file will be created automatically when you click <strong>Install workflow</strong>. Or add it manually:
-                <CodeBlock code={CODEX_WORKFLOW} />
-              </Step>
-              <Step number={3}>
-                <strong>Optional:</strong> For automatic reviews on every PR without a workflow, enable{" "}
-                <a href="https://developers.openai.com/codex/cloud/code-review" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Codex Cloud Code Review
-                </a>
-                {" "}in your Codex settings and turn on Automatic reviews. Then tag <InlineCode>@codex review</InlineCode> in any PR comment.
-              </Step>
-              <p className="text-[11px] text-muted-foreground">
-                Docs:{" "}
-                <a href="https://github.com/openai/codex-action" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  openai/codex-action
-                </a>
-                {" "}·{" "}
-                <a href="https://developers.openai.com/codex/github-action" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  OpenAI Docs
-                </a>
-              </p>
-            </div>
-          )}
-
-          {tool === "gemini" && (
-            <div className="space-y-3">
-              <div className="border border-border p-2 text-[11px] text-muted-foreground">
-                <strong>Note:</strong> Gemini Code Assist is a GitHub App installed via the marketplace — it cannot be installed by pushing a workflow file.
-              </div>
-              <Step number={1}>
-                Go to the{" "}
-                <a href="https://github.com/marketplace/gemini-code-assist" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Gemini Code Assist GitHub Marketplace page
-                </a>{" "}
-                and click <strong>Install</strong>.
-              </Step>
-              <Step number={2}>
-                Select your organization and the repositories you want to enable, including <InlineCode>{repo}</InlineCode>.
-              </Step>
-              <Step number={3}>
-                Accept the Google Terms of Service and complete setup. Gemini will automatically review new PRs within minutes.
-              </Step>
-              <Step number={4}>
-                <strong>Optional:</strong> Customize behavior by adding a <InlineCode>.gemini/config.yaml</InlineCode> or a code review style guide to your repo.
-              </Step>
-              <p className="text-[11px] text-muted-foreground">
-                <strong>Alternative — Gemini CLI GitHub Action (beta, no-cost):</strong> Download{" "}
-                <a href="https://github.com/google-github-actions/run-gemini-cli" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Gemini CLI ≥0.1.18
-                </a>
-                , run <InlineCode>gemini /setup-github</InlineCode>, and copy the generated workflows into <InlineCode>.github/workflows/</InlineCode>.
-              </p>
-              <p className="text-[11px] text-muted-foreground">
-                Docs:{" "}
-                <a href="https://developers.google.com/gemini-code-assist/docs/set-up-code-assist-github" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Set up Gemini Code Assist on GitHub
-                </a>
-              </p>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function RepoSetupSection({ repoStatus }: { repoStatus: RepoOnboardingStatus }) {
-  const missing = (["claude", "codex", "gemini"] as ReviewTool[]).filter((t) => !repoStatus.codeReviews[t]);
-
-  if (repoStatus.accessible && missing.length === 0) return null;
-
-  return (
-    <div className="space-y-2">
-      <div className="text-[11px] font-medium">
-        <a
-          href={`https://github.com/${repoStatus.repo}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline underline-offset-2"
-        >
-          {repoStatus.repo}
-        </a>
-      </div>
-
-      {!repoStatus.accessible ? (
-        <p className="text-[12px] text-destructive">
-          Cannot access this repository: {repoStatus.error ?? "unknown error"}
-        </p>
-      ) : (
-        <div className="space-y-1">
-          <p className="text-[11px] text-muted-foreground">
-            No AI code review tools detected. Install one or more to get automated PR feedback:
-          </p>
-          <div className="space-y-1">
-            {missing.map((tool) => (
-              <ReviewToolSetup key={tool} tool={tool} repo={repoStatus.repo} />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function OnboardingPanel() {
   const [dismissed, setDismissed] = useState(false);
   const [expanded, setExpanded] = useState(true);
@@ -469,15 +102,7 @@ export function OnboardingPanel() {
     refetchInterval: 30000,
   });
 
-  if (isLoading || !status) return null;
-
-  const reposNeedingSetup = status.repos.filter(
-    (r) => !r.accessible || (!r.codeReviews.claude && !r.codeReviews.codex && !r.codeReviews.gemini),
-  );
-
-  const hasIssues = !status.githubConnected || reposNeedingSetup.length > 0;
-
-  if (!hasIssues || dismissed) return null;
+  if (isLoading || !status || status.githubConnected || dismissed) return null;
 
   return (
     <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/5">
@@ -490,11 +115,7 @@ export function OnboardingPanel() {
           <span className="text-[11px] font-medium uppercase tracking-wider text-amber-400">
             Setup needed
           </span>
-          <span className="text-[11px] text-muted-foreground">
-            {!status.githubConnected
-              ? "GitHub not connected"
-              : `${reposNeedingSetup.length} repo${reposNeedingSetup.length !== 1 ? "s" : ""} missing AI code review`}
-          </span>
+          <span className="text-[11px] text-muted-foreground">GitHub not connected</span>
           <span className="text-[10px] text-muted-foreground">{expanded ? "▲" : "▼"}</span>
         </button>
         <button
@@ -507,32 +128,17 @@ export function OnboardingPanel() {
 
       {expanded && (
         <div className="border-t border-amber-500/20 px-4 py-4 space-y-6">
-          {!status.githubConnected && (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-destructive">
-                  GitHub not connected
-                </span>
-                {status.githubError && (
-                  <span className="text-[11px] text-muted-foreground">— {status.githubError}</span>
-                )}
-              </div>
-              <GitHubSetupSection />
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-wider text-destructive">
+                GitHub not connected
+              </span>
+              {status.githubError && (
+                <span className="text-[11px] text-muted-foreground">— {status.githubError}</span>
+              )}
             </div>
-          )}
-
-          {status.githubConnected && reposNeedingSetup.length > 0 && (
-            <div className="space-y-4">
-              <div className="text-[11px] font-medium uppercase tracking-wider">
-                AI code review not detected
-              </div>
-              <div className="space-y-4">
-                {reposNeedingSetup.map((r) => (
-                  <RepoSetupSection key={r.repo} repoStatus={r} />
-                ))}
-              </div>
-            </div>
-          )}
+            <GitHubSetupSection />
+          </div>
         </div>
       )}
     </div>

--- a/server/onboardingPanel.test.ts
+++ b/server/onboardingPanel.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getOnboardingPanelState } from "../client/src/components/OnboardingPanel";
+
+test("getOnboardingPanelState keeps the panel visible for inaccessible repos after GitHub connects", () => {
+  const state = getOnboardingPanelState({
+    githubConnected: true,
+    repos: [
+      { repo: "octo/accessible", accessible: true },
+      { repo: "octo/inaccessible", accessible: false, error: "Resource not accessible by integration" },
+    ],
+  });
+
+  assert.equal(state.hasIssues, true);
+  assert.equal(state.summary, "1 inaccessible repo");
+  assert.deepEqual(state.inaccessibleRepos, [
+    { repo: "octo/inaccessible", accessible: false, error: "Resource not accessible by integration" },
+  ]);
+});
+
+test("getOnboardingPanelState hides the panel when GitHub is connected and watched repos are accessible", () => {
+  const state = getOnboardingPanelState({
+    githubConnected: true,
+    repos: [{ repo: "octo/accessible", accessible: true }],
+  });
+
+  assert.equal(state.hasIssues, false);
+  assert.equal(state.summary, "0 inaccessible repos");
+  assert.deepEqual(state.inaccessibleRepos, []);
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-04-01 - Default to removing the named UI surface, not its whole container
+- Pattern: I treated a request to remove the `"AI code review not detected"` dialog as possibly meaning the entire onboarding banner, even after locating the text inside a shared panel with unrelated GitHub setup content.
+- Rule: When the user names a specific dialog, heading, or message inside a composite UI, default to removing only that named surface and preserving adjacent sections unless they explicitly ask for broader cleanup.
+- Prevention checklist:
+  - Trace the exact component boundary around the named UI before widening scope.
+  - Preserve unrelated content in shared panels by default.
+  - Ask a scope question only when the named text maps to multiple equally plausible surfaces.
+
 ## 2026-03-28 - Design product features around user repositories, not this repo's own workflow
 - Pattern: I framed a new PR-documentation feature as if it were about Code Factory's own repository and CI/docs pipeline, when the user intended a product capability that agents apply to any tracked repository.
 - Rule: When designing or implementing Code Factory behavior, default to repository-agnostic product semantics unless the user explicitly scopes the request to this repo's own operations.


### PR DESCRIPTION
## Summary
- remove the repo AI review setup warning and installer UI from the dashboard onboarding panel
- keep the GitHub connection onboarding banner and setup instructions intact
- record the scope-handling lesson in tasks/lessons.md

## Verification
- npm run check
- npm run build
- rg -n "AI code review not detected|missing AI code review|No AI code review tools detected|Install workflow" client server shared