### PR TITLE
fix: requeue expired leases during poll loop

### DIFF
--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -169,6 +169,67 @@ test("BackgroundJobDispatcher waitForIdle reflects active queue handlers", async
   }
 });
 
+test("BackgroundJobDispatcher reclaims expired leases during operation, not just at startup", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+
+  // Use a controllable clock so we can expire leases on demand.
+  let clockMs = Date.now();
+  const now = () => new Date(clockMs);
+
+  let handled = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 2_000, // 2-second lease
+    heartbeatIntervalMs: 0, // disable heartbeat for this test
+    now,
+    handlers: {
+      babysit_pr: async () => {
+        handled += 1;
+      },
+    },
+  });
+
+  try {
+    // Start dispatcher with no jobs — requeueExpired runs but finds nothing.
+    await dispatcher.start();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(handled, 0);
+
+    // Enqueue a job and immediately claim it as a "dead worker",
+    // simulating a handler whose heartbeat died.
+    const job = await queue.enqueue(
+      "babysit_pr", "pr-1", "babysit_pr:pr-1", { prId: "pr-1" },
+      { availableAt: now() },
+    );
+    const claimed = await queue.claimNext({
+      workerId: "dead-worker",
+      leaseMs: 2_000,
+      now: now(),
+    });
+    assert.ok(claimed);
+    assert.equal(claimed.status, "leased");
+
+    // Advance the clock past the lease expiry.
+    clockMs += 5_000;
+
+    // The job is now stuck in "leased" with an expired lease.
+    // Without the fix, the dispatcher's poll loop would never reclaim it.
+    // With the fix, pollOnce calls requeueExpired before claiming.
+    dispatcher.wake();
+    await waitForCondition(() => handled === 1, 500);
+    assert.equal(await dispatcher.waitForIdle(250), true);
+
+    const final = await storage.getBackgroundJob(job.id);
+    assert.equal(final?.status, "completed");
+  } finally {
+    dispatcher.stop();
+  }
+});
+
 test("BackgroundJobDispatcher cancels jobs when the handler raises a cancel error", async () => {
   const storage = new MemStorage();
   const queue = new BackgroundJobQueue(storage);

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -130,6 +130,8 @@ export class BackgroundJobDispatcher {
         return;
       }
 
+      await this.queue.requeueExpired(this.now());
+
       const job = await this.queue.claimNext({
         workerId: this.workerId,
         leaseMs: this.leaseMs,


### PR DESCRIPTION
## Summary

- **Bug**: `requeueExpired()` was only called once at dispatcher startup, so jobs whose leases expired while the dispatcher was already running stayed permanently stuck in `leased` status. This caused PR babysit jobs to wedge when a handler's heartbeat died mid-operation (e.g., during CI polling).
- **Fix**: Call `requeueExpired()` on every poll cycle in `pollOnce()` so stale leases are reclaimed promptly during normal operation.
- **Test**: Added a test with a controllable clock that simulates a dead worker's expired lease and verifies the dispatcher reclaims it without a restart.

## Test plan

- [x] All 298 existing tests pass
- [x] New test specifically covers the runtime lease reclamation scenario
- [ ] Deploy and verify stuck babysit_pr jobs recover within one poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)