### PR TITLE
[codex] Guard shared repo cache reclones

### DIFF
--- a/server/repoWorkspace.test.ts
+++ b/server/repoWorkspace.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp } from "fs/promises";
 import os from "os";
 import path from "path";
 import test from "node:test";
-import { preparePrWorktree } from "./repoWorkspace";
+import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 
 test("preparePrWorktree reuses the watched-repo cache and fetches fork heads on demand", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "codefactory-workspace-"));
@@ -128,4 +128,168 @@ test("preparePrWorktree reclones the cache when git health checks fail", async (
   assert.equal(cloneCount, 1);
   assert.equal(result.healed, true);
   assert.equal(result.remoteName, "origin");
+});
+
+test("ensureRepoCache treats tokenized and public GitHub clone URLs as the same remote", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "codefactory-workspace-auth-"));
+  let cloneCount = 0;
+
+  const result = await ensureRepoCache({
+    rootDir,
+    repoFullName: "acme/widgets",
+    repoCloneUrl: "https://x-access-token:ghs_123@github.com/acme/widgets.git",
+    runCommand: async (command, args) => {
+      if (command !== "git") {
+        return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+      }
+
+      if (args[0] === "-C" && args[2] === "rev-parse") {
+        return { code: 0, stdout: "true\n", stderr: "" };
+      }
+
+      if (args[0] === "-C" && args[2] === "config" && args[3] === "--get" && args[4] === "remote.origin.url") {
+        return { code: 0, stdout: "https://github.com/acme/widgets.git\n", stderr: "" };
+      }
+
+      if (args[0] === "-C" && args[2] === "status") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+
+      if (args[0] === "-C" && args[2] === "fetch") {
+        return { code: 0, stdout: "fetched\n", stderr: "" };
+      }
+
+      if (args[0] === "clone") {
+        cloneCount += 1;
+        return { code: 0, stdout: "cloned\n", stderr: "" };
+      }
+
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  });
+
+  assert.equal(result.healed, false);
+  assert.equal(cloneCount, 0);
+});
+
+test("ensureRepoCache refuses to reclone while an active worktree still depends on the shared cache", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "codefactory-workspace-active-"));
+  let cloned = false;
+  let cloneCount = 0;
+
+  const runCommand = async (command: string, args: string[]) => {
+    if (command !== "git") {
+      return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+    }
+
+    if (args[0] === "-C" && args[2] === "rev-parse") {
+      return cloned ? { code: 0, stdout: "true\n", stderr: "" } : { code: 1, stdout: "", stderr: "" };
+    }
+
+    if (args[0] === "clone") {
+      cloned = true;
+      cloneCount += 1;
+      await mkdir(args[2], { recursive: true });
+      return { code: 0, stdout: "cloned\n", stderr: "" };
+    }
+
+    if (args[0] === "-C" && args[2] === "config" && args[3] === "--get" && args[4] === "remote.origin.url") {
+      return { code: 0, stdout: "https://github.com/acme/widgets.git\n", stderr: "" };
+    }
+
+    if (args[0] === "-C" && args[2] === "status") {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+
+    if (args[0] === "-C" && args[2] === "fetch") {
+      return { code: 0, stdout: "fetched\n", stderr: "" };
+    }
+
+    if (args[0] === "-C" && args[2] === "worktree" && args[3] === "add") {
+      await mkdir(args[5], { recursive: true });
+      return { code: 0, stdout: "worktree added\n", stderr: "" };
+    }
+
+    if (args[0] === "-C" && args[2] === "worktree" && args[3] === "remove") {
+      return { code: 0, stdout: "worktree removed\n", stderr: "" };
+    }
+
+    return { code: 0, stdout: "", stderr: "" };
+  };
+
+  const worktree = await preparePrWorktree({
+    rootDir,
+    repoFullName: "acme/widgets",
+    repoCloneUrl: "https://github.com/acme/widgets.git",
+    headRepoFullName: "acme/widgets",
+    headRepoCloneUrl: "https://github.com/acme/widgets.git",
+    headRef: "feature-branch",
+    prNumber: 18,
+    runId: "run-2",
+    runCommand,
+  });
+
+  await assert.rejects(
+    () => ensureRepoCache({
+      rootDir,
+      repoFullName: "acme/widgets",
+      repoCloneUrl: "https://github.com/acme/widgets.git",
+      runCommand,
+      forceReclone: true,
+    }),
+    /active workspace/,
+  );
+  assert.equal(cloneCount, 1);
+
+  await removePrWorktree({
+    repoCacheDir: worktree.repoCacheDir,
+    worktreePath: worktree.worktreePath,
+    runCommand,
+  });
+
+  const healed = await ensureRepoCache({
+    rootDir,
+    repoFullName: "acme/widgets",
+    repoCloneUrl: "https://github.com/acme/widgets.git",
+    runCommand,
+    forceReclone: true,
+  });
+
+  assert.equal(healed.healed, true);
+  assert.equal(cloneCount, 2);
+});
+
+test("ensureRepoCache refuses to reclone when registered worktrees still exist on disk", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "codefactory-workspace-registered-"));
+  const repoCacheDir = path.join(rootDir, "repos", "acme__widgets");
+  await mkdir(path.join(repoCacheDir, ".git", "worktrees", "pr-18-run-2"), { recursive: true });
+  let cloneCount = 0;
+
+  await assert.rejects(
+    () => ensureRepoCache({
+      rootDir,
+      repoFullName: "acme/widgets",
+      repoCloneUrl: "https://github.com/acme/widgets.git",
+      forceReclone: true,
+      runCommand: async (command, args) => {
+        if (command !== "git") {
+          return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+        }
+
+        if (args[0] === "-C" && args[2] === "worktree" && args[3] === "prune") {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+
+        if (args[0] === "clone") {
+          cloneCount += 1;
+          return { code: 0, stdout: "cloned\n", stderr: "" };
+        }
+
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    }),
+    /registered worktree/,
+  );
+
+  assert.equal(cloneCount, 0);
 });

