### PR TITLE
fix: repair GitHub review thread replies

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -398,6 +398,102 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
   assert.ok(logs.some((log) => log.message.includes("queued release evaluation")));
 });
 
+test("syncAndBabysitTrackedRepos repairs missing review-thread metadata on archived PRs", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Repair review-thread metadata",
+    repo: "octo/example",
+    branch: "feature/repair",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "archived",
+    feedbackItems: [
+      {
+        id: "gh-review-comment-1",
+        author: "reviewer",
+        body: "Please reply in thread",
+        bodyHtml: "<p>Please reply in thread</p>",
+        replyKind: "review_thread",
+        sourceId: "101",
+        sourceNodeId: null,
+        sourceUrl: "https://github.com/octo/example/pull/42#discussion_r101",
+        threadId: null,
+        threadResolved: null,
+        auditToken: "codefactory-feedback:gh-review-comment-1",
+        file: "server/github.ts",
+        line: 100,
+        type: "review_comment",
+        createdAt: "2026-04-02T10:00:00Z",
+        decision: null,
+        decisionReason: null,
+        action: null,
+        status: "pending",
+        statusReason: null,
+      },
+    ],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const babysitter = new PRBabysitter(storage, {
+    buildOctokit: async () => ({}) as never,
+    fetchFeedbackItemsForPR: async () => [
+      {
+        id: "gh-review-comment-1",
+        author: "reviewer",
+        body: "Please reply in thread",
+        bodyHtml: "<p>Please reply in thread</p>",
+        replyKind: "review_thread",
+        sourceId: "101",
+        sourceNodeId: null,
+        sourceUrl: "https://github.com/octo/example/pull/42#discussion_r101",
+        threadId: "THREAD_node_101",
+        threadResolved: false,
+        auditToken: "codefactory-feedback:gh-review-comment-1",
+        file: "server/github.ts",
+        line: 100,
+        type: "review_comment",
+        createdAt: "2026-04-02T10:00:00Z",
+        decision: null,
+        decisionReason: null,
+        action: null,
+        status: "pending",
+        statusReason: null,
+      },
+    ],
+    fetchPullSummary: async () => {
+      throw new Error("unused in this test");
+    },
+    listFailingStatuses: async () => [],
+    listOpenPullsForRepo: async () => [],
+    postFollowUpForFeedbackItem: async () => undefined,
+    postPRComment: async () => undefined,
+    resolveReviewThread: async () => undefined,
+    resolveGitHubAuthToken: async () => undefined,
+    addReactionToComment: async () => {},
+    postStatusReplyForFeedbackItem: async () => null,
+    updateStatusReply: async () => {},
+    checkCISettled: async () => true,
+    fetchCheckSnapshotsForRef: async () => [],
+  });
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const repaired = await storage.getArchivedPRs();
+  const repairedPr = repaired.find((candidate) => candidate.id === pr.id);
+  const repairedItem = repairedPr?.feedbackItems.find((candidate) => candidate.id === "gh-review-comment-1");
+
+  assert.equal(repairedItem?.threadId, "THREAD_node_101");
+  assert.equal(repairedItem?.threadResolved, false);
+  assert.equal(repairedPr?.status, "archived");
+});
+
 test("syncAndBabysitTrackedRepos skips automatic babysits when pr watch is paused", async () => {
   const storage = new MemStorage();
   const babysitCalls: string[] = [];

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -183,6 +183,12 @@ function mergeFeedbackItems(existing: FeedbackItem[], incoming: FeedbackItem[]):
   return { merged, newCount };
 }
 
+function hasMissingReviewThreadMetadata(pr: PR): boolean {
+  return pr.feedbackItems.some((item) =>
+    item.replyKind === "review_thread" && (item.threadId === null || item.threadResolved === null),
+  );
+}
+
 function formatFeedbackSyncLogMessage(total: number, newCount: number): string {
   const suffix = total === 1 ? "" : "s";
   return `GitHub sync complete: ${total} feedback item${suffix} (${newCount} new)`;
@@ -974,6 +980,23 @@ export class PRBabysitter {
     const runtimeState = await this.storage.getRuntimeState();
     if (runtimeState.drainMode) {
       return;
+    }
+
+    const repairCandidates = [
+      ...(await this.storage.getPRs()),
+      ...(await this.storage.getArchivedPRs()),
+    ].filter(hasMissingReviewThreadMetadata);
+
+    for (const pr of repairCandidates) {
+      try {
+        await this.syncFeedbackForPR(pr.id, {
+          phase: "repair",
+        });
+      } catch (error) {
+        await this.storage.addLog(pr.id, "warn", `Could not repair missing GitHub review-thread metadata: ${summarizeUnknownError(error)}`, {
+          phase: "repair",
+        });
+      }
     }
 
     const config = await this.storage.getConfig();

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -280,26 +280,24 @@ test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored"
         },
       ];
     },
