### PR TITLE
feat: add per-pr watch toggle

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -315,6 +315,27 @@ Remove a PR from tracking.
 
 ---
 
+#### `PATCH /api/prs/:id/watch`
+
+Pause or resume background automation for a single tracked PR.
+
+When `enabled` is `false`, the background watcher skips autonomous sync/apply
+cycles for that PR, but manual routes such as `POST /api/prs/:id/fetch`,
+`POST /api/prs/:id/triage`, `POST /api/prs/:id/apply`, and
+`POST /api/prs/:id/babysit` still work. Re-enabling watch schedules an
+immediate watcher pass.
+
+**Body**
+```json
+{ "enabled": false }
+```
+
+**Response** `200` — updated [PR object](#pr)
+**Response** `400` — invalid body
+**Response** `404` — PR not found
+
+---
+
 #### `POST /api/prs/:id/fetch`
 
 Force a fresh pull of comments and reviews from GitHub for this PR.
@@ -600,6 +621,7 @@ Install the Code Factory code-review GitHub Actions workflow on a repository.
   testsPassed: boolean | null;
   lintPassed: boolean | null;
   lastChecked: string | null;  // ISO 8601
+  watchEnabled: boolean;       // false pauses autonomous watcher runs for this PR
   addedAt: string;             // ISO 8601
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ No hosted service. No agent edits inside your working copy. Your PR automation s
 
 - Watch multiple repositories or add a single PR by URL.
 - Auto-register open PRs, archive closed or merged PRs, and keep syncing review activity.
+- Pause background automation for an individual tracked PR while keeping manual runs available.
 - Store PR state, questions, logs, and social changelogs in SQLite with mirrored log files.
 - Triage feedback into `accept`, `reject`, or `flag`, with manual overrides and retry for failed or warned items.
 - Run `codex` or `claude` in isolated worktrees under `~/.oh-my-pr`, then push verified fixes back to the PR branch.
@@ -38,7 +39,7 @@ No hosted service. No agent edits inside your working copy. Your PR automation s
 <img width="969" height="572" alt="Code Factory workflow" src="https://github.com/user-attachments/assets/b9dbd102-ae2e-4837-a862-a0282bdfa0b8" />
 
 1. Add a repository to the watch list or register a PR directly by URL.
-2. The watcher polls GitHub, auto-registers open PRs, syncs reviews and comments, archives PRs that closed upstream, and queues babysitter runs.
+2. The watcher polls GitHub, auto-registers open PRs, syncs reviews and comments, archives PRs that closed upstream, and queues babysitter runs for tracked PRs whose background watch is enabled.
 3. Accepted work is executed in an app-owned repo cache and isolated git worktree under `~/.oh-my-pr`.
 4. The agent applies fixes, verifies the result, pushes to the PR branch, updates GitHub threads, and writes logs for the full run.
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -72,6 +72,14 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
   );
 }
 
