### PR TITLE
fix: resolve review conversations on closure

### DIFF
--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -44,6 +44,7 @@ import {
   markFailed,
   markRetry,
   markWarning,
+  shouldResolveReviewConversation,
 } from "./feedbackLifecycle";
 
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
@@ -545,7 +546,7 @@ function needsGitHubFollowUp(item: FeedbackItem, feedbackItems: FeedbackItem[]):
     return true;
   }
 
-  return item.replyKind === "review_thread" && !item.threadResolved;
+  return shouldResolveReviewConversation(markResolved(item));
 }
 
 function collectGitHubFollowUpTasks(pr: PR): FeedbackItem[] {
@@ -2242,7 +2243,7 @@ export class PRBabysitter {
 
       for (const item of followUpTasks) {
         const shouldPostFollowUp = !hasAuditTrail(item, pr.feedbackItems);
-        const shouldResolveThread = item.replyKind === "review_thread" && !item.threadResolved;
+        const shouldResolveThread = shouldResolveReviewConversation(markResolved(item));
 
         if (shouldPostFollowUp) {
           await queueLog(pr.id, "info", `Posting GitHub follow-up for ${item.id}${shouldResolveThread ? " and resolving conversation" : ""}`, {

--- a/server/feedbackLifecycle.test.ts
+++ b/server/feedbackLifecycle.test.ts
@@ -5,11 +5,14 @@ import {
   applyManualDecision,
   applyEvaluationDecision,
   applyFlagDecision,
+  isFeedbackClosedStatus,
+  markReviewConversationResolved,
   markInProgress,
   markResolved,
   markFailed,
   markWarning,
   markRetry,
+  shouldResolveReviewConversation,
 } from "./feedbackLifecycle";
 
 function applyLegacyTriage(item: FeedbackItem): FeedbackItem {
@@ -105,6 +108,50 @@ test("markResolved maps to resolved", () => {
   const item = makeItem({ status: "in_progress" });
   const result = markResolved(item);
   assert.equal(result.status, "resolved");
+});
+
+test("isFeedbackClosedStatus only treats rejected and resolved as closed", () => {
+  assert.equal(isFeedbackClosedStatus("rejected"), true);
+  assert.equal(isFeedbackClosedStatus("resolved"), true);
+  assert.equal(isFeedbackClosedStatus("queued"), false);
+});
+
+test("shouldResolveReviewConversation closes unresolved review threads for terminal states", () => {
+  assert.equal(
+    shouldResolveReviewConversation(makeItem({ status: "rejected", threadId: "PRRT_kwDO_example", threadResolved: false })),
+    true,
+  );
+  assert.equal(
+    shouldResolveReviewConversation(makeItem({ status: "resolved", threadId: "PRRT_kwDO_example", threadResolved: false })),
+    true,
+  );
+  assert.equal(
+    shouldResolveReviewConversation(makeItem({ status: "queued", threadId: "PRRT_kwDO_example", threadResolved: false })),
+    false,
+  );
+  assert.equal(
+    shouldResolveReviewConversation(makeItem({
+      replyKind: "general_comment",
+      type: "general_comment",
+      status: "resolved",
+      threadResolved: false,
+    })),
+    false,
+  );
+});
+
+test("markReviewConversationResolved sets threadResolved for review threads only", () => {
+  const reviewThread = makeItem({ threadResolved: false });
+  const resolvedThread = markReviewConversationResolved(reviewThread);
+  assert.equal(resolvedThread.threadResolved, true);
+
+  const generalComment = makeItem({
+    replyKind: "general_comment",
+    type: "general_comment",
+    threadResolved: null,
+  });
+  const untouchedComment = markReviewConversationResolved(generalComment);
+  assert.equal(untouchedComment.threadResolved, null);
 });
 
 test("markFailed maps to failed with reason", () => {

--- a/server/feedbackLifecycle.ts
+++ b/server/feedbackLifecycle.ts
@@ -1,5 +1,26 @@
 import type { FeedbackItem } from "@shared/schema";
 
+export function isFeedbackClosedStatus(status: FeedbackItem["status"]): boolean {
+  return status === "rejected" || status === "resolved";
+}
+
+export function shouldResolveReviewConversation(
+  item: Pick<FeedbackItem, "replyKind" | "status" | "threadResolved">,
+): boolean {
+  return item.replyKind === "review_thread" && !item.threadResolved && isFeedbackClosedStatus(item.status);
+}
+
+export function markReviewConversationResolved(item: FeedbackItem): FeedbackItem {
+  if (item.replyKind !== "review_thread" || item.threadResolved) {
+    return item;
+  }
+
+  return {
+    ...item,
+    threadResolved: true,
+  };
+}
+
 export function applyManualDecision(
   item: FeedbackItem,
   decision: "accept" | "reject" | "flag",

--- a/server/manualFeedback.test.ts
+++ b/server/manualFeedback.test.ts
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FeedbackItem } from "@shared/schema";
+import { MemStorage } from "./storage";
+import { GitHubIntegrationError } from "./github";
+import { applyManualFeedbackDecision } from "./manualFeedback";
+
+function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    id: "gh-review-comment-1",
+    author: "alice",
+    body: "Please fix this",
+    bodyHtml: "<p>Please fix this</p>",
+    replyKind: "review_thread",
+    sourceId: "1",
+    sourceNodeId: null,
+    sourceUrl: "https://github.com/octo/example/pull/42#discussion_r1",
+    threadId: "PRRT_kwDO_example",
+    threadResolved: false,
+    auditToken: "codefactory-feedback:gh-review-comment-1",
+    file: "server/example.ts",
+    line: 10,
+    type: "review_comment",
+    createdAt: "2026-04-01T10:00:00Z",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+    ...overrides,
+  };
+}
+
+async function addPRWithFeedback(storage: MemStorage, feedbackItems: FeedbackItem[]) {
+  return storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems,
+    accepted: feedbackItems.filter((item) => item.decision === "accept").length,
+    rejected: feedbackItems.filter((item) => item.decision === "reject").length,
+    flagged: feedbackItems.filter((item) => item.decision === "flag").length,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+}
+
+test("applyManualFeedbackDecision resolves GitHub review threads when feedback is rejected", async () => {
+  const storage = new MemStorage();
+  const item = makeFeedbackItem();
+  const pr = await addPRWithFeedback(storage, [item]);
+  const resolvedThreads: string[] = [];
+
+  const updated = await applyManualFeedbackDecision({
+    storage,
+    pr,
+    feedbackId: item.id,
+    decision: "reject",
+    github: {
+      buildOctokit: async () => ({}) as never,
+      resolveReviewThread: async (_octokit, parsed, threadId) => {
+        assert.deepEqual(parsed, { owner: "octo", repo: "example", number: 42 });
+        resolvedThreads.push(threadId);
+      },
+    },
+  });
+
+  const updatedItem = updated?.feedbackItems.find((candidate) => candidate.id === item.id);
+  assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
+  assert.equal(updatedItem?.decision, "reject");
+  assert.equal(updatedItem?.status, "rejected");
+  assert.equal(updatedItem?.threadResolved, true);
+  assert.equal(updated?.rejected, 1);
+});
+
+test("applyManualFeedbackDecision still rejects locally when the review thread ID is unavailable", async () => {
+  const storage = new MemStorage();
+  const item = makeFeedbackItem({ threadId: null, threadResolved: null });
+  const pr = await addPRWithFeedback(storage, [item]);
+  let buildCalled = false;
+  let resolveCalled = false;
+
+  const updated = await applyManualFeedbackDecision({
+    storage,
+    pr,
+    feedbackId: item.id,
+    decision: "reject",
+    github: {
+      buildOctokit: async () => {
+        buildCalled = true;
+        return {} as never;
+      },
+      resolveReviewThread: async () => {
+        resolveCalled = true;
+      },
+    },
+  });
+
+  const updatedItem = updated?.feedbackItems.find((candidate) => candidate.id === item.id);
+  assert.equal(buildCalled, false);
+  assert.equal(resolveCalled, false);
+  assert.equal(updatedItem?.status, "rejected");
+  assert.equal(updatedItem?.threadResolved, null);
+});
+
+test("applyManualFeedbackDecision does not persist thread resolution when GitHub resolution fails", async () => {
+  const storage = new MemStorage();
+  const item = makeFeedbackItem();
+  const pr = await addPRWithFeedback(storage, [item]);
+
+  await assert.rejects(
+    () => applyManualFeedbackDecision({
+      storage,
+      pr,
+      feedbackId: item.id,
+      decision: "reject",
+      github: {
+        buildOctokit: async () => ({}) as never,
+        resolveReviewThread: async () => {
+          throw new GitHubIntegrationError("GitHub review thread resolution failed", 502);
+        },
+      },
+    }),
+    /GitHub review thread resolution failed/,
+  );
+
+  const reloaded = await storage.getPR(pr.id);
+  const reloadedItem = reloaded?.feedbackItems.find((candidate) => candidate.id === item.id);
+  assert.equal(reloadedItem?.decision, null);
+  assert.equal(reloadedItem?.status, "pending");
+  assert.equal(reloadedItem?.threadResolved, false);
+  assert.equal(reloaded?.rejected, 0);
+});

--- a/server/manualFeedback.ts
+++ b/server/manualFeedback.ts
@@ -54,7 +54,7 @@ export async function applyManualFeedbackDecision(params: {
   );
 
   const updatedItem = feedbackItems.find((item) => item.id === feedbackId);
-  if (updatedItem && shouldResolveReviewConversation(updatedItem) && updatedItem.threadId) {
+  if (updatedItem?.threadId && shouldResolveReviewConversation(updatedItem)) {
     const parsedPr = parsePRUrl(pr.url);
     if (!parsedPr) {
       throw new GitHubIntegrationError(`Invalid PR URL: ${pr.url}`, 500);

--- a/server/manualFeedback.ts
+++ b/server/manualFeedback.ts
@@ -1,0 +1,79 @@
+import type { PR, TriageDecision, FeedbackItem } from "@shared/schema";
+import type { IStorage } from "./storage";
+import {
+  applyManualDecision,
+  markReviewConversationResolved,
+  shouldResolveReviewConversation,
+} from "./feedbackLifecycle";
+import {
+  buildOctokit,
+  GitHubIntegrationError,
+  parsePRUrl,
+  resolveReviewThread,
+} from "./github";
+
+export type ManualFeedbackGitHubService = {
+  buildOctokit: typeof buildOctokit;
+  resolveReviewThread: typeof resolveReviewThread;
+};
+
+const defaultGitHubService: ManualFeedbackGitHubService = {
+  buildOctokit,
+  resolveReviewThread,
+};
+
+function countDecisions(items: FeedbackItem[]): {
+  accepted: number;
+  rejected: number;
+  flagged: number;
+} {
+  return {
+    accepted: items.filter((item) => item.decision === "accept").length,
+    rejected: items.filter((item) => item.decision === "reject").length,
+    flagged: items.filter((item) => item.decision === "flag").length,
+  };
+}
+
+export async function applyManualFeedbackDecision(params: {
+  storage: IStorage;
+  pr: PR;
+  feedbackId: string;
+  decision: TriageDecision;
+  github?: ManualFeedbackGitHubService;
+}): Promise<PR | undefined> {
+  const {
+    storage,
+    pr,
+    feedbackId,
+    decision,
+    github = defaultGitHubService,
+  } = params;
+
+  let feedbackItems = pr.feedbackItems.map((item) =>
+    item.id === feedbackId ? applyManualDecision(item, decision) : item,
+  );
+
+  const updatedItem = feedbackItems.find((item) => item.id === feedbackId);
+  if (updatedItem && shouldResolveReviewConversation(updatedItem) && updatedItem.threadId) {
+    const parsedPr = parsePRUrl(pr.url);
+    if (!parsedPr) {
+      throw new GitHubIntegrationError(`Invalid PR URL: ${pr.url}`, 500);
+    }
+
+    const config = await storage.getConfig();
+    const octokit = await github.buildOctokit(config);
+    await github.resolveReviewThread(octokit, parsedPr, updatedItem.threadId);
+
+    feedbackItems = feedbackItems.map((item) =>
+      item.id === feedbackId ? markReviewConversationResolved(item) : item,
+    );
+  }
+
+  const counters = countDecisions(feedbackItems);
+  return storage.updatePR(pr.id, {
+    feedbackItems,
+    accepted: counters.accepted,
+    rejected: counters.rejected,
+    flagged: counters.flagged,
+  });
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,4 @@
-import type { Express } from "express";
+import type { Express, Response } from "express";
 import type { Server } from "http";
 import { z } from "zod";
 import { addPRSchema, askQuestionSchema, configSchema } from "@shared/schema";
@@ -24,6 +24,19 @@ import {
   parseRepoSlug,
   resolveNextSemverTag,
 } from "./github";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sendGitHubAwareError(res: Response, error: unknown): void {
+  if (error instanceof GitHubIntegrationError) {
+    res.status(error.statusCode).json({ error: error.message });
+    return;
+  }
+
+  res.status(500).json({ error: getErrorMessage(error) });
+}
 
 export async function registerRoutes(
   httpServer: Server,
@@ -306,13 +319,7 @@ export async function registerRoutes(
       if (err instanceof z.ZodError) {
         return res.status(400).json({ error: err.errors[0].message });
       }
-
-      if (err instanceof GitHubIntegrationError) {
-        return res.status(err.statusCode).json({ error: err.message });
-      }
-
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: message });
+      sendGitHubAwareError(res, err);
     }
   });
 
@@ -333,13 +340,10 @@ export async function registerRoutes(
       const updated = await babysitter.syncFeedbackForPR(pr.id);
       res.json(updated);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       await storage.updatePR(pr.id, { status: "error", lastChecked: new Date().toISOString() });
       await storage.addLog(pr.id, "error", `Fetch failed: ${message}`);
-      if (error instanceof GitHubIntegrationError) {
-        return res.status(error.statusCode).json({ error: message });
-      }
-      res.status(500).json({ error: message });
+      sendGitHubAwareError(res, error);
     }
   });
 
@@ -443,12 +447,7 @@ export async function registerRoutes(
       });
       res.json(updated);
     } catch (err: unknown) {
-      if (err instanceof GitHubIntegrationError) {
-        return res.status(err.statusCode).json({ error: err.message });
-      }
-
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: message });
+      sendGitHubAwareError(res, err);
     }
   });
 
@@ -541,11 +540,7 @@ export async function registerRoutes(
       if (err instanceof z.ZodError) {
         return res.status(400).json({ error: err.errors[0].message });
       }
-      if (err instanceof GitHubIntegrationError) {
-        return res.status(err.statusCode).json({ error: err.message });
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: message });
+      sendGitHubAwareError(res, err);
     }
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
 import { addPRSchema, askQuestionSchema, configSchema } from "@shared/schema";
 import { storage } from "./storage";
 import { PRBabysitter } from "./babysitter";