-    request: async () => ({
-      data: {
-        repository: {
-          pullRequest: {
-            reviewThreads: {
-              nodes: [
-                {
-                  id: "THREAD_node_123",
-                  isResolved: false,
-                  comments: {
-                    nodes: [
-                      { databaseId: 1 },
-                    ],
-                  },
+    graphql: async () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: "THREAD_node_123",
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    { databaseId: 1 },
+                  ],
                 },
-              ],
-              pageInfo: {
-                hasNextPage: false,
-                endCursor: null,
               },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
             },
           },
         },
@@ -397,38 +395,36 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
 
       throw new Error("Unexpected paginate call");
     },
-    request: async (_route: string, params: { query: string; variables?: { threadId?: string; cursor?: string | null } }) => {
+    graphql: async (query: string, params: { threadId?: string; cursor?: string | null }) => {
       graphqlCalls.push({
-        query: params.query,
-        threadId: params.variables?.threadId,
-        cursor: params.variables?.cursor ?? null,
+        query,
+        threadId: params.threadId,
+        cursor: params.cursor ?? null,
       });
 
-      if (params.query.includes("CodeFactoryReviewThreads")) {
+      if (query.includes("CodeFactoryReviewThreads")) {
         return {
-          data: {
-            repository: {
-              pullRequest: {
-                reviewThreads: {
-                  nodes: [
-                    {
-                      id: "THREAD_node_999",
-                      isResolved: true,
-                      comments: {
-                        nodes: Array.from({ length: 100 }, (_unused, index) => ({
-                          databaseId: index + 1,
-                        })),
-                        pageInfo: {
-                          hasNextPage: true,
-                          endCursor: "cursor-100",
-                        },
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [
+                  {
+                    id: "THREAD_node_999",
+                    isResolved: true,
+                    comments: {
+                      nodes: Array.from({ length: 100 }, (_unused, index) => ({
+                        databaseId: index + 1,
+                      })),
+                      pageInfo: {
+                        hasNextPage: true,
+                        endCursor: "cursor-100",
                       },
                     },
-                  ],
-                  pageInfo: {
-                    hasNextPage: false,
-                    endCursor: null,
                   },
+                ],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
                 },
               },
             },
@@ -436,22 +432,20 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
         };
       }
 
-      assert.equal(params.variables?.threadId, "THREAD_node_999");
-      assert.equal(params.variables?.cursor, "cursor-100");
+      assert.equal(params.threadId, "THREAD_node_999");
+      assert.equal(params.cursor, "cursor-100");
 
       return {
-        data: {
-          node: {
-            id: "THREAD_node_999",
-            isResolved: true,
-            comments: {
-              nodes: [
-                { databaseId: 101 },
-              ],
-              pageInfo: {
-                hasNextPage: false,
-                endCursor: null,
-              },
+        node: {
+          id: "THREAD_node_999",
+          isResolved: true,
+          comments: {
+            nodes: [
+              { databaseId: 101 },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
             },
           },
         },
@@ -494,16 +488,12 @@ test("fetchFeedbackItemsForPR paginates review thread comments beyond the first 
 });
 
 test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThread resolves them", async () => {
-  const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
+  const requests: Array<{ query: string; params: Record<string, unknown> }> = [];
 
   const octokit = {
-    request: async (route: string, params: Record<string, unknown>) => {
-      requests.push({ route, params });
-      return {
-        data: {
-          ok: true,
-        },
-      };
+    graphql: async (query: string, params: Record<string, unknown>) => {
+      requests.push({ query, params });
+      return { ok: true };
     },
     issues: {
       createComment: async () => {
@@ -525,31 +515,23 @@ test("postFollowUpForFeedbackItem replies to review threads and resolveReviewThr
   );
 
   assert.equal(requests.length, 2);
-  assert.equal(requests[0]?.route, "POST /graphql");
-  assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  const vars0 = requests[0]?.params.variables as { threadId?: string; body?: string } | undefined;
-  assert.equal(vars0?.threadId, "THREAD_node_123");
+  assert.match(String(requests[0]?.query || ""), /addPullRequestReviewThreadReply/);
+  assert.equal(requests[0]?.params.threadId, "THREAD_node_123");
   assert.equal(
-    vars0?.body,
+    requests[0]?.params.body,
     "Addressed in the latest babysitter update.\n\ncodefactory-feedback:gh-review-comment-1",
   );
-  assert.equal(requests[1]?.route, "POST /graphql");
-  assert.match(String(requests[1]?.params.query || ""), /resolveReviewThread/);
-  const vars1 = requests[1]?.params.variables as { threadId?: string } | undefined;
-  assert.equal(vars1?.threadId, "THREAD_node_123");
+  assert.match(String(requests[1]?.query || ""), /resolveReviewThread/);
+  assert.equal(requests[1]?.params.threadId, "THREAD_node_123");
 });
 
 test("postFollowUpForFeedbackItem replies and resolves review thread in one call when resolve option is set", async () => {
-  const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
+  const requests: Array<{ query: string; params: Record<string, unknown> }> = [];
 
   const octokit = {
-    request: async (route: string, params: Record<string, unknown>) => {
-      requests.push({ route, params });
-      return {
-        data: {
-          ok: true,
-        },
-      };
+    graphql: async (query: string, params: Record<string, unknown>) => {
+      requests.push({ query, params });
+      return { ok: true };
     },
     issues: {
       createComment: async () => {
@@ -567,19 +549,18 @@ test("postFollowUpForFeedbackItem replies and resolves review thread in one call
   );
 
   assert.equal(requests.length, 2, "expected both a reply and a resolve request");
-  assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  assert.match(String(requests[1]?.params.query || ""), /resolveReviewThread/);
-  const vars1 = requests[1]?.params.variables as { threadId?: string } | undefined;
-  assert.equal(vars1?.threadId, "THREAD_node_123");
+  assert.match(String(requests[0]?.query || ""), /addPullRequestReviewThreadReply/);
+  assert.match(String(requests[1]?.query || ""), /resolveReviewThread/);
+  assert.equal(requests[1]?.params.threadId, "THREAD_node_123");
 });
 
 test("postFollowUpForFeedbackItem does not resolve when resolve option is false", async () => {
-  const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
+  const requests: Array<{ query: string; params: Record<string, unknown> }> = [];
 
   const octokit = {
-    request: async (route: string, params: Record<string, unknown>) => {
-      requests.push({ route, params });
-      return { data: { ok: true } };
+    graphql: async (query: string, params: Record<string, unknown>) => {
+      requests.push({ query, params });
+      return { ok: true };
     },
     issues: {
       createComment: async () => {
@@ -597,14 +578,14 @@ test("postFollowUpForFeedbackItem does not resolve when resolve option is false"
   );
 
   assert.equal(requests.length, 1, "expected only a reply, no resolve");
-  assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
+  assert.match(String(requests[0]?.query || ""), /addPullRequestReviewThreadReply/);
 });
 
 test("postFollowUpForFeedbackItem routes review and general comments to PR comments", async () => {
   const comments: Array<Record<string, unknown>> = [];
 
   const octokit = {
-    request: async () => {
+    graphql: async () => {
       throw new Error("unexpected graphql request");
     },
     issues: {
@@ -664,7 +645,7 @@ test("postFollowUpForFeedbackItem falls back to PR comment when review thread ID
   const comments: Array<Record<string, unknown>> = [];
 
   const octokit = {
-    request: async () => {
+    graphql: async () => {
       throw new Error("should not call graphql when falling back");
     },
     issues: {
@@ -703,7 +684,7 @@ test("postStatusReplyForFeedbackItem falls back to PR comment when review thread
   const issueCommentUpdates: Array<Record<string, unknown>> = [];
 
   const octokit = {
-    request: async () => {
+    graphql: async () => {
       throw new Error("should not call graphql when falling back");
     },
     pulls: {
@@ -770,18 +751,16 @@ test("postStatusReplyForFeedbackItem falls back to PR comment when review thread
 });
 
 test("postStatusReplyForFeedbackItem validates review-thread replies and updateStatusReply mutates the local ref", async () => {
-  const requests: Array<{ route: string; params: Record<string, unknown> }> = [];
+  const requests: Array<{ query: string; params: Record<string, unknown> }> = [];
   const updatedReviewComments: Array<Record<string, unknown>> = [];
 
   const octokit = {
-    request: async (route: string, params: Record<string, unknown>) => {
-      requests.push({ route, params });
+    graphql: async (query: string, params: Record<string, unknown>) => {
+      requests.push({ query, params });
       return {
-        data: {
-          addPullRequestReviewThreadReply: {
-            comment: {
-              databaseId: 456,
-            },
+        addPullRequestReviewThreadReply: {
+          comment: {
+            databaseId: 456,
           },
         },
       };
@@ -814,11 +793,9 @@ test("postStatusReplyForFeedbackItem validates review-thread replies and updateS
   );
 
   assert.equal(requests.length, 1);
-  assert.equal(requests[0]?.route, "POST /graphql");
-  assert.match(String(requests[0]?.params.query || ""), /addPullRequestReviewThreadReply/);
-  const statusVars = requests[0]?.params.variables as { threadId?: string; body?: string } | undefined;
-  assert.equal(statusVars?.threadId, "THREAD_node_123");
-  assert.equal(statusVars?.body, "Queued for processing");
+  assert.match(String(requests[0]?.query || ""), /addPullRequestReviewThreadReply/);
+  assert.equal(requests[0]?.params.threadId, "THREAD_node_123");
+  assert.equal(requests[0]?.params.body, "Queued for processing");
   assert.deepEqual(ref, {
     commentDatabaseId: 456,
     replyKind: "review_thread",
@@ -849,12 +826,10 @@ test("postStatusReplyForFeedbackItem validates review-thread replies and updateS
 
 test("postStatusReplyForFeedbackItem rejects malformed review-thread reply payloads", async () => {
   const octokit = {
-    request: async () => ({
-      data: {
-        addPullRequestReviewThreadReply: {
-          comment: {
-            databaseId: "not-a-number",
-          },
+    graphql: async () => ({
+      addPullRequestReviewThreadReply: {
+        comment: {
+          databaseId: "not-a-number",
         },
       },
     }),

--- a/server/github.ts
+++ b/server/github.ts
@@ -956,18 +956,14 @@ async function appendPaginatedReviewThreadComments(
 
   while (cursor) {
     const response = await withGitHubErrorHandling("review thread comments", parsed, () =>
-      octokit.request("POST /graphql", {
-        query: REVIEW_THREAD_COMMENTS_QUERY,
-        variables: {
-          threadId: thread.id,
-          cursor,
-        },
+      octokit.graphql<{
+        node?: ReviewThreadNode | null;
+      }>(REVIEW_THREAD_COMMENTS_QUERY, {
+        threadId: thread.id,
+        cursor,
       }),
     );
-
-    const paginatedThread = (response.data as {
-      node?: ReviewThreadNode | null;
-    }).node;
+    const paginatedThread = response.node;
 
     if (!paginatedThread?.id) {
       break;
@@ -1000,30 +996,27 @@ async function fetchReviewThreadLookup(
 
   while (true) {
     const response = await withGitHubErrorHandling("review threads", parsed, () =>
-      octokit.request("POST /graphql", {
-        query: REVIEW_THREADS_QUERY,
-        variables: {
-          owner: parsed.owner,
-          repo: parsed.repo,
-          number: parsed.number,
-          cursor,
-        },
-      }),
-    );
-
-    const reviewThreads = (response.data as {
-      repository?: {
-        pullRequest?: {
-          reviewThreads?: {
-            nodes?: ReviewThreadNode[];
-            pageInfo?: {
-              hasNextPage?: boolean | null;
-              endCursor?: string | null;
+      octokit.graphql<{
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: {
+              nodes?: ReviewThreadNode[];
+              pageInfo?: {
+                hasNextPage?: boolean | null;
+                endCursor?: string | null;
+              };
             };
           };
         };
-      };
-    }).repository?.pullRequest?.reviewThreads;
+      }>(REVIEW_THREADS_QUERY, {
+        owner: parsed.owner,
+        repo: parsed.repo,
+        number: parsed.number,
+        cursor,
+      }),
+    );
+
+    const reviewThreads = response.repository?.pullRequest?.reviewThreads;
 
     for (const thread of reviewThreads?.nodes || []) {
       if (!thread?.id) {
@@ -1052,12 +1045,9 @@ export async function replyToReviewThread(
   body: string,
 ): Promise<void> {
   await withGitHubErrorHandling("review thread reply", parsed, () =>
-    octokit.request("POST /graphql", {
-      query: REVIEW_THREAD_REPLY_MUTATION,
-      variables: {
-        threadId,
-        body,
-      },
+    octokit.graphql(REVIEW_THREAD_REPLY_MUTATION, {
+      threadId,
+      body,
     }),
   );
 }
@@ -1068,11 +1058,8 @@ export async function resolveReviewThread(
   threadId: string,
 ): Promise<void> {
   await withGitHubErrorHandling("review thread resolution", parsed, () =>
-    octokit.request("POST /graphql", {
-      query: RESOLVE_REVIEW_THREAD_MUTATION,
-      variables: {
-        threadId,
-      },
+    octokit.graphql(RESOLVE_REVIEW_THREAD_MUTATION, {
+      threadId,
     }),
   );
 }
@@ -1381,16 +1368,13 @@ export async function postStatusReplyForFeedbackItem(
     }
 
     const result = await withGitHubErrorHandling("status reply in review thread", parsed, () =>
-      octokit.request("POST /graphql", {
-        query: REVIEW_THREAD_REPLY_MUTATION,
-        variables: {
-          threadId: item.threadId,
-          body,
-        },
+      octokit.graphql(REVIEW_THREAD_REPLY_MUTATION, {
+        threadId: item.threadId,
+        body,
       }),
     );
 
-    const parsedResult = statusReplyMutationSchema.safeParse(result.data);
+    const parsedResult = statusReplyMutationSchema.safeParse(result);
     if (!parsedResult.success) {
       throw new GitHubIntegrationError(
         `GitHub returned an unexpected payload while creating a status reply for feedback item ${item.id} on ${formatGitHubTarget(parsed)}.`,


### PR DESCRIPTION
## Summary
- switch GitHub review-thread GraphQL calls to `octokit.graphql(...)` so thread metadata and reply payloads are parsed correctly
- add a repair pass that re-syncs stored PRs with missing review-thread metadata, including archived PRs
- update GitHub and babysitter tests to match Octokit's actual GraphQL response shape and cover the repair path

## Verification
- `node --test --import tsx server/github.test.ts server/babysitter.test.ts server/manualFeedback.test.ts`
- `npm run check`