--- a/server/repoWorkspace.ts
+++ b/server/repoWorkspace.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from "fs/promises";
+import { mkdir, readdir, rm } from "fs/promises";
 import path from "path";
 import { type CommandResult, runCommand } from "./agentRunner";
 import { getCodeFactoryPaths } from "./paths";
@@ -31,8 +31,31 @@ type RemovePrWorktreeParams = {
   runCommand: GitRunner;
 };
 
+const repoMutationLocks = new Map<string, Promise<void>>();
+const activeRepoWorkspaceCounts = new Map<string, number>();
+
 function summarizeCommandFailure(result: CommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || "no output";
+}
+
+function normalizeRemoteUrl(remoteUrl: string): string {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    const pathname = parsed.pathname.replace(/\/+$/, "");
+    const port = parsed.port ? `:${parsed.port}` : "";
+    return `${parsed.protocol.toLowerCase()}//${parsed.hostname.toLowerCase()}${port}${pathname}`;
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+function sameRemoteUrl(left: string, right: string): boolean {
+  return normalizeRemoteUrl(left) === normalizeRemoteUrl(right);
 }
 
 async function ensureDirectory(dirPath: string): Promise<void> {
@@ -64,6 +87,77 @@ function getForkRemoteName(headRepoFullName: string): string {
   return `fork-${safeOwner}`;
 }
 
+async function withRepoMutationLock<T>(repoCacheDir: string, operation: () => Promise<T>): Promise<T> {
+  const previousLock = repoMutationLocks.get(repoCacheDir) ?? Promise.resolve();
+  let releaseCurrentLock: (() => void) | undefined;
+  const currentLock = new Promise<void>((resolve) => {
+    releaseCurrentLock = () => resolve();
+  });
+  const lockQueue = previousLock.then(() => currentLock);
+  repoMutationLocks.set(repoCacheDir, lockQueue);
+
+  await previousLock;
+  try {
+    return await operation();
+  } finally {
+    releaseCurrentLock?.();
+    if (repoMutationLocks.get(repoCacheDir) === lockQueue) {
+      repoMutationLocks.delete(repoCacheDir);
+    }
+  }
+}
+
+function adjustActiveRepoWorkspaceCount(repoCacheDir: string, delta: number): void {
+  const nextCount = Math.max(0, (activeRepoWorkspaceCounts.get(repoCacheDir) ?? 0) + delta);
+  if (nextCount === 0) {
+    activeRepoWorkspaceCounts.delete(repoCacheDir);
+    return;
+  }
+
+  activeRepoWorkspaceCounts.set(repoCacheDir, nextCount);
+}
+
+async function pruneRegisteredWorktrees(repoCacheDir: string, run: GitRunner): Promise<void> {
+  const pruneResult = await runGit(run, ["-C", repoCacheDir, "worktree", "prune"], 15000);
+  if (pruneResult.code !== 0) {
+    const revParseResult = await runGit(run, ["-C", repoCacheDir, "rev-parse", "--is-inside-work-tree"], 4000);
+    if (revParseResult.code === 0) {
+      throw new Error(`git worktree prune failed: ${summarizeCommandFailure(pruneResult)}`);
+    }
+  }
+}
+
+async function countRegisteredWorktrees(repoCacheDir: string): Promise<number> {
+  try {
+    const worktreeEntries = await readdir(path.join(repoCacheDir, ".git", "worktrees"), { withFileTypes: true });
+    return worktreeEntries.filter((entry) => entry.isDirectory()).length;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return 0;
+    }
+
+    throw error;
+  }
+}
+
+async function assertRepoCacheCanBeRecloned(repoCacheDir: string, run: GitRunner): Promise<void> {
+  const activeWorkspaceCount = activeRepoWorkspaceCounts.get(repoCacheDir) ?? 0;
+  if (activeWorkspaceCount > 0) {
+    throw new Error(
+      `Refusing to reclone repo cache while ${activeWorkspaceCount} active workspace(s) still depend on it`,
+    );
+  }
+
+  await pruneRegisteredWorktrees(repoCacheDir, run);
+
+  const registeredWorktreeCount = await countRegisteredWorktrees(repoCacheDir);
+  if (registeredWorktreeCount > 0) {
+    throw new Error(
+      `Refusing to reclone repo cache while ${registeredWorktreeCount} registered worktree(s) still exist`,
+    );
+  }
+}
+
 async function isRepoCacheHealthy(repoCacheDir: string, repoCloneUrl: string, run: GitRunner): Promise<boolean> {
   const repoCheck = await runGit(run, ["-C", repoCacheDir, "rev-parse", "--is-inside-work-tree"], 4000);
   if (repoCheck.code !== 0) {
@@ -71,7 +165,7 @@ async function isRepoCacheHealthy(repoCacheDir: string, repoCloneUrl: string, ru
   }
 
   const originUrl = await runGit(run, ["-C", repoCacheDir, "config", "--get", "remote.origin.url"], 4000);
-  if (originUrl.code !== 0 || originUrl.stdout.trim() !== repoCloneUrl) {
+  if (originUrl.code !== 0 || !sameRemoteUrl(originUrl.stdout, repoCloneUrl)) {
     return false;
   }
 
@@ -107,7 +201,7 @@ async function ensureRemote(repoCacheDir: string, remoteName: string, cloneUrl: 
     return;
   }
 
-  if (currentUrl.stdout.trim() !== cloneUrl) {
+  if (!sameRemoteUrl(currentUrl.stdout, cloneUrl)) {
     const setUrlResult = await runGit(run, ["-C", repoCacheDir, "remote", "set-url", remoteName, cloneUrl], 8000);
     if (setUrlResult.code !== 0) {
       throw new Error(`git remote set-url ${remoteName} failed: ${summarizeCommandFailure(setUrlResult)}`);
@@ -166,7 +260,7 @@ export function sanitizeRepoName(repoFullName: string): string {
   return repoFullName.replace(/[^a-zA-Z0-9_.-]+/g, "__");
 }
 
-export async function ensureRepoCache(params: EnsureRepoCacheParams): Promise<{
+async function ensureRepoCacheUnlocked(params: EnsureRepoCacheParams): Promise<{
   repoCacheDir: string;
   healed: boolean;
 }> {
@@ -178,12 +272,14 @@ export async function ensureRepoCache(params: EnsureRepoCacheParams): Promise<{
 
   let healed = forceReclone;
   if (forceReclone || !await isRepoCacheHealthy(repoCacheDir, repoCloneUrl, run)) {
+    await assertRepoCacheCanBeRecloned(repoCacheDir, run);
     await cloneRepoCache(repoCacheDir, repoCloneUrl, run);
     healed = true;
   }
 
   const fetchResult = await fetchOrigin(repoCacheDir, run);
   if (fetchResult.code !== 0) {
+    await assertRepoCacheCanBeRecloned(repoCacheDir, run);
     await cloneRepoCache(repoCacheDir, repoCloneUrl, run);
     healed = true;
 
@@ -194,6 +290,14 @@ export async function ensureRepoCache(params: EnsureRepoCacheParams): Promise<{
   }
 
   return { repoCacheDir, healed };
+}
+
+export async function ensureRepoCache(params: EnsureRepoCacheParams): Promise<{
+  repoCacheDir: string;
+  healed: boolean;
+}> {
+  const repoCacheDir = getRepoCacheDir(params.rootDir, params.repoFullName);
+  return withRepoMutationLock(repoCacheDir, async () => ensureRepoCacheUnlocked(params));
 }
 
 export async function preparePrWorktree(params: PreparePrWorktreeParams): Promise<{
@@ -215,47 +319,57 @@ export async function preparePrWorktree(params: PreparePrWorktreeParams): Promis
   } = params;
 
   const worktreePath = getWorktreePath(rootDir, repoFullName, prNumber, runId);
+  const repoCacheDir = getRepoCacheDir(rootDir, repoFullName);
 
-  let healed = false;
-  let lastError: Error | null = null;
+  return withRepoMutationLock(repoCacheDir, async () => {
+    let healed = false;
+    let lastError: Error | null = null;
 
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const cache = await ensureRepoCache({
-      rootDir,
-      repoFullName,
-      repoCloneUrl,
-      runCommand: run,
-      forceReclone: attempt > 0,
-    });
-    healed = healed || cache.healed;
-
-    try {
-      const remoteName = await fetchHeadRef({
-        repoCacheDir: cache.repoCacheDir,
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const cache = await ensureRepoCacheUnlocked({
+        rootDir,
         repoFullName,
-        headRepoFullName,
-        headRepoCloneUrl,
-        headRef,
+        repoCloneUrl,
         runCommand: run,
+        forceReclone: attempt > 0,
       });
+      healed = healed || cache.healed;
 
-      await addWorktree(cache.repoCacheDir, worktreePath, run);
-      return {
-        repoCacheDir: cache.repoCacheDir,
-        worktreePath,
-        healed,
-        remoteName,
-      };
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
+      try {
+        const remoteName = await fetchHeadRef({
+          repoCacheDir: cache.repoCacheDir,
+          repoFullName,
+          headRepoFullName,
+          headRepoCloneUrl,
+          headRef,
+          runCommand: run,
+        });
+
+        await addWorktree(cache.repoCacheDir, worktreePath, run);
+        adjustActiveRepoWorkspaceCount(cache.repoCacheDir, 1);
+        return {
+          repoCacheDir: cache.repoCacheDir,
+          worktreePath,
+          healed,
+          remoteName,
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
     }
-  }
 
-  throw lastError ?? new Error("Failed to prepare PR worktree");
+    throw lastError ?? new Error("Failed to prepare PR worktree");
+  });
 }
 
 export async function removePrWorktree(params: RemovePrWorktreeParams): Promise<void> {
   const { repoCacheDir, worktreePath, runCommand: run } = params;
-  await runGit(run, ["-C", repoCacheDir, "worktree", "remove", "--force", worktreePath], 30000);
-  await rm(worktreePath, { recursive: true, force: true });
+  await withRepoMutationLock(repoCacheDir, async () => {
+    try {
+      await runGit(run, ["-C", repoCacheDir, "worktree", "remove", "--force", worktreePath], 30000);
+      await rm(worktreePath, { recursive: true, force: true });
+    } finally {
+      adjustActiveRepoWorkspaceCount(repoCacheDir, -1);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- normalize equivalent GitHub clone URLs so tokenized and public remotes do not trigger unnecessary repo-cache healing
- serialize shared repo-cache mutations and refuse reclones while active or still-registered worktrees depend on the cache
- add regressions for auth-vs-public remote matching and shared-cache worktree protection

## Root Cause
The babysitter and healing paths could disagree about the expected `origin` URL for the same repository because some callers used tokenized clone URLs while others used the public GitHub clone URL. That exact-string mismatch caused healthy caches to be treated as unhealthy and recloned. Because repo caches are shared across PR worktrees, a reclone could delete the `.git/worktrees/...` admin directory for a still-running worktree, which then surfaced as `not a git repository` failures during later git commands.

## Impact
This makes shared repo caches stable across babysitter and healing flows and prevents a broken cache heal from invalidating live PR worktrees.

## Verification
- `node --test --import tsx server/repoWorkspace.test.ts`
- `npm run check`
- `node --test --import tsx server/*.test.ts`