### PR TITLE
feat(tui): impeccable.style polish pass for IDE-dense design

### DIFF
--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -10,6 +10,7 @@ import { PrListPane } from "./components/PrListPane";
 import { PrDetailPane } from "./components/PrDetailPane";
 import { ContextPane } from "./components/ContextPane";
 import { Footer } from "./components/Footer";
+import { color, glyph } from "./theme";
 
 type AppProps = {
   runtime: TuiRuntime;
@@ -324,10 +325,13 @@ export default function App(props: AppProps) {
 
   if (layoutMode === "compact-warning") {
     return (
-      <Box flexDirection="column" borderStyle="single" paddingX={1}>
-        <Text bold>oh-my-pr tui</Text>
-        <Text>Window too narrow for the terminal UI.</Text>
-        <Text dimColor>Resize to at least 110 columns.</Text>
+      <Box flexDirection="column" borderStyle="round" borderColor={color.warn} paddingX={1}>
+        <Text>
+          <Text color={color.accent} bold>{glyph.focus} </Text>
+          <Text bold>oh-my-pr</Text>
+        </Text>
+        <Text color={color.warn}>Window too narrow for the terminal UI.</Text>
+        <Text color={color.muted}>Resize to at least 110 columns.</Text>
       </Box>
     );
   }
@@ -343,7 +347,8 @@ export default function App(props: AppProps) {
         contextMode={selection.contextMode}
       />
       {snapshot.loading ? (
-        <Box borderStyle="single" paddingX={1}>
+        <Box borderStyle="round" borderColor={color.muted} paddingX={1}>
+          <Text color={color.info}>{glyph.running} </Text>
           <Text>Loading TUI…</Text>
         </Box>
       ) : (

--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -318,7 +318,7 @@ export default function App(props: AppProps) {
     }
 
     return {
-      list: undefined,
+      list: width,
       context: undefined,
     };
   }, [layoutMode]);

--- a/server/tui/components/AskPane.tsx
+++ b/server/tui/components/AskPane.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { PRQuestion } from "@shared/schema";
 import { wrapText } from "../viewModel";
+import { color, glyph } from "../theme";
 
 export function AskPane(props: {
   questions: PRQuestion[];
@@ -12,24 +13,48 @@ export function AskPane(props: {
   return (
     <Box flexDirection="column">
       {props.questions.length === 0 ? (
-        <Text dimColor>Press Enter to ask about the selected PR.</Text>
-      ) : props.questions.slice(-6).map((question) => (
-        <Box key={question.id} flexDirection="column" marginBottom={1}>
-          <Text color="cyan">Q: {question.question}</Text>
-          {question.status === "answered" && question.answer ? (
-            wrapText(question.answer, Math.max(20, props.width - 4)).map((line, index) => (
-              <Text key={`${question.id}-${index}`}>{line}</Text>
-            ))
-          ) : question.status === "error" ? (
-            <Text color="red">Error: {question.error ?? "Unknown error"}</Text>
-          ) : (
-            <Text dimColor>Agent is thinking...</Text>
-          )}
-        </Box>
-      ))}
-      <Text color={props.inputMode ? "green" : undefined}>
-        {props.inputMode ? `Ask: ${props.inputValue || "…"}` : "Enter to compose a question"}
-      </Text>
+        <Text color={color.muted}>Press Enter to ask about the selected PR.</Text>
+      ) : (
+        props.questions.slice(-6).map((question) => (
+          <Box key={question.id} flexDirection="column" marginBottom={1}>
+            <Box>
+              <Text color={color.accent} bold>Q </Text>
+              <Text>{question.question}</Text>
+            </Box>
+            {question.status === "answered" && question.answer ? (
+              wrapText(question.answer, Math.max(20, props.width - 4)).map((line, index) => (
+                <Box key={`${question.id}-${index}`}>
+                  {index === 0 && <Text color={color.ok} bold>A </Text>}
+                  {index !== 0 && <Text>  </Text>}
+                  <Text>{line}</Text>
+                </Box>
+              ))
+            ) : question.status === "error" ? (
+              <Box>
+                <Text color={color.err} bold>{glyph.cross} </Text>
+                <Text color={color.err}>{question.error ?? "Unknown error"}</Text>
+              </Box>
+            ) : (
+              <Box>
+                <Text color={color.info}>{glyph.running} </Text>
+                <Text color={color.muted}>Agent is thinking…</Text>
+              </Box>
+            )}
+          </Box>
+        ))
+      )}
+      <Box marginTop={1}>
+        {props.inputMode ? (
+          <>
+            <Text color={color.ok} bold>Ask</Text>
+            <Text color={color.muted}>{": "}</Text>
+            <Text>{props.inputValue || "…"}</Text>
+            <Text color={color.accent}>▌</Text>
+          </>
+        ) : (
+          <Text color={color.muted}>Press Enter to compose a question</Text>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/server/tui/components/ContextPane.tsx
+++ b/server/tui/components/ContextPane.tsx
@@ -6,8 +6,9 @@ import { LogPane } from "./LogPane";
 import { AskPane } from "./AskPane";
 import { RepoManagerPane } from "./RepoManagerPane";
 import { SettingsPane } from "./SettingsPane";
+import { color } from "../theme";
 
-export function ContextPane(props: {
+type ContextPaneProps = {
   mode: ContextMode;
   active: boolean;
   width?: number;
@@ -18,11 +19,57 @@ export function ContextPane(props: {
   selectedContextIndex: number;
   inputMode: InputMode;
   inputValue: string;
-}) {
+};
+
+const TABS: Array<{ key: ContextMode; label: string; hint: string }> = [
+  { key: "logs", label: "logs", hint: "l" },
+  { key: "ask", label: "ask", hint: "a" },
+  { key: "repos", label: "repos", hint: "o" },
+  { key: "settings", label: "settings", hint: "s" },
+];
+
+function TabStrip(props: { mode: ContextMode; active: boolean }) {
   return (
-    <Box flexDirection="column" borderStyle="single" paddingX={1} width={props.width}>
-      <Text bold color={props.active ? "cyan" : undefined}>Context</Text>
-      <Text dimColor>logs | ask | repos | settings</Text>
+    <Box>
+      {TABS.map((tab, index) => {
+        const isActive = tab.key === props.mode;
+        return (
+          <React.Fragment key={tab.key}>
+            {isActive ? (
+              <Text color={props.active ? color.accent : color.muted} inverse bold>
+                {` ${tab.label} `}
+              </Text>
+            ) : (
+              <Text color={color.muted}>
+                {` ${tab.label} `}
+                <Text dimColor>[{tab.hint}]</Text>
+              </Text>
+            )}
+            {index < TABS.length - 1 && <Text color={color.muted}> </Text>}
+          </React.Fragment>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function ContextPane(props: ContextPaneProps) {
+  const borderColor = props.active ? color.accent : color.muted;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle={props.active ? "round" : "single"}
+      borderColor={borderColor}
+      paddingX={1}
+      width={props.width}
+    >
+      <Box marginBottom={1} justifyContent="space-between">
+        <Text bold color={props.active ? color.accent : undefined}>
+          Context
+        </Text>
+      </Box>
+      <TabStrip mode={props.mode} active={props.active} />
       <Box marginTop={1} flexDirection="column">
         {props.mode === "logs" && <LogPane logs={props.logs} />}
         {props.mode === "ask" && (

--- a/server/tui/components/FeedbackActions.tsx
+++ b/server/tui/components/FeedbackActions.tsx
@@ -1,5 +1,14 @@
 import React from "react";
 import { Box, Text } from "ink";
+import { color } from "../theme";
+
+const TONE_FOR_ACTION: Record<string, string> = {
+  Accept: color.ok,
+  Reject: color.err,
+  Flag: color.warn,
+  Retry: color.info,
+  Collapse: color.muted,
+};
 
 export function FeedbackActions(props: {
   actions: string[];
@@ -7,13 +16,23 @@ export function FeedbackActions(props: {
 }) {
   return (
     <Box marginTop={1}>
-      {props.actions.map((action, index) => (
-        <Text key={action} color={index === props.selectedActionIndex ? "green" : undefined}>
-          {index === props.selectedActionIndex ? "[*] " : "[ ] "}
-          {action}
-          {index < props.actions.length - 1 ? "  " : ""}
-        </Text>
-      ))}
+      {props.actions.map((action, index) => {
+        const tone = TONE_FOR_ACTION[action] ?? color.accent;
+        const isSelected = index === props.selectedActionIndex;
+
+        return (
+          <React.Fragment key={action}>
+            {isSelected ? (
+              <Text inverse bold color={tone}>
+                {` ${action} `}
+              </Text>
+            ) : (
+              <Text color={tone}>{` ${action} `}</Text>
+            )}
+            {index < props.actions.length - 1 && <Text> </Text>}
+          </React.Fragment>
+        );
+      })}
     </Box>
   );
 }

--- a/server/tui/components/FeedbackList.tsx
+++ b/server/tui/components/FeedbackList.tsx
@@ -3,8 +3,9 @@ import { Box, Text } from "ink";
 import type { FeedbackItem } from "@shared/schema";
 import { getFeedbackActions, formatFeedbackStatusLabel, wrapText } from "../viewModel";
 import { FeedbackActions } from "./FeedbackActions";
+import { color, feedbackGlyph, feedbackTone, glyph } from "../theme";
 
-export function FeedbackList(props: {
+type FeedbackListProps = {
   items: FeedbackItem[];
   selectedFeedbackIndex: number;
   active: boolean;
@@ -12,9 +13,11 @@ export function FeedbackList(props: {
   selectedActionIndex: number;
   selectedActions: string[];
   width: number;
-}) {
+};
+
+export function FeedbackList(props: FeedbackListProps) {
   if (props.items.length === 0) {
-    return <Text dimColor>No feedback items yet.</Text>;
+    return <Text color={color.muted}>No feedback items yet.</Text>;
   }
 
   return (
@@ -23,21 +26,39 @@ export function FeedbackList(props: {
         const selected = index === props.selectedFeedbackIndex;
         const expanded = props.expandedFeedbackIds.has(item.id);
         const actions = selected && expanded ? props.selectedActions : getFeedbackActions(item);
-        const wrappedBody = wrapText(item.body, Math.max(20, props.width - 8));
+        const wrappedBody = wrapText(item.body, Math.max(20, props.width - 10));
+        const tone = feedbackTone(item.status);
+        const statusLabel = formatFeedbackStatusLabel(item.status);
+        const location = item.file ? `${item.file}${item.line ? `:${item.line}` : ""}` : "";
 
         return (
           <Box key={item.id} flexDirection="column" marginBottom={1}>
-            <Text color={selected ? "cyan" : undefined}>
-              {selected ? "› " : "  "}
-              [{formatFeedbackStatusLabel(item.status)}] {item.author} {item.file ? `· ${item.file}${item.line ? `:${item.line}` : ""}` : ""}
-            </Text>
+            <Box>
+              <Text color={selected ? color.accent : color.muted}>
+                {selected ? `${glyph.focus} ` : "  "}
+              </Text>
+              <Text color={tone}>{feedbackGlyph(item.status)}</Text>
+              <Text color={tone}>{` ${statusLabel}`}</Text>
+              <Text color={color.muted}>{`  ${item.author}`}</Text>
+              {location && (
+                <>
+                  <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
+                  <Text color={color.muted}>{location}</Text>
+                </>
+              )}
+            </Box>
             {expanded && (
-              <Box flexDirection="column" marginLeft={2}>
+              <Box flexDirection="column" marginLeft={4} marginTop={0}>
                 {wrappedBody.map((line, lineIndex) => (
-                  <Text key={`${item.id}-${lineIndex}`}>{line}</Text>
+                  <Text key={`${item.id}-${lineIndex}`} color={color.muted}>
+                    {line}
+                  </Text>
                 ))}
                 {selected && props.active && (
-                  <FeedbackActions actions={actions} selectedActionIndex={Math.min(props.selectedActionIndex, actions.length - 1)} />
+                  <FeedbackActions
+                    actions={actions}
+                    selectedActionIndex={Math.min(props.selectedActionIndex, actions.length - 1)}
+                  />
                 )}
               </Box>
             )}

--- a/server/tui/components/Footer.tsx
+++ b/server/tui/components/Footer.tsx
@@ -1,19 +1,44 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { formatFooterHints } from "../viewModel";
+import { getFooterHints } from "../viewModel";
 import type { ContextMode } from "../useSelectionState";
+import { color, glyph } from "../theme";
 
-export function Footer(props: {
+type FooterProps = {
   contextMode: ContextMode;
   statusMessage: string | null;
   errorMessage: string | null;
-}) {
+};
+
+export function Footer(props: FooterProps) {
+  const hasError = Boolean(props.errorMessage);
+  const statusTone = hasError ? color.err : props.statusMessage ? color.ok : color.muted;
+  const statusText = props.errorMessage ?? props.statusMessage ?? "Ready";
+  const hints = getFooterHints();
+
   return (
-    <Box justifyContent="space-between" borderStyle="single" paddingX={1}>
-      <Text color={props.errorMessage ? "red" : "green"}>
-        {props.errorMessage ?? props.statusMessage ?? "Ready"}
-      </Text>
-      <Text dimColor>{formatFooterHints(props.contextMode)}</Text>
+    <Box
+      justifyContent="space-between"
+      borderStyle="round"
+      borderColor={color.muted}
+      paddingX={1}
+    >
+      <Box>
+        <Text color={statusTone}>{glyph.dot}</Text>
+        <Text> </Text>
+        <Text color={statusTone} bold={hasError}>
+          {statusText}
+        </Text>
+      </Box>
+      <Box>
+        {hints.map((hint, index) => (
+          <React.Fragment key={hint.key}>
+            <Text color={color.accent} inverse bold>{` ${hint.key} `}</Text>
+            <Text color={color.muted}>{` ${hint.label}`}</Text>
+            {index < hints.length - 1 && <Text color={color.muted}>{"  "}</Text>}
+          </React.Fragment>
+        ))}
+      </Box>
     </Box>
   );
 }

--- a/server/tui/components/Header.tsx
+++ b/server/tui/components/Header.tsx
@@ -2,21 +2,59 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { Config } from "@shared/schema";
 import type { TuiRuntimeSnapshot } from "../types";
+import { color, glyph } from "../theme";
 
-export function Header(props: {
+type HeaderProps = {
   runtime: TuiRuntimeSnapshot | null;
   config: Config | null;
   repoCount: number;
   prCount: number;
   activePane: string;
   contextMode: string;
-}) {
+};
+
+function Sep() {
+  return <Text color={color.muted}>{` ${glyph.sep} `}</Text>;
+}
+
+function Chip(props: { glyph: string; label: string; value: number | string; tone: string }) {
   return (
-    <Box justifyContent="space-between" borderStyle="single" paddingX={1}>
-      <Text bold>oh-my-pr tui</Text>
-      <Text>
-        agent={props.config?.codingAgent ?? "claude"}  repos={props.repoCount}  prs={props.prCount}  activeRuns={props.runtime?.activeRuns ?? 0}  pane={props.activePane}  context={props.contextMode}
+    <Text>
+      <Text color={props.tone}>{props.glyph}</Text>
+      <Text> </Text>
+      <Text bold color={props.tone}>
+        {props.value}
       </Text>
+      <Text color={color.muted}>{" "}{props.label}</Text>
+    </Text>
+  );
+}
+
+export function Header(props: HeaderProps) {
+  const agent = props.config?.codingAgent ?? "claude";
+  const active = props.runtime?.activeRuns ?? 0;
+
+  return (
+    <Box justifyContent="space-between" borderStyle="round" borderColor={color.accent} paddingX={1}>
+      <Box>
+        <Text color={color.accent} bold>{glyph.focus} </Text>
+        <Text bold>oh-my-pr</Text>
+        <Text color={color.muted}>{` ${glyph.sep} `}</Text>
+        <Text color={color.muted}>agent </Text>
+        <Text color={color.accent}>{agent}</Text>
+      </Box>
+      <Box>
+        <Chip glyph={glyph.dot} label="repos" value={props.repoCount} tone={color.accent} />
+        <Sep />
+        <Chip glyph={glyph.dot} label="prs" value={props.prCount} tone={color.accent} />
+        <Sep />
+        <Chip
+          glyph={active > 0 ? glyph.running : glyph.ring}
+          label="active"
+          value={active}
+          tone={active > 0 ? color.info : color.muted}
+        />
+      </Box>
     </Box>
   );
 }

--- a/server/tui/components/LogPane.tsx
+++ b/server/tui/components/LogPane.tsx
@@ -1,21 +1,40 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { LogEntry } from "@shared/schema";
+import { color } from "../theme";
+
+const LEVEL_TONE: Record<string, string> = {
+  error: color.err,
+  warn: color.warn,
+  warning: color.warn,
+  info: color.accent,
+  debug: color.muted,
+};
+
+function formatTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
+}
 
 export function LogPane(props: { logs: LogEntry[] }) {
   const rows = props.logs.slice(-10);
 
   if (rows.length === 0) {
-    return <Text dimColor>No log entries.</Text>;
+    return <Text color={color.muted}>No log entries.</Text>;
   }
 
   return (
     <Box flexDirection="column">
-      {rows.map((log) => (
-        <Text key={log.id}>
-          {new Date(log.timestamp).toLocaleTimeString("en-US", { hour12: false })} [{log.level}] {log.phase ? `${log.phase} ` : ""}{log.message}
-        </Text>
-      ))}
+      {rows.map((log) => {
+        const tone = LEVEL_TONE[log.level] ?? color.muted;
+        return (
+          <Text key={log.id}>
+            <Text color={color.muted}>{formatTime(log.timestamp)} </Text>
+            <Text color={tone} bold>{log.level.toUpperCase()}</Text>
+            {log.phase && <Text color={color.muted}> {log.phase}</Text>}
+            <Text> {log.message}</Text>
+          </Text>
+        );
+      })}
     </Box>
   );
 }

--- a/server/tui/components/LogPane.tsx
+++ b/server/tui/components/LogPane.tsx
@@ -25,7 +25,7 @@ export function LogPane(props: { logs: LogEntry[] }) {
   return (
     <Box flexDirection="column">
       {rows.map((log) => {
-        const tone = LEVEL_TONE[log.level] ?? color.muted;
+        const tone = LEVEL_TONE[log.level.toLowerCase()] ?? color.muted;
         return (
           <Text key={log.id}>
             <Text color={color.muted}>{formatTime(log.timestamp)} </Text>

--- a/server/tui/components/PrDetailPane.tsx
+++ b/server/tui/components/PrDetailPane.tsx
@@ -3,8 +3,9 @@ import { Box, Text } from "ink";
 import type { PR } from "@shared/schema";
 import { FeedbackList } from "./FeedbackList";
 import { formatStatusLabel } from "../viewModel";
+import { color, glyph, prStatusGlyph, prStatusTone } from "../theme";
 
-export function PrDetailPane(props: {
+type PrDetailPaneProps = {
   pr: PR | null;
   selectedFeedbackIndex: number;
   active: boolean;
@@ -12,19 +13,53 @@ export function PrDetailPane(props: {
   selectedActionIndex: number;
   selectedActions: string[];
   width?: number;
-}) {
+};
+
+export function PrDetailPane(props: PrDetailPaneProps) {
+  const borderColor = props.active ? color.accent : color.muted;
+
   return (
-    <Box flexDirection="column" borderStyle="single" paddingX={1} width={props.width} flexGrow={1}>
-      <Text bold color={props.active ? "cyan" : undefined}>PR Detail</Text>
+    <Box
+      flexDirection="column"
+      borderStyle={props.active ? "round" : "single"}
+      borderColor={borderColor}
+      paddingX={1}
+      width={props.width}
+      flexGrow={1}
+    >
+      <Box marginBottom={1}>
+        <Text bold color={props.active ? color.accent : undefined}>
+          PR Detail
+        </Text>
+      </Box>
       {!props.pr ? (
-        <Text dimColor>Select a PR.</Text>
+        <Text color={color.muted}>Select a PR.</Text>
       ) : (
         <>
-          <Text>{props.pr.repo} #{props.pr.number}</Text>
-          <Text bold>{props.pr.title}</Text>
-          <Text dimColor>
-            status={formatStatusLabel(props.pr.status)}  watch={props.pr.watchEnabled ? "on" : "paused"}  feedback={props.pr.feedbackItems.length}
-          </Text>
+          <Box>
+            <Text color={color.muted}>{props.pr.repo}</Text>
+            <Text color={color.muted}>{"  "}</Text>
+            <Text bold color={color.accent}>#{props.pr.number}</Text>
+          </Box>
+          <Box>
+            <Text bold>{props.pr.title}</Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text color={prStatusTone(props.pr.status)}>
+              {prStatusGlyph(props.pr.status)}
+              {" "}
+              {formatStatusLabel(props.pr.status)}
+            </Text>
+            <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
+            <Text color={props.pr.watchEnabled ? color.ok : color.warn}>
+              {props.pr.watchEnabled ? glyph.dot : glyph.pause}
+              {" "}
+              {props.pr.watchEnabled ? "watching" : "paused"}
+            </Text>
+            <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
+            <Text color={color.muted}>feedback </Text>
+            <Text bold>{props.pr.feedbackItems.length}</Text>
+          </Box>
           <Box marginTop={1}>
             <FeedbackList
               items={props.pr.feedbackItems}

--- a/server/tui/components/PrListPane.tsx
+++ b/server/tui/components/PrListPane.tsx
@@ -1,29 +1,109 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { PR } from "@shared/schema";
-import { formatPrRow } from "../viewModel";
+import { color, glyph, prStatusGlyph, prStatusTone } from "../theme";
+import { countActiveFeedbackStatuses, isPRReadyToMerge } from "../viewModel";
 
-export function PrListPane(props: {
+type PrListPaneProps = {
   prs: PR[];
   selectedPrIndex: number;
   active: boolean;
   width?: number;
-}) {
-  return (
-    <Box flexDirection="column" borderStyle="single" paddingX={1} width={props.width}>
-      <Text bold color={props.active ? "cyan" : undefined}>Pull Requests</Text>
-      {props.prs.length === 0 ? (
-        <Text dimColor>No tracked PRs.</Text>
-      ) : props.prs.map((pr, index) => {
-        const selected = index === props.selectedPrIndex;
+};
 
-        return (
-          <Text key={pr.id} color={selected ? "cyan" : undefined}>
-            {selected ? "› " : "  "}
-            {formatPrRow(pr)}
-          </Text>
-        );
-      })}
+function truncate(input: string, max: number): string {
+  if (max <= 1) return input.slice(0, max);
+  if (input.length <= max) return input;
+  return `${input.slice(0, Math.max(1, max - 1))}…`;
+}
+
+function padNumber(n: number, width: number): string {
+  const str = `#${n}`;
+  return str.length >= width ? str : `${" ".repeat(width - str.length)}${str}`;
+}
+
+type Badge = { label: string; tone: string };
+
+function getBadges(pr: PR): Badge[] {
+  const badges: Badge[] = [];
+  const counts = countActiveFeedbackStatuses(pr.feedbackItems);
+
+  if (counts.failed > 0) badges.push({ label: `${counts.failed}!`, tone: color.err });
+  if (counts.warning > 0) badges.push({ label: `${counts.warning}⚠`, tone: color.warn });
+  if (counts.inProgress > 0) badges.push({ label: `${counts.inProgress}◐`, tone: color.info });
+  if (counts.queued > 0) badges.push({ label: `${counts.queued}○`, tone: color.accent });
+  if (!pr.watchEnabled) badges.push({ label: "paused", tone: color.muted });
+  if (isPRReadyToMerge(pr.feedbackItems) && pr.status !== "processing") {
+    badges.push({ label: "ready", tone: color.ok });
+  }
+  return badges;
+}
+
+function PrRow(props: { pr: PR; selected: boolean; width: number }) {
+  const { pr, selected, width } = props;
+  const tone = prStatusTone(pr.status);
+  const badges = getBadges(pr);
+  const numCol = padNumber(pr.number, 5);
+  const badgesText = badges.map((b) => b.label).join(" ");
+  const reserved = 2 + 1 + numCol.length + 1 + badgesText.length + 1 + 2;
+  const titleSpace = Math.max(8, width - reserved);
+  const title = truncate(pr.title, titleSpace);
+
+  return (
+    <Box>
+      <Text color={selected ? color.accent : color.muted}>
+        {selected ? `${glyph.focus} ` : "  "}
+      </Text>
+      <Text color={tone}>{prStatusGlyph(pr.status)}</Text>
+      <Text color={color.muted}>{` ${numCol} `}</Text>
+      <Text bold={selected} color={selected ? color.accent : undefined}>
+        {title}
+      </Text>
+      {badges.length > 0 && (
+        <>
+          <Text>{" "}</Text>
+          {badges.map((b, i) => (
+            <Text key={i} color={b.tone}>
+              {b.label}
+              {i < badges.length - 1 ? " " : ""}
+            </Text>
+          ))}
+        </>
+      )}
+    </Box>
+  );
+}
+
+export function PrListPane(props: PrListPaneProps) {
+  const borderColor = props.active ? color.accent : color.muted;
+  const innerWidth = (props.width ?? 40) - 4;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle={props.active ? "round" : "single"}
+      borderColor={borderColor}
+      paddingX={1}
+      width={props.width}
+    >
+      <Box marginBottom={1}>
+        <Text bold color={props.active ? color.accent : undefined}>
+          Pull Requests
+        </Text>
+        <Text color={color.muted}>{`  ${props.prs.length}`}</Text>
+      </Box>
+      {props.prs.length === 0 ? (
+        <Text color={color.muted}>No tracked PRs.</Text>
+      ) : (
+        props.prs.map((pr, index) => (
+          <PrRow
+            key={pr.id}
+            pr={pr}
+            selected={index === props.selectedPrIndex}
+            width={innerWidth}
+          />
+        ))
+      )}
     </Box>
   );
 }

--- a/server/tui/components/RepoManagerPane.tsx
+++ b/server/tui/components/RepoManagerPane.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { InputMode } from "../useSelectionState";
+import { color, glyph } from "../theme";
 
 const ACTIONS = ["Sync repositories", "Add repository", "Add PR URL"] as const;
 
@@ -12,24 +13,41 @@ export function RepoManagerPane(props: {
 }) {
   return (
     <Box flexDirection="column">
-      {ACTIONS.map((action, index) => (
-        <Text key={action} color={index === props.selectedActionIndex ? "cyan" : undefined}>
-          {index === props.selectedActionIndex ? "› " : "  "}
-          {action}
-        </Text>
-      ))}
+      {ACTIONS.map((action, index) => {
+        const selected = index === props.selectedActionIndex;
+        return (
+          <Box key={action}>
+            <Text color={selected ? color.accent : color.muted}>
+              {selected ? `${glyph.focus} ` : "  "}
+            </Text>
+            <Text color={selected ? color.accent : undefined} bold={selected}>
+              {action}
+            </Text>
+          </Box>
+        );
+      })}
       <Box flexDirection="column" marginTop={1}>
-        <Text dimColor>Tracked repositories</Text>
+        <Text color={color.muted}>Tracked repositories</Text>
         {props.repos.length === 0 ? (
-          <Text dimColor>None yet.</Text>
-        ) : props.repos.map((repo) => (
-          <Text key={repo}>{repo}</Text>
-        ))}
+          <Text color={color.muted}>  None yet.</Text>
+        ) : (
+          props.repos.map((repo) => (
+            <Box key={repo}>
+              <Text color={color.muted}>  {glyph.dot} </Text>
+              <Text>{repo}</Text>
+            </Box>
+          ))
+        )}
       </Box>
       {props.inputMode !== "none" && (
-        <Text color="green">
-          {props.inputMode === "addRepo" ? "Repo" : "PR URL"}: {props.inputValue || "…"}
-        </Text>
+        <Box marginTop={1}>
+          <Text color={color.ok} bold>
+            {props.inputMode === "addRepo" ? "Repo" : "PR URL"}
+          </Text>
+          <Text color={color.muted}>{": "}</Text>
+          <Text>{props.inputValue || "…"}</Text>
+          <Text color={color.accent}>▌</Text>
+        </Box>
       )}
     </Box>
   );

--- a/server/tui/components/SettingsPane.tsx
+++ b/server/tui/components/SettingsPane.tsx
@@ -1,26 +1,51 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { Config } from "@shared/schema";
+import { color, glyph } from "../theme";
+
+type SettingRow = { label: string; value: boolean | string };
 
 export function SettingsPane(props: {
   config: Config | null;
   selectedIndex: number;
 }) {
-  const rows = [
-    `Coding agent: ${props.config?.codingAgent ?? "claude"}`,
-    `Auto-resolve conflicts: ${props.config?.autoResolveMergeConflicts ? "on" : "off"}`,
-    `Auto-update docs: ${props.config?.autoUpdateDocs ? "on" : "off"}`,
+  const rows: SettingRow[] = [
+    { label: "Coding agent", value: props.config?.codingAgent ?? "claude" },
+    { label: "Auto-resolve conflicts", value: Boolean(props.config?.autoResolveMergeConflicts) },
+    { label: "Auto-update docs", value: Boolean(props.config?.autoUpdateDocs) },
   ];
 
   return (
     <Box flexDirection="column">
-      {rows.map((row, index) => (
-        <Text key={row} color={index === props.selectedIndex ? "cyan" : undefined}>
-          {index === props.selectedIndex ? "› " : "  "}
-          {row}
-        </Text>
-      ))}
-      <Text dimColor>Enter toggles the selected setting.</Text>
+      {rows.map((row, index) => {
+        const selected = index === props.selectedIndex;
+        const isToggle = typeof row.value === "boolean";
+        const toneForValue = isToggle
+          ? row.value ? color.ok : color.muted
+          : color.accent;
+
+        return (
+          <Box key={row.label}>
+            <Text color={selected ? color.accent : color.muted}>
+              {selected ? `${glyph.focus} ` : "  "}
+            </Text>
+            <Text color={selected ? color.accent : undefined}>{row.label}</Text>
+            <Text color={color.muted}>{"  "}</Text>
+            {isToggle ? (
+              <Text color={toneForValue} bold>
+                {row.value ? `${glyph.dot} on` : `${glyph.ring} off`}
+              </Text>
+            ) : (
+              <Text color={toneForValue} bold>
+                {String(row.value)}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
+      <Box marginTop={1}>
+        <Text color={color.muted}>Enter toggles the selected setting.</Text>
+      </Box>
     </Box>
   );
 }

--- a/server/tui/theme.ts
+++ b/server/tui/theme.ts
@@ -1,0 +1,64 @@
+import type { FeedbackStatus, PR } from "@shared/schema";
+
+export const color = {
+  accent: "cyan",
+  ok: "green",
+  warn: "yellow",
+  err: "red",
+  info: "magenta",
+  muted: "gray",
+} as const;
+
+export type ThemeColor = (typeof color)[keyof typeof color];
+
+export const glyph = {
+  focus: "❯",
+  bullet: "•",
+  dot: "●",
+  ring: "○",
+  running: "◐",
+  check: "✓",
+  cross: "✗",
+  warn: "!",
+  pause: "⏸",
+  caret: "›",
+  sep: "│",
+  collapsed: "▸",
+  expanded: "▾",
+} as const;
+
+export function prStatusTone(status: PR["status"]): ThemeColor {
+  if (status === "processing") return color.info;
+  if (status === "done") return color.ok;
+  if (status === "error") return color.err;
+  if (status === "archived") return color.muted;
+  return color.accent;
+}
+
+export function prStatusGlyph(status: PR["status"]): string {
+  if (status === "processing") return glyph.running;
+  if (status === "done") return glyph.check;
+  if (status === "error") return glyph.cross;
+  if (status === "archived") return glyph.ring;
+  return glyph.dot;
+}
+
+export function feedbackTone(status: FeedbackStatus): ThemeColor {
+  if (status === "resolved") return color.ok;
+  if (status === "rejected") return color.muted;
+  if (status === "failed") return color.err;
+  if (status === "warning") return color.warn;
+  if (status === "in_progress") return color.info;
+  if (status === "queued") return color.accent;
+  return color.muted;
+}
+
+export function feedbackGlyph(status: FeedbackStatus): string {
+  if (status === "resolved") return glyph.check;
+  if (status === "rejected") return glyph.cross;
+  if (status === "failed") return glyph.cross;
+  if (status === "warning") return glyph.warn;
+  if (status === "in_progress") return glyph.running;
+  if (status === "queued") return glyph.ring;
+  return glyph.bullet;
+}

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -154,3 +154,20 @@ export function wrapText(input: string, width: number): string[] {
 export function formatFooterHints(contextMode: "logs" | "ask" | "repos" | "settings"): string {
   return `Tab pane • arrows move • Enter select • r run • w watch • l logs • a ask • o repos • s settings • q quit • pane=${contextMode}`;
 }
+
+export type FooterHint = { key: string; label: string };
+
+export function getFooterHints(): FooterHint[] {
+  return [
+    { key: "Tab", label: "pane" },
+    { key: "↑↓", label: "move" },
+    { key: "⏎", label: "select" },
+    { key: "r", label: "run" },
+    { key: "w", label: "watch" },
+    { key: "l", label: "logs" },
+    { key: "a", label: "ask" },
+    { key: "o", label: "repos" },
+    { key: "s", label: "settings" },
+    { key: "q", label: "quit" },
+  ];
+}


### PR DESCRIPTION
## Summary
- Introduces `server/tui/theme.ts` with semantic color/glyph tokens (`accent`, `ok`, `warn`, `err`, `info`, `muted`) and helpers like `prStatusTone` / `feedbackTone` so visual decisions live in one place.
- Restyles every TUI component (Header, Footer, PrListPane, PrDetailPane, ContextPane, FeedbackList, FeedbackActions, LogPane, SettingsPane, RepoManagerPane, AskPane, App) to use the theme. Active panes get round accent borders, inactive panes stay muted `single` — focus is now obvious at a glance.
- Information-dense IDE look: PR rows use ❯ focus marker + status glyph + padded #num + truncated title + colored badges; feedback items get a severity gutter; context pane gains a real tab strip with inline [key] hints; footer shortcuts render as inverse pills.

## Test plan
- [x] `npm test` — 317/317 pass
- [x] `npx eslint server/tui/` — clean
- [x] Offline visual render against a fake runtime (header, three panes, footer all render correctly at 160 cols)
- [ ] Manual smoke test: `npm run build && ./bin/codefactory.cjs` in a real terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)