+function WatchPausedIndicator() {
+  return (
+    <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+      watch paused
+    </span>
+  );
+}
+
 function ReadyToMergeIndicator({
   href,
   testId,
@@ -196,11 +204,7 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
               {pr.repo}
             </a>
             <span>{formatStatusLabel(pr.status)}</span>
-            {!watchEnabled && (
-              <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
-                watch paused
-              </span>
-            )}
+            {!watchEnabled && <WatchPausedIndicator />}
             {pr.feedbackItems.length > 0 && (() => {
               const counts = countActiveFeedbackStatuses(pr.feedbackItems);
               const parts: string[] = [];
@@ -931,11 +935,7 @@ export default function Dashboard() {
                       <StatusDot status={selectedPR.status} />
                       <span className="truncate font-medium">{selectedPR.title}</span>
                       <AgentIndicator pr={selectedPR} />
-                      {!selectedPRWatchEnabled && (
-                        <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
-                          watch paused
-                        </span>
-                      )}
+                      {!selectedPRWatchEnabled && <WatchPausedIndicator />}
                       <a
                         href={selectedPR.url}
                         target="_blank"
@@ -947,11 +947,7 @@ export default function Dashboard() {
                     </div>
                     <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                       <span>status: {formatStatusLabel(selectedPR.status)}</span>
-                      {!selectedPRWatchEnabled && (
-                        <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
-                          watch paused
-                        </span>
-                      )}
+                      {!selectedPRWatchEnabled && <WatchPausedIndicator />}
                       <span>{selectedPR.feedbackItems.length} items</span>
                       {selectedPR.feedbackItems.length > 0 && (() => {
                         const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -24,6 +24,10 @@ function formatClock(timestamp: string | null): string | null {
   return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
 }
 
+function isPRWatchEnabled(pr: PR): boolean {
+  return pr.watchEnabled;
+}
+
 function formatStatusLabel(status: PR["status"]): string {
   if (status === "processing") {
     return "autonomous run active";
@@ -137,6 +141,7 @@ function AgentIndicator({ pr }: { pr: PR }) {
 
 function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSelect: () => void }) {
   const checkedAt = formatClock(pr.lastChecked);
+  const watchEnabled = isPRWatchEnabled(pr);
   const agentActive = pr.status === "processing" || countActiveFeedbackStatuses(pr.feedbackItems).inProgress > 0;
   const readyToMerge = !agentActive && isPRReadyToMerge(pr.feedbackItems);
 
@@ -191,6 +196,11 @@ function PRRow({ pr, isSelected, onSelect }: { pr: PR; isSelected: boolean; onSe
               {pr.repo}
             </a>
             <span>{formatStatusLabel(pr.status)}</span>
+            {!watchEnabled && (
+              <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+                watch paused
+              </span>
+            )}
             {pr.feedbackItems.length > 0 && (() => {
               const counts = countActiveFeedbackStatuses(pr.feedbackItems);
               const parts: string[] = [];
@@ -593,6 +603,7 @@ export default function Dashboard() {
   }, [displayedPRs, selectedPRId]);
 
   const selectedPR = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
+  const selectedPRWatchEnabled = selectedPR ? isPRWatchEnabled(selectedPR) : true;
 
   const addMutation = useMutation({
     mutationFn: async (url: string) => {
@@ -620,6 +631,21 @@ export default function Dashboard() {
     },
     onError: (error) => {
       showMutationError("Could not run babysitter", error);
+    },
+  });
+
+  const watchMutation = useMutation({
+    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
+      const res = await apiRequest("PATCH", `/api/prs/${id}/watch`, { enabled });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not update PR watch state", error);
     },
   });
 
@@ -905,6 +931,11 @@ export default function Dashboard() {
                       <StatusDot status={selectedPR.status} />
                       <span className="truncate font-medium">{selectedPR.title}</span>
                       <AgentIndicator pr={selectedPR} />
+                      {!selectedPRWatchEnabled && (
+                        <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          watch paused
+                        </span>
+                      )}
                       <a
                         href={selectedPR.url}
                         target="_blank"
@@ -916,6 +947,11 @@ export default function Dashboard() {
                     </div>
                     <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                       <span>status: {formatStatusLabel(selectedPR.status)}</span>
+                      {!selectedPRWatchEnabled && (
+                        <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          watch paused
+                        </span>
+                      )}
                       <span>{selectedPR.feedbackItems.length} items</span>
                       {selectedPR.feedbackItems.length > 0 && (() => {
                         const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
@@ -938,14 +974,24 @@ export default function Dashboard() {
                     </div>
                   </div>
                   {!isArchived && (
-                    <button
-                      onClick={() => applyMutation.mutate(selectedPR.id)}
-                      disabled={applyMutation.isPending || selectedPR.status === "processing"}
-                      data-testid="button-apply"
-                      className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
-                    >
-                      {selectedPR.status === "processing" ? "Running" : "Run now"}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => applyMutation.mutate(selectedPR.id)}
+                        disabled={applyMutation.isPending || selectedPR.status === "processing"}
+                        data-testid="button-apply"
+                        className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                      >
+                        {selectedPR.status === "processing" ? "Running" : "Run now"}
+                      </button>
+                      <button
+                        onClick={() => watchMutation.mutate({ id: selectedPR.id, enabled: !selectedPRWatchEnabled })}
+                        disabled={watchMutation.isPending}
+                        data-testid="button-toggle-watch"
+                        className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                      >
+                        {selectedPRWatchEnabled ? "Pause watch" : "Resume watch"}
+                      </button>
+                    </div>
                   )}
                 </div>
                 {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
@@ -960,14 +1006,18 @@ export default function Dashboard() {
                   />
                 )}
                 <div className="text-[11px] text-muted-foreground">
-                  Background watcher syncs GitHub feedback and pushes approved fixes automatically.
+                  {selectedPRWatchEnabled
+                    ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
+                    : "Background watch is paused for this PR; manual runs still work."}
                 </div>
               </div>
 
               <div className="flex-1 overflow-y-auto">
                 {selectedPR.feedbackItems.length === 0 ? (
                   <div className="p-4 text-[12px] text-muted-foreground">
-                    No feedback yet. The watcher will sync GitHub comments automatically.
+                    {selectedPRWatchEnabled
+                      ? "No feedback yet. The watcher will sync GitHub comments automatically."
+                      : "No feedback yet. Background watch is paused for this PR."}
                   </div>
                 ) : (
                   selectedPR.feedbackItems.map((item) => (

--- a/docs/plans/2026-04-01-per-pr-watch-toggle-design.md
+++ b/docs/plans/2026-04-01-per-pr-watch-toggle-design.md
@@ -1,0 +1,125 @@
+# Per-PR Watch Toggle Design
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Goal
+
+Let users turn background watch off for individual tracked pull requests so stale or low-priority PRs stop receiving automatic sync and babysitter runs without disappearing from the active dashboard or losing manual run access.
+
+## Requirements
+
+- Add a per-PR background-watch toggle with a default of enabled.
+- Keep paused PRs visible in the active PR list and detail pane.
+- Preserve manual `Run now` behavior when background watch is disabled.
+- Keep repo-level watch and PR discovery behavior unchanged.
+- Continue archiving PRs automatically when they close on GitHub, even if background watch is disabled.
+- Persist the toggle across restarts in both memory and SQLite storage.
+- Do not overload `status` with watch-enabled semantics.
+- Make the paused state visible in the dashboard row and detail surfaces.
+- Write explicit activity logs when background watch is paused or resumed.
+- Resuming watch should trigger an immediate background sync instead of waiting for the next poll interval.
+
+## Architecture
+
+Add a dedicated boolean field, `watchEnabled`, to the shared PR model. This field represents whether the background watcher may automatically sync and babysit that PR. The existing `status` field remains responsible for lifecycle state such as `watching`, `processing`, `done`, `error`, and `archived`.
+
+The repository watcher should keep its current repo-driven discovery loop. It should still list open PRs for watched repositories, auto-register newly discovered PRs, and archive PRs that are no longer open. For open PRs that already exist locally, it should branch on `watchEnabled`: enabled PRs continue through the normal babysitter flow, while disabled PRs are skipped for automatic sync and remediation.
+
+Manual babysitter execution remains available regardless of `watchEnabled`. This keeps the feature scoped to background automation control rather than becoming a second PR lifecycle.
+
+## Data Model
+
+### PR State
+
+Add `watchEnabled: boolean` to `prSchema` and default it to `true` when a PR is created.
+
+Persist the field through:
+
+- `shared/schema.ts`
+- `shared/models.ts`
+- `server/memoryStorage.ts`
+- `server/sqliteStorage.ts`
+
+### SQLite Persistence
+
+Add a `watch_enabled` column to the `prs` table with `INTEGER NOT NULL DEFAULT 1`. Include it in both the canonical `CREATE TABLE` definition and the `ensureColumn` migration so fresh and migrated databases share the same schema.
+
+## API
+
+Add a dedicated route:
+
+- `PATCH /api/prs/:id/watch`
+
+Request body:
+
+```json
+{ "enabled": true }
+```
+
+Behavior:
+
+- validate the payload with Zod;
+- update the PR's `watchEnabled` field;
+- append an activity log stating whether background watch was paused or resumed;
+- return the updated PR;
+- if watch is resumed, trigger `runWatcher()` asynchronously so the PR is refreshed immediately.
+
+This route should not block or reject manual babysitter actions. If a PR is already `processing`, changing `watchEnabled` only affects future background cycles.
+
+## Watcher Behavior
+
+Inside `syncAndBabysitTrackedRepos()`:
+
+1. Keep building the repo candidate set from `config.watchedRepos` plus tracked PR repos.
+2. Keep listing all open PRs per repo.
+3. Keep archiving tracked PRs that are no longer open.
+4. Keep auto-registering newly discovered open PRs with `watchEnabled: true`.
+5. Before queueing an automatic babysitter run for an open PR, check `watchEnabled`.
+6. If `watchEnabled` is `false`, skip automatic babysitting for that PR and leave its existing state intact.
+
+This means repo watch remains the mechanism for discovery, while per-PR watch controls ongoing automation.
+
+## Dashboard UX
+
+Add the primary control in the selected PR header next to `Run now`:
+
+- `Pause watch` when `watchEnabled` is `true`
+- `Resume watch` when `watchEnabled` is `false`
+
+Show passive paused-state indicators in two places:
+
+- a small label in the PR row so users can scan paused PRs quickly;
+- a metadata label in the detail pane.
+
+Update the detail copy:
+
+- watched PR: background watcher syncs GitHub feedback and pushes approved fixes automatically;
+- paused PR: background watch is paused for this PR; manual runs still work.
+
+Do not create a separate paused tab or reuse the archived view.
+
+## Error Handling
+
+- If the watch-toggle route receives an invalid body, return `400`.
+- If the PR does not exist, return `404`.
+- If a resume-triggered watcher run later fails, the route still succeeds; the failure is surfaced through existing logs and watcher error handling.
+- Pausing a currently running PR does not cancel the in-flight run.
+
+## Testing Strategy
+
+Add targeted coverage for:
+
+- shared schema and model defaults for `watchEnabled`;
+- SQLite and memory-storage persistence for `watchEnabled`;
+- the watch-toggle route updating PR state and logging pause/resume events;
+- the watcher skipping automatic babysits for paused PRs;
+- the watcher resuming automatic babysits after `watchEnabled` is turned back on;
+- paused PRs still being archived when GitHub reports them closed;
+- dashboard type safety and build compatibility after the new UI control is added.
+
+## Risks And Constraints
+
+- Repo watch still discovers all open PRs in a watched repo. Turning off watch for one PR does not stop new PRs from that repo from being auto-registered.
+- Skipping automatic babysits must not accidentally suppress archival detection, release evaluation for merged PRs, or other repo-level discovery logic.
+- A dedicated boolean is intentionally simpler than introducing a new paused status; it minimizes impact across the existing lifecycle codepaths.

--- a/docs/plans/2026-04-01-per-pr-watch-toggle.md
+++ b/docs/plans/2026-04-01-per-pr-watch-toggle.md
@@ -1,0 +1,189 @@
+# Per-PR Watch Toggle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users pause background monitoring for individual tracked PRs while keeping those PRs visible and manually runnable.
+
+**Architecture:** Add a dedicated `watchEnabled` boolean to the shared PR model and persist it in both storage backends. Keep repo-level PR discovery and archival unchanged, but gate automatic babysitter runs on the per-PR flag. Expose the toggle through a small PR-specific API route and a dashboard control in the selected PR header.
+
+**Tech Stack:** TypeScript, Express, React, SQLite (`node:sqlite`), Node test runner (`node --test --import tsx`).
+
+---
+
+### Task 1: Add The Shared PR Watch Flag
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `shared/models.ts`
+- Modify: `server/defaultConfig.test.ts` only if fixtures require it
+- Modify: `server/github.test.ts` only if config fixtures require it
+
+**Step 1: Write the failing schema-adjacent tests**
+Add or update targeted assertions so test fixtures constructing a `PR` must include the new `watchEnabled` field or rely on a default that is explicitly asserted.
+
+**Step 2: Run the targeted tests**
+Run: `node --test --import tsx server/defaultConfig.test.ts server/github.test.ts`
+Expected: FAIL if shared schema changes require fixture updates.
+
+**Step 3: Write minimal shared-model implementation**
+Implement:
+- `watchEnabled: z.boolean().default(true)` on `prSchema`
+- preservation of `watchEnabled` through `createPR(...)`
+- preservation of `watchEnabled` through `applyPRUpdate(...)`
+
+**Step 4: Re-run the targeted tests**
+Run: `node --test --import tsx server/defaultConfig.test.ts server/github.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git add shared/schema.ts shared/models.ts server/defaultConfig.test.ts server/github.test.ts`
+`git commit -m "feat: add per-pr watch flag to shared model"`
+
+### Task 2: Persist The Watch Flag In Storage
+
+**Files:**
+- Modify: `server/sqliteStorage.ts`
+- Modify: `server/memoryStorage.ts`
+- Modify: `server/storage.test.ts`
+- Modify: `server/memoryStorage.test.ts`
+
+**Step 1: Write the failing storage tests**
+Add coverage for:
+- new PRs defaulting `watchEnabled` to `true`,
+- SQLite round-tripping `watchEnabled`,
+- memory storage round-tripping `watchEnabled`,
+- migrated SQLite databases seeing `watch_enabled = 1` by default.
+
+**Step 2: Run the targeted storage tests**
+Run: `node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts`
+Expected: FAIL.
+
+**Step 3: Write minimal persistence implementation**
+Implement:
+- `watch_enabled` in the SQLite `prs` table definition,
+- matching `ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1")`,
+- row parsing and writes for `watchEnabled`,
+- memory-storage preservation of the same field.
+
+**Step 4: Re-run the targeted storage tests**
+Run: `node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git add server/sqliteStorage.ts server/memoryStorage.ts server/storage.test.ts server/memoryStorage.test.ts`
+`git commit -m "feat: persist per-pr watch state"`
+
+### Task 3: Add The Per-PR Watch API
+
+**Files:**
+- Modify: `server/routes.ts`
+- Modify: `server/babysitter.test.ts` if route coverage reuses babysitter behavior stubs
+- Create or Modify: route test file if one already exists for API behavior
+
+**Step 1: Write the failing route tests**
+Add coverage for:
+- `PATCH /api/prs/:id/watch` returning `404` for missing PRs,
+- disabling watch updating the PR and logging a pause message,
+- enabling watch updating the PR and triggering a watcher run,
+- invalid payload returning `400`.
+
+**Step 2: Run the targeted route tests**
+Run the smallest relevant API test command for the chosen file(s).
+Expected: FAIL.
+
+**Step 3: Write minimal route implementation**
+Implement:
+- Zod request parsing with `{ enabled: z.boolean() }`,
+- `storage.updatePR(...)` for `watchEnabled`,
+- `storage.addLog(...)` for pause/resume messages,
+- async `runWatcher()` call on resume only.
+
+**Step 4: Re-run the targeted route tests**
+Run the same targeted API test command.
+Expected: PASS.
+
+**Step 5: Commit**
+`git add server/routes.ts <route-test-files>`
+`git commit -m "feat: add per-pr watch toggle api"`
+
+### Task 4: Gate Background Babysits On The Watch Flag
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Write the failing watcher tests**
+Add coverage for:
+- open PRs with `watchEnabled: false` being discovered but not babysat,
+- the same PR being babysat after `watchEnabled` is set back to `true`,
+- paused PRs still being archived when they close on GitHub.
+
+**Step 2: Run the babysitter tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL.
+
+**Step 3: Write minimal watcher implementation**
+Implement:
+- auto-registered PRs with `watchEnabled: true`,
+- an early watch-flag branch before logging/queueing automatic babysitter runs,
+- no change to archival and release-trigger logic.
+
+**Step 4: Re-run the babysitter tests**
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+`git add server/babysitter.ts server/babysitter.test.ts`
+`git commit -m "feat: respect per-pr watch state in watcher"`
+
+### Task 5: Add The Dashboard Pause And Resume Control
+
+**Files:**
+- Modify: `client/src/pages/dashboard.tsx`
+
+**Step 1: Add the UI state and control**
+Implement:
+- a mutation for `PATCH /api/prs/:id/watch`,
+- a `Pause watch` / `Resume watch` button in the selected PR header,
+- a passive paused label in each PR row,
+- a paused-state message in the PR detail pane.
+
+**Step 2: Run strict typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 3: Run the production build**
+Run: `npm run build`
+Expected: PASS.
+
+**Step 4: Manual smoke check**
+Start the app, pause a PR, confirm the label updates after refetch, refresh the page, and confirm the paused state persists. Resume the PR and confirm it returns to the normal watched state.
+
+**Step 5: Commit**
+`git add client/src/pages/dashboard.tsx`
+`git commit -m "feat: add dashboard control for per-pr watch state"`
+
+### Task 6: Final Verification Sweep
+
+**Files:**
+- Modify: only files above as needed
+
+**Step 1: Run targeted backend tests**
+Run: `node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts server/babysitter.test.ts`
+Expected: PASS.
+
+**Step 2: Run the full server test suite**
+Run: `node --test --import tsx server/*.test.ts`
+Expected: PASS.
+
+**Step 3: Run strict typecheck**
+Run: `npm run check`
+Expected: PASS.
+
+**Step 4: Run the production build**
+Run: `npm run build`
+Expected: PASS.
+
+**Step 5: Commit final verification fixes**
+`git add <changed-files>`
+`git commit -m "test: verify per-pr watch toggle flow"`

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -189,7 +189,9 @@
 <li>New PRs opened against the repository.</li>
 <li>Review comments and change requests on existing PRs.</li>
 <li>Status changes (approvals, dismissals, re-requests).</li>
+<li>A per-PR watch state so you can pause background automation for one tracked PR without removing it.</li>
 </ul>
+<p>Paused PRs stay tracked locally and can still be run manually from the dashboard or API. While paused, the background watcher skips autonomous sync and babysitter runs for that PR until you resume watch.</p>
 <h3>2. Review Sync</h3>
 <p>Every review comment is captured and stored locally. oh-my-pr understands GitHub&#39;s threaded review model:</p>
 <ul>
@@ -262,6 +264,7 @@
 <li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
 <li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
 <li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.</li>
+<li><strong>Per-PR watch toggle</strong> — Pause one tracked PR&#39;s background automation while keeping manual runs available.</li>
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for details.</p>
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -11,6 +11,9 @@ When you add a repository to oh-my-pr, the babysitter begins polling for open pu
 - New PRs opened against the repository.
 - Review comments and change requests on existing PRs.
 - Status changes (approvals, dismissals, re-requests).
+- A per-PR watch state so you can pause background automation for one tracked PR without removing it.
+
+Paused PRs stay tracked locally and can still be run manually from the dashboard or API. While paused, the background watcher skips autonomous sync and babysitter runs for that PR until you resume watch.
 
 ### 2. Review Sync
 
@@ -71,5 +74,6 @@ You can control babysitter behavior per repository:
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
 - **Agent preference** — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.
+- **Per-PR watch toggle** — Pause one tracked PR's background automation while keeping manual runs available.
 
 See [Configuration](./configuration.md) for details.

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -352,6 +352,7 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
     testsPassed: null,
     lintPassed: null,
     lastChecked: null,
+    watchEnabled: false,
   });
 
   const babysitter = new PRBabysitter(
@@ -379,6 +380,117 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
   assert.equal(queued.length, 1);
   assert.equal(queued[0]?.triggerMergeSha, "merge123");
   assert.ok(logs.some((log) => log.message.includes("queued release evaluation")));
+});
+
+test("syncAndBabysitTrackedRepos skips automatic babysits when pr watch is paused", async () => {
+  const storage = new MemStorage();
+  const babysitCalls: string[] = [];
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Example PR",
+        branch: "feature/example",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+      }],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+  babysitter.babysitPR = async (prId) => {
+    babysitCalls.push(prId);
+    return;
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(updated?.watchEnabled, false);
+  assert.deepEqual(babysitCalls, []);
+  assert.ok(!logs.some((log) => log.message.includes("Watcher queued autonomous babysitter run")));
+});
+
+test("syncAndBabysitTrackedRepos resumes automatic babysits when pr watch is re-enabled", async () => {
+  const storage = new MemStorage();
+  const babysitCalls: string[] = [];
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Example PR",
+        branch: "feature/example",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+      }],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+  babysitter.babysitPR = async (prId) => {
+    babysitCalls.push(prId);
+    return;
+  };
+
+  await storage.updatePR(pr.id, { watchEnabled: false });
+  await babysitter.syncAndBabysitTrackedRepos();
+  await storage.updatePR(pr.id, { watchEnabled: true });
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const logs = await storage.getLogs(pr.id);
+  assert.deepEqual(babysitCalls, [pr.id]);
+  assert.ok(logs.some((log) => log.message.includes("Watcher queued autonomous babysitter run")));
 });
 
 test("syncAndBabysitTrackedRepos does not queue release evaluation for closed-unmerged PRs", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1008,6 +1008,10 @@ export class PRBabysitter {
           await this.storage.addLog(local.id, "info", `Auto-registered open PR #${pull.number} from ${repoSlug}`);
         }
 
+        if (!local.watchEnabled) {
+          continue;
+        }
+
         await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
           phase: "watcher",
           metadata: { repo: repoSlug },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -2,9 +2,9 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { MemStorage } from "./memoryStorage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
-import type { AgentRun, PR } from "@shared/schema";
+import type { AgentRun, NewPR, PR } from "@shared/schema";
 
-function makePRInput(overrides: Partial<Omit<PR, "id" | "addedAt">> = {}): Omit<PR, "id" | "addedAt"> {
+function makePRInput(overrides: Partial<NewPR> = {}): NewPR {
   return {
     number: 1,
     title: "Test PR",
@@ -58,6 +58,7 @@ describe("MemStorage", () => {
       assert.ok(pr.addedAt, "should have addedAt");
       assert.equal(pr.title, "Test PR");
       assert.equal(pr.status, "watching");
+      assert.equal(pr.watchEnabled, true);
     });
   });
 

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { MemStorage } from "./memoryStorage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
-import type { AgentRun, NewPR, PR } from "@shared/schema";
+import type { AgentRun, NewPR } from "@shared/schema";
 
 function makePRInput(overrides: Partial<NewPR> = {}): NewPR {
   return {

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -3,6 +3,7 @@ import type {
   AgentRunStatus,
   Config,
   LogEntry,
+  NewPR,
   PR,
   PRQuestion,
   ReleaseRun,
@@ -67,7 +68,7 @@ export class MemStorage implements IStorage {
     return Array.from(this.prs.values()).find((pr) => pr.repo === repo && pr.number === number);
   }
 
-  async addPR(pr: Omit<PR, "id" | "addedAt">): Promise<PR> {
+  async addPR(pr: NewPR): Promise<PR> {
     const full = createPR(pr);
     this.prs.set(full.id, full);
     return full;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -321,6 +321,37 @@ export async function registerRoutes(
     res.json({ ok: true });
   });
 
+  app.patch("/api/prs/:id/watch", async (req, res) => {
+    try {
+      const { enabled } = z.object({ enabled: z.boolean() }).parse(req.body);
+      const pr = await storage.getPR(req.params.id);
+      if (!pr) {
+        return res.status(404).json({ error: "PR not found" });
+      }
+
+      const updated = await storage.updatePR(pr.id, { watchEnabled: enabled });
+      if (!updated) {
+        return res.status(404).json({ error: "PR not found" });
+      }
+
+      if (pr.watchEnabled !== enabled) {
+        await storage.addLog(pr.id, "info", enabled ? "Background watch resumed" : "Background watch paused");
+        if (enabled) {
+          void runWatcher();
+        }
+      }
+
+      res.json(updated);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) {
+        return res.status(400).json({ error: err.errors[0].message });
+      }
+
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
   app.post("/api/prs/:id/fetch", async (req, res) => {
     const pr = await storage.getPR(req.params.id);
     if (!pr) return res.status(404).json({ error: "PR not found" });

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -8,6 +8,7 @@ import type {
   Config,
   FeedbackItem,
   LogEntry,
+  NewPR,
   PR,
   PRQuestion,
   ReleaseRun,
@@ -79,6 +80,7 @@ type PRRow = {
   tests_passed: number | null;
   lint_passed: number | null;
   last_checked: string | null;
+  watch_enabled: number;
   docs_assessment_json: string | null;
   added_at: string;
 };
@@ -358,6 +360,7 @@ export class SqliteStorage implements IStorage {
         tests_passed INTEGER,
         lint_passed INTEGER,
         last_checked TEXT,
+        watch_enabled INTEGER NOT NULL DEFAULT 1,
         docs_assessment_json TEXT,
         added_at TEXT NOT NULL,
         UNIQUE(repo, number)
@@ -496,6 +499,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
@@ -627,6 +631,7 @@ export class SqliteStorage implements IStorage {
       testsPassed: row.tests_passed === null ? null : Boolean(row.tests_passed),
       lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
       lastChecked: row.last_checked,
+      watchEnabled: Boolean(row.watch_enabled),
       docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
       addedAt: row.added_at,
     };
@@ -762,7 +767,7 @@ export class SqliteStorage implements IStorage {
   async getPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
+             tests_passed, lint_passed, last_checked, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY datetime(added_at) DESC
@@ -776,7 +781,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
+             tests_passed, lint_passed, last_checked, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY datetime(added_at) DESC
@@ -790,7 +795,7 @@ export class SqliteStorage implements IStorage {
   async getPR(id: string): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
+             tests_passed, lint_passed, last_checked, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE id = ?
     `, id);
@@ -806,7 +811,7 @@ export class SqliteStorage implements IStorage {
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
+             tests_passed, lint_passed, last_checked, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE repo = ? AND number = ?
     `, repo, number);
@@ -819,15 +824,15 @@ export class SqliteStorage implements IStorage {
     return this.parsePRRow(row, itemsByPrId.get(row.id) || []);
   }
 
-  async addPR(pr: Omit<PR, "id" | "addedAt">): Promise<PR> {
+  async addPR(pr: NewPR): Promise<PR> {
     const full = createPR(pr);
 
     this.withWriteTransaction(() => {
       this.run(`
         INSERT INTO prs (
           id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
-          tests_passed, lint_passed, last_checked, docs_assessment_json, added_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          tests_passed, lint_passed, last_checked, watch_enabled, docs_assessment_json, added_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         full.id,
         full.number,
@@ -843,6 +848,7 @@ export class SqliteStorage implements IStorage {
         full.testsPassed === null ? null : Number(full.testsPassed),
         full.lintPassed === null ? null : Number(full.lintPassed),
         full.lastChecked,
+        Number(full.watchEnabled),
         full.docsAssessment ? JSON.stringify(full.docsAssessment) : null,
         full.addedAt,
       );
@@ -864,7 +870,7 @@ export class SqliteStorage implements IStorage {
       this.run(`
         UPDATE prs
         SET number = ?, title = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
-            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?, docs_assessment_json = ?
+            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?, watch_enabled = ?, docs_assessment_json = ?
         WHERE id = ?
       `,
         updated.number,
@@ -880,6 +886,7 @@ export class SqliteStorage implements IStorage {
         updated.testsPassed === null ? null : Number(updated.testsPassed),
         updated.lintPassed === null ? null : Number(updated.lintPassed),
         updated.lastChecked,
+        Number(updated.watchEnabled),
         updated.docsAssessment ? JSON.stringify(updated.docsAssessment) : null,
         id,
       );

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -83,6 +83,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     testsPassed: null,
     lintPassed: null,
     lastChecked: null,
+    watchEnabled: false,
   });
   await first.updatePR(pr.id, {
     feedbackItems: [
@@ -185,6 +186,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(reloadedPr?.feedbackItems[0]?.threadId, "PRRT_kwDO_thread");
   assert.equal(reloadedPr?.feedbackItems[0]?.auditToken, "codefactory-feedback:feedback-1");
   assert.equal(reloadedPr?.accepted, 1);
+  assert.equal(reloadedPr?.watchEnabled, false);
   assert.equal(reloadedPr?.docsAssessment?.headSha, "abc123");
   assert.equal(reloadedPr?.docsAssessment?.status, "needed");
   assert.match(reloadedPr?.docsAssessment?.summary || "", /README/);
@@ -240,6 +242,36 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
     });
   } finally {
     db.close();
+    storage.close();
+  }
+});
+
+test("SqliteStorage defaults watchEnabled to true for new PRs", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+
+  try {
+    const pr = await storage.addPR({
+      number: 107,
+      title: "Watch defaults on",
+      repo: "alex-morgan-o/lolodex",
+      branch: "feature/default-watch",
+      author: "octocat",
+      url: "https://github.com/alex-morgan-o/lolodex/pull/107",
+      status: "watching",
+      feedbackItems: [],
+      accepted: 0,
+      rejected: 0,
+      flagged: 0,
+      testsPassed: null,
+      lintPassed: null,
+      lastChecked: null,
+    });
+
+    const reloaded = await storage.getPR(pr.id);
+    assert.equal(pr.watchEnabled, true);
+    assert.equal(reloaded?.watchEnabled, true);
+  } finally {
     storage.close();
   }
 });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3,6 +3,7 @@ import type {
   AgentRunStatus,
   Config,
   LogEntry,
+  NewPR,
   PR,
   PRQuestion,
   ReleaseRun,
@@ -19,7 +20,7 @@ export interface IStorage {
   getArchivedPRs(): Promise<PR[]>;
   getPR(id: string): Promise<PR | undefined>;
   getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined>;
-  addPR(pr: Omit<PR, "id" | "addedAt">): Promise<PR>;
+  addPR(pr: NewPR): Promise<PR>;
   updatePR(id: string, updates: Partial<PR>): Promise<PR | undefined>;
   removePR(id: string): Promise<boolean>;
 

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -14,6 +14,7 @@ import type {
   Config,
   FeedbackItem,
   LogEntry,
+  NewPR,
   PR,
   PRQuestion,
   ReleaseRun,
@@ -22,7 +23,7 @@ import type {
 
 // ── PR ───────────────────────────────────────────────────────────────────────
 
-export function createPR(data: Omit<PR, "id" | "addedAt">): PR {
+export function createPR(data: NewPR): PR {
   return prSchema.parse({
     ...data,
     id: randomUUID(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -71,10 +71,17 @@ export const prSchema = z.object({
   testsPassed: z.boolean().nullable(),
   lintPassed: z.boolean().nullable(),
   lastChecked: z.string().nullable(),
+  watchEnabled: z.boolean().default(true),
   docsAssessment: docsAssessmentSchema.nullable().optional(),
   addedAt: z.string(),
 });
 export type PR = z.infer<typeof prSchema>;
+
+export const newPRSchema = prSchema.omit({
+  id: true,
+  addedAt: true,
+});
+export type NewPR = z.input<typeof newPRSchema>;
 
 export const addPRSchema = z.object({
   url: z.string().url(),


### PR DESCRIPTION
## Summary
- add a persisted per-PR `watchEnabled` flag with a dedicated `PATCH /api/prs/:id/watch` route
- skip automatic watcher babysits for paused PRs while still archiving closed PRs and preserving manual `Run now`
- add dashboard pause/resume controls plus paused-state indicators and copy updates
- document the approved design and implementation plan under `docs/plans/`

## Verification
- `node --test --import tsx server/memoryStorage.test.ts server/storage.test.ts server/babysitter.test.ts`
- `node --test --import tsx server/*.test.ts`
- `npm run check`
- `npm run build`