-import { applyEvaluationDecision, applyFlagDecision, applyManualDecision } from "./feedbackLifecycle";
+import { applyEvaluationDecision, applyFlagDecision } from "./feedbackLifecycle";
+import { applyManualFeedbackDecision } from "./manualFeedback";
 import { createWatcherScheduler } from "./watcherScheduler";
 import { answerPRQuestion } from "./prQuestionAgent";
 import { ReleaseManager } from "./releaseManager";
@@ -423,26 +424,32 @@ export async function registerRoutes(
   });
 
   app.patch("/api/prs/:id/feedback/:feedbackId", async (req, res) => {
-    const pr = await storage.getPR(req.params.id);
-    if (!pr) return res.status(404).json({ error: "PR not found" });
+    try {
+      const pr = await storage.getPR(req.params.id);
+      if (!pr) return res.status(404).json({ error: "PR not found" });
 
-    const { decision } = req.body;
-    if (!["accept", "reject", "flag"].includes(decision)) {
-      return res.status(400).json({ error: "Invalid decision" });
+      const { decision } = req.body;
+      if (!["accept", "reject", "flag"].includes(decision)) {
+        return res.status(400).json({ error: "Invalid decision" });
+      }
+
+      const manualDecision = decision as "accept" | "reject" | "flag";
+
+      const updated = await applyManualFeedbackDecision({
+        storage,
+        pr,
+        feedbackId: req.params.feedbackId,
+        decision: manualDecision,
+      });
+      res.json(updated);
+    } catch (err: unknown) {
+      if (err instanceof GitHubIntegrationError) {
+        return res.status(err.statusCode).json({ error: err.message });
+      }
+
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
     }
-
-    const feedbackItems = pr.feedbackItems.map((item) =>
-      item.id === req.params.feedbackId
-        ? applyManualDecision(item, decision as "accept" | "reject" | "flag")
-        : item,
-    );
-
-    const accepted = feedbackItems.filter((i) => i.decision === "accept").length;
-    const rejected = feedbackItems.filter((i) => i.decision === "reject").length;
-    const flagged = feedbackItems.filter((i) => i.decision === "flag").length;
-
-    const updated = await storage.updatePR(pr.id, { feedbackItems, accepted, rejected, flagged });
-    res.json(updated);
   });
 
   app.post("/api/prs/:id/feedback/:feedbackId/retry", async (req, res) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-04-01 - Treat local feedback closure states as GitHub conversation closure triggers
+- Pattern: I initially scoped PR conversation cleanup too narrowly and paused on whether manual rejection should resolve GitHub review threads immediately.
+- Rule: In oh-my-pr, any feedback item transition to a terminal closed state owned by the app (`rejected` or `resolved`) should immediately attempt to resolve the corresponding GitHub review thread when one exists.
+- Prevention checklist:
+  - When implementing feedback-state transitions, map each terminal local state to its required remote GitHub side effect before coding.
+  - Do not limit conversation cleanup to babysitter-authored follow-ups if the UI can also close items manually.
+  - Verify both manual and automated paths converge on the same review-thread resolution behavior.
+
 ## 2026-03-28 - Design product features around user repositories, not this repo's own workflow
 - Pattern: I framed a new PR-documentation feature as if it were about Code Factory's own repository and CI/docs pipeline, when the user intended a product capability that agents apply to any tracked repository.
 - Rule: When designing or implementing Code Factory behavior, default to repository-agnostic product semantics unless the user explicitly scopes the request to this repo's own operations.


### PR DESCRIPTION
## Summary
- resolve GitHub review threads immediately when manual feedback rejection closes an item in oh-my-pr
- share the review-conversation closure rule with the babysitter resolved path so both closed states converge on thread cleanup
- add regression coverage for closure detection, manual rejection resolution, and failure handling when GitHub resolution fails

## Testing
- node --import tsx --test server/feedbackLifecycle.test.ts server/manualFeedback.test.ts server/babysitter.test.ts
- npm run check