### PR TITLE
feat: improve onboarding checklist

### DIFF
--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -1,33 +1,135 @@
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useState, type ReactNode } from "react";
+import { Link } from "wouter";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import type { Config } from "@shared/schema";
+import { queryClient, apiRequest } from "@/lib/queryClient";
+import { toast } from "@/hooks/use-toast";
+
+const ONBOARDING_DISMISS_KEY = "onboarding-panel-dismissed-v2";
+const REVIEW_TOOL_LABELS = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+} as const;
+const REVIEW_PROVIDER_GUIDES = [
+  {
+    label: "Gemini Code Assist",
+    href: "https://github.com/apps/gemini-code-assist",
+  },
+  {
+    label: "OpenAI Codex",
+    href: "https://developers.openai.com/codex/integrations/github",
+  },
+  {
+    label: "Claude Code",
+    href: "https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code",
+  },
+  {
+    label: "Cursor",
+    href: "https://cursor.com/docs/integrations/github",
+  },
+] as const;
 
 type OnboardingStatus = {
   githubConnected: boolean;
   githubError?: string;
+  githubUser?: string;
   repos: RepoOnboardingStatus[];
+};
+
+type CodeReviewPresence = {
+  claude: boolean;
+  codex: boolean;
+  gemini: boolean;
 };
 
 type RepoOnboardingStatus = {
   repo: string;
   accessible: boolean;
   error?: string;
+  codeReviews: CodeReviewPresence;
 };
+
+type InstallReviewTool = "claude" | "codex";
+type ReviewTool = keyof CodeReviewPresence;
+type OnboardingStepId = "github" | "repo" | "workflow";
+
+type OnboardingStep = {
+  id: OnboardingStepId;
+  title: string;
+  description: string;
+  complete: boolean;
+};
+
+function hasDetectedCodeReviewWorkflow(codeReviews: CodeReviewPresence) {
+  return codeReviews.claude || codeReviews.codex || codeReviews.gemini;
+}
+
+function getDetectedReviewTools(codeReviews: CodeReviewPresence): ReviewTool[] {
+  return (Object.entries(codeReviews) as Array<[ReviewTool, boolean]>)
+    .filter(([, present]) => present)
+    .map(([tool]) => tool);
+}
 
 export function getOnboardingPanelState(status: OnboardingStatus) {
-  const inaccessibleRepos = status.githubConnected
-    ? status.repos.filter((repo) => !repo.accessible)
-    : [];
-  const hasIssues = !status.githubConnected || inaccessibleRepos.length > 0;
-  const summary = !status.githubConnected
-    ? "GitHub not connected"
-    : `${inaccessibleRepos.length} inaccessible repo${inaccessibleRepos.length === 1 ? "" : "s"}`;
+  const accessibleRepos = status.repos.filter((repo) => repo.accessible);
+  const inaccessibleRepos = status.repos.filter((repo) => !repo.accessible);
+  const reposWithReview = accessibleRepos.filter((repo) => hasDetectedCodeReviewWorkflow(repo.codeReviews));
+  const reposMissingReview = accessibleRepos.filter((repo) => !hasDetectedCodeReviewWorkflow(repo.codeReviews));
+
+  const steps: OnboardingStep[] = [
+    {
+      id: "github",
+      title: "Connect GitHub",
+      description: status.githubConnected
+        ? `Connected${status.githubUser ? ` as @${status.githubUser}` : ""}.`
+        : "Connect GitHub so the app can read repositories, sync feedback, and install review workflows.",
+      complete: status.githubConnected,
+    },
+    {
+      id: "repo",
+      title: "Track your first repository or PR",
+      description: accessibleRepos.length > 0
+        ? `Watching ${accessibleRepos.length} accessible repo${accessibleRepos.length === 1 ? "" : "s"}.`
+        : "Use the Add PR or Watch form below. Adding a PR also adds its repository to the watch list.",
+      complete: accessibleRepos.length > 0,
+    },
+    {
+      id: "workflow",
+      title: "Enable first-pass AI review",
+      description: reposWithReview.length > 0
+        ? `Detected an AI review workflow in ${reposWithReview.length} repo${reposWithReview.length === 1 ? "" : "s"}.`
+        : accessibleRepos.length > 0
+          ? "Install a Claude or Codex review workflow on any tracked repository to seed actionable review comments automatically."
+          : "Track an accessible repository first, then install a review workflow.",
+      complete: reposWithReview.length > 0,
+    },
+  ];
+
+  const completedCount = steps.filter((step) => step.complete).length;
+  const pendingSteps = steps.filter((step) => !step.complete);
+  const dismissalKey = [
+    ...pendingSteps.map((step) => step.id),
+    ...inaccessibleRepos.map((repo) => `access:${repo.repo}:${repo.error ?? ""}`),
+  ].join("|") || "complete";
+  const hasIssues = pendingSteps.length > 0 || inaccessibleRepos.length > 0;
+  const summary = pendingSteps.length > 0
+    ? `${completedCount} of ${steps.length} complete`
+    : `${inaccessibleRepos.length} access issue${inaccessibleRepos.length === 1 ? "" : "s"}`;
 
   return {
+    accessibleRepos,
     hasIssues,
     inaccessibleRepos,
+    reposMissingReview,
+    reposWithReview,
+    steps,
+    pendingSteps,
+    completedCount,
+    dismissalKey,
     summary,
   };
-};
+}
 
 function InlineCode({ children }: { children: string }) {
   return (
@@ -37,7 +139,7 @@ function InlineCode({ children }: { children: string }) {
   );
 }
 
-function Step({ number, children }: { number: number; children: React.ReactNode }) {
+function Step({ number, children }: { number: number; children: ReactNode }) {
   return (
     <div className="flex gap-2.5">
       <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border border-border text-[10px] text-muted-foreground">
@@ -48,68 +150,30 @@ function Step({ number, children }: { number: number; children: React.ReactNode 
   );
 }
 
-function GitHubSetupSection() {
-  const [showPAT, setShowPAT] = useState(false);
-
+function StepCard({
+  step,
+  index,
+  children,
+}: {
+  step: OnboardingStep;
+  index: number;
+  children?: ReactNode;
+}) {
   return (
-    <div className="space-y-3">
-      <p className="text-[12px] text-muted-foreground">
-        Code Factory needs a GitHub token to read repositories and sync PR feedback. Choose one of these options:
-      </p>
-
-      <div className="space-y-2">
-        <div className="border border-border p-3 space-y-2">
-          <div className="text-[11px] font-medium uppercase tracking-wider">Option A — GitHub CLI (recommended)</div>
-          <Step number={1}>
-            Install the GitHub CLI from{" "}
-            <a href="https://cli.github.com" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-              cli.github.com
-            </a>
-          </Step>
-          <Step number={2}>
-            Run <InlineCode>gh auth login</InlineCode> and follow the prompts to authenticate.
-          </Step>
-          <Step number={3}>
-            Restart Code Factory — it will automatically detect your token via <InlineCode>gh auth token</InlineCode>.
-          </Step>
-        </div>
-
-        <div className="border border-border p-3 space-y-2">
-          <div className="text-[11px] font-medium uppercase tracking-wider">Option B — Environment variable</div>
-          <Step number={1}>
-            Create a Personal Access Token at{" "}
-            <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-              github.com/settings/tokens
-            </a>
-            {" "}with <InlineCode>repo</InlineCode> and <InlineCode>read:user</InlineCode> scopes.
-          </Step>
-          <Step number={2}>
-            Set it before starting the app: <InlineCode>export GITHUB_TOKEN=ghp_your_token</InlineCode>
-          </Step>
-        </div>
-
-        <div className="border border-border p-3 space-y-2">
-          <button
-            onClick={() => setShowPAT(!showPAT)}
-            className="flex w-full items-center justify-between text-[11px] font-medium uppercase tracking-wider"
-          >
-            <span>Option C — Enter token in settings</span>
-            <span className="text-muted-foreground">{showPAT ? "▲" : "▼"}</span>
-          </button>
-          {showPAT && (
-            <div className="space-y-2 pt-1">
-              <Step number={1}>
-                Create a{" "}
-                <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  Personal Access Token
-                </a>
-                {" "}with <InlineCode>repo</InlineCode> and <InlineCode>read:user</InlineCode> scopes.
-              </Step>
-              <Step number={2}>
-                Paste it via the API: <InlineCode>{`curl -X PATCH http://localhost:5001/api/config -H 'Content-Type: application/json' -d '{"githubToken":"ghp_your_token"}'`}</InlineCode>
-              </Step>
-            </div>
-          )}
+    <div className={`border px-3 py-3 ${step.complete ? "border-border bg-background/60" : "border-amber-500/30 bg-amber-500/5"}`}>
+      <div className="flex gap-3">
+        <span className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center border text-[10px] ${step.complete ? "border-border text-foreground" : "border-amber-500/40 text-amber-500"}`}>
+          {step.complete ? "✓" : index}
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] font-medium uppercase tracking-wider">{step.title}</span>
+            <span className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${step.complete ? "border-border text-muted-foreground" : "border-amber-500/40 text-amber-500"}`}>
+              {step.complete ? "done" : "next"}
+            </span>
+          </div>
+          <p className="text-[12px] text-muted-foreground">{step.description}</p>
+          {children}
         </div>
       </div>
     </div>
@@ -117,36 +181,83 @@ function GitHubSetupSection() {
 }
 
 export function OnboardingPanel() {
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissedKey, setDismissedKey] = useState<string | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return window.localStorage.getItem(ONBOARDING_DISMISS_KEY);
+  });
   const [expanded, setExpanded] = useState(true);
 
   const { data: status, isLoading } = useQuery<OnboardingStatus>({
     queryKey: ["/api/onboarding/status"],
     refetchInterval: 30000,
   });
+  const { data: config } = useQuery<Config>({
+    queryKey: ["/api/config"],
+  });
+
+  const installWorkflowMutation = useMutation({
+    mutationFn: async ({ repo, tool }: { repo: string; tool: InstallReviewTool }) => {
+      const res = await apiRequest("POST", "/api/onboarding/install-review", { repo, tool });
+      return res.json();
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
+      toast({
+        description: `${REVIEW_TOOL_LABELS[variables.tool]} review workflow installed for ${variables.repo}.`,
+      });
+    },
+    onError: (error) => {
+      toast({
+        variant: "destructive",
+        description: `Could not install review workflow: ${error.message}`,
+      });
+    },
+  });
 
   if (isLoading || !status) return null;
 
-  const { hasIssues, inaccessibleRepos, summary } = getOnboardingPanelState(status);
+  const {
+    accessibleRepos,
+    completedCount,
+    dismissalKey,
+    hasIssues,
+    inaccessibleRepos,
+    reposMissingReview,
+    reposWithReview,
+    steps,
+    summary,
+  } = getOnboardingPanelState(status);
+  const preferredTool = config?.codingAgent ?? "claude";
+  const installOrder: InstallReviewTool[] = preferredTool === "codex"
+    ? ["codex", "claude"]
+    : ["claude", "codex"];
 
-  if (!hasIssues || dismissed) return null;
+  if (!hasIssues || dismissedKey === dismissalKey) return null;
 
   return (
-    <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/5">
+    <div className="shrink-0 border-b border-border bg-muted/35">
       <div className="flex items-center justify-between px-4 py-2">
         <button
           onClick={() => setExpanded(!expanded)}
           className="flex items-center gap-2 text-left"
         >
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
-          <span className="text-[11px] font-medium uppercase tracking-wider text-amber-400">
-            Setup needed
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-foreground" />
+          <span className="text-[11px] font-medium uppercase tracking-wider">
+            Getting started
           </span>
           <span className="text-[11px] text-muted-foreground">{summary}</span>
           <span className="text-[10px] text-muted-foreground">{expanded ? "▲" : "▼"}</span>
         </button>
         <button
-          onClick={() => setDismissed(true)}
+          onClick={() => {
+            if (typeof window !== "undefined") {
+              window.localStorage.setItem(ONBOARDING_DISMISS_KEY, dismissalKey);
+            }
+            setDismissedKey(dismissalKey);
+          }}
           className="text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
         >
           dismiss
@@ -154,25 +265,146 @@ export function OnboardingPanel() {
       </div>
 
       {expanded && (
-        <div className="border-t border-amber-500/20 px-4 py-4 space-y-6">
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <span className="text-[11px] font-medium uppercase tracking-wider text-destructive">
-                GitHub not connected
-              </span>
-              {status.githubError && (
-                <span className="text-[11px] text-muted-foreground">— {status.githubError}</span>
-              )}
+        <div className="border-t border-border px-4 py-4 space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
+              Setup checklist
             </div>
-            <GitHubSetupSection />
+            <div className="text-[11px] text-muted-foreground">
+              {completedCount} of {steps.length} complete
+            </div>
           </div>
 
-          {status.githubConnected && inaccessibleRepos.length > 0 && (
-            <div className="space-y-4">
-              <div className="text-[11px] font-medium uppercase tracking-wider">
+          <div className="space-y-3">
+            {steps.map((step, index) => (
+              <StepCard key={step.id} step={step} index={index + 1}>
+                {step.id === "github" && !step.complete && (
+                  <div className="space-y-2 pt-1">
+                    {status.githubError && (
+                      <p className="text-[12px] text-destructive">{status.githubError}</p>
+                    )}
+                    <div className="space-y-1.5 text-[12px] text-muted-foreground">
+                      <Step number={1}>
+                        Run <InlineCode>gh auth login</InlineCode> on this machine, or set <InlineCode>GITHUB_TOKEN</InlineCode> before starting the app.
+                      </Step>
+                      <Step number={2}>
+                        Prefer the built-in token field if you want the app to remember it. Open <Link href="/settings" className="underline underline-offset-2">settings</Link> to paste a Personal Access Token.
+                      </Step>
+                    </div>
+                  </div>
+                )}
+
+                {step.id === "repo" && !step.complete && (
+                  <div className="pt-1 text-[12px] text-muted-foreground">
+                    The left sidebar is the real entry point. Use <span className="text-foreground">Add</span> for a PR URL or <span className="text-foreground">Watch</span> for an <InlineCode>owner/repo</InlineCode> slug.
+                  </div>
+                )}
+
+                {step.id === "workflow" && !step.complete && accessibleRepos.length > 0 && (
+                  <div className="space-y-2 pt-1">
+                    <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
+                      <p className="text-[12px] text-muted-foreground">
+                        Oh-my-PR is best used along with a chain of AI code review tools. Different models have different strengths and weaknesses. Below are instructions on how to install code reviews with different providers.
+                      </p>
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
+                        {REVIEW_PROVIDER_GUIDES.map((provider) => (
+                          <a
+                            key={provider.href}
+                            href={provider.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
+                          >
+                            {provider.label}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                    {reposMissingReview.map((repoStatus) => (
+                      <div key={repoStatus.repo} className="flex flex-col gap-2 border border-border bg-background/50 px-3 py-2 md:flex-row md:items-center md:justify-between">
+                        <div className="min-w-0">
+                          <a
+                            href={`https://github.com/${repoStatus.repo}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block truncate text-[11px] font-medium underline underline-offset-2"
+                          >
+                            {repoStatus.repo}
+                          </a>
+                          <p className="text-[11px] text-muted-foreground">
+                            No AI review workflow detected yet.
+                          </p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {installOrder.map((tool) => {
+                            const isPending = installWorkflowMutation.isPending
+                              && installWorkflowMutation.variables?.repo === repoStatus.repo
+                              && installWorkflowMutation.variables?.tool === tool;
+                            return (
+                              <button
+                                key={`${repoStatus.repo}-${tool}`}
+                                type="button"
+                                onClick={() => installWorkflowMutation.mutate({ repo: repoStatus.repo, tool })}
+                                disabled={installWorkflowMutation.isPending}
+                                className="border border-border px-2 py-1 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-40"
+                              >
+                                {isPending ? "Installing…" : `Install ${REVIEW_TOOL_LABELS[tool]}`}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {step.id === "workflow" && step.complete && reposWithReview.length > 0 && (
+                  <div className="space-y-2 pt-1">
+                    <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
+                      <p className="text-[12px] text-muted-foreground">
+                        Oh-my-PR is best used along with a chain of AI code review tools. Different models have different strengths and weaknesses. Below are instructions on how to install code reviews with different providers.
+                      </p>
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
+                        {REVIEW_PROVIDER_GUIDES.map((provider) => (
+                          <a
+                            key={provider.href}
+                            href={provider.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
+                          >
+                            {provider.label}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {reposWithReview.map((repoStatus) => {
+                        const detectedTools = getDetectedReviewTools(repoStatus.codeReviews)
+                          .map((tool) => REVIEW_TOOL_LABELS[tool])
+                          .join(" + ");
+                        return (
+                          <span
+                            key={repoStatus.repo}
+                            className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+                          >
+                            {repoStatus.repo} · {detectedTools}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </StepCard>
+            ))}
+          </div>
+
+          {inaccessibleRepos.length > 0 && (
+            <div className="space-y-3 border border-destructive/30 bg-destructive/5 px-3 py-3">
+              <div className="text-[11px] font-medium uppercase tracking-wider text-destructive">
                 Repository access issues
               </div>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {inaccessibleRepos.map((repoStatus) => (
                   <div key={repoStatus.repo} className="space-y-1">
                     <div className="text-[11px] font-medium">

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -109,9 +109,9 @@ export function getOnboardingPanelState(status: OnboardingStatus) {
   const completedCount = steps.filter((step) => step.complete).length;
   const pendingSteps = steps.filter((step) => !step.complete);
   const dismissalKey = [
-    ...pendingSteps.map((step) => step.id),
-    ...inaccessibleRepos.map((repo) => `access:${repo.repo}:${repo.error ?? ""}`),
-  ].join("|") || "complete";
+    ...pendingSteps.map((step) => step.id.toLowerCase()),
+    ...inaccessibleRepos.map((repo) => "access:" + repo.repo.toLowerCase() + ":" + (repo.error?.slice(0, 100) ?? "").toLowerCase()),
+  ].sort().join("|") || "complete";
   const hasIssues = pendingSteps.length > 0 || inaccessibleRepos.length > 0;
   const summary = pendingSteps.length > 0
     ? `${completedCount} of ${steps.length} complete`

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -725,6 +725,7 @@ export default function Dashboard() {
     },
     onSuccess: (data: PR) => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
       setAddUrl("");
       setSelectedPRId(data.id);
     },
@@ -769,6 +770,7 @@ export default function Dashboard() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
     },
     onError: (error) => {
       showMutationError("Could not update settings", error);
@@ -783,6 +785,7 @@ export default function Dashboard() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
       queryClient.invalidateQueries({ queryKey: ["/api/repos"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
     },
     onError: (error) => {
       showMutationError("Could not sync repositories", error);
@@ -797,6 +800,7 @@ export default function Dashboard() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/repos"] });
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
       setAddRepo("");
     },
     onError: (error) => {

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -20,6 +20,7 @@ export default function Settings() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
       toast({ description: "Settings saved." });
     },
     onError: (error) => {

--- a/server/onboardingPanel.test.ts
+++ b/server/onboardingPanel.test.ts
@@ -2,29 +2,94 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { getOnboardingPanelState } from "../client/src/components/OnboardingPanel";
 
+test("getOnboardingPanelState starts with three pending steps and no repos", () => {
+  const state = getOnboardingPanelState({
+    githubConnected: false,
+    githubError: "No GitHub token found",
+    repos: [],
+  });
+
+  assert.equal(state.hasIssues, true);
+  assert.equal(state.summary, "0 of 3 complete");
+  assert.equal(state.completedCount, 0);
+  assert.deepEqual(
+    state.steps.map((step) => ({ id: step.id, complete: step.complete })),
+    [
+      { id: "github", complete: false },
+      { id: "repo", complete: false },
+      { id: "workflow", complete: false },
+    ],
+  );
+  assert.equal(state.dismissalKey, "github|repo|workflow");
+});
+
 test("getOnboardingPanelState keeps the panel visible for inaccessible repos after GitHub connects", () => {
   const state = getOnboardingPanelState({
     githubConnected: true,
     repos: [
-      { repo: "octo/accessible", accessible: true },
-      { repo: "octo/inaccessible", accessible: false, error: "Resource not accessible by integration" },
+      {
+        repo: "octo/accessible",
+        accessible: true,
+        codeReviews: { claude: false, codex: false, gemini: false },
+      },
+      {
+        repo: "octo/inaccessible",
+        accessible: false,
+        error: "Resource not accessible by integration",
+        codeReviews: { claude: false, codex: false, gemini: false },
+      },
     ],
   });
 
   assert.equal(state.hasIssues, true);
-  assert.equal(state.summary, "1 inaccessible repo");
+  assert.equal(state.summary, "2 of 3 complete");
   assert.deepEqual(state.inaccessibleRepos, [
-    { repo: "octo/inaccessible", accessible: false, error: "Resource not accessible by integration" },
+    {
+      repo: "octo/inaccessible",
+      accessible: false,
+      error: "Resource not accessible by integration",
+      codeReviews: { claude: false, codex: false, gemini: false },
+    },
   ]);
+  assert.equal(state.dismissalKey, "workflow|access:octo/inaccessible:Resource not accessible by integration");
 });
 
-test("getOnboardingPanelState hides the panel when GitHub is connected and watched repos are accessible", () => {
+test("getOnboardingPanelState keeps only workflow pending when repo access works but no review workflow exists", () => {
   const state = getOnboardingPanelState({
     githubConnected: true,
-    repos: [{ repo: "octo/accessible", accessible: true }],
+    githubUser: "octo",
+    repos: [
+      {
+        repo: "octo/accessible",
+        accessible: true,
+        codeReviews: { claude: false, codex: false, gemini: false },
+      },
+    ],
+  });
+
+  assert.equal(state.hasIssues, true);
+  assert.equal(state.summary, "2 of 3 complete");
+  assert.deepEqual(state.pendingSteps.map((step) => step.id), ["workflow"]);
+  assert.deepEqual(state.reposMissingReview.map((repo) => repo.repo), ["octo/accessible"]);
+});
+
+test("getOnboardingPanelState hides the panel when GitHub, repo access, and a review workflow are ready", () => {
+  const state = getOnboardingPanelState({
+    githubConnected: true,
+    githubUser: "octo",
+    repos: [
+      {
+        repo: "octo/accessible",
+        accessible: true,
+        codeReviews: { claude: false, codex: true, gemini: false },
+      },
+    ],
   });
 
   assert.equal(state.hasIssues, false);
-  assert.equal(state.summary, "0 inaccessible repos");
+  assert.equal(state.summary, "0 access issues");
   assert.deepEqual(state.inaccessibleRepos, []);
+  assert.equal(state.completedCount, 3);
+  assert.deepEqual(state.reposWithReview.map((repo) => repo.repo), ["octo/accessible"]);
+  assert.equal(state.dismissalKey, "complete");
 });

--- a/server/onboardingPanel.test.ts
+++ b/server/onboardingPanel.test.ts
@@ -51,7 +51,7 @@ test("getOnboardingPanelState keeps the panel visible for inaccessible repos aft
       codeReviews: { claude: false, codex: false, gemini: false },
     },
   ]);
-  assert.equal(state.dismissalKey, "workflow|access:octo/inaccessible:Resource not accessible by integration");
+  assert.equal(state.dismissalKey, "access:octo/inaccessible:resource not accessible by integration|workflow");
 });
 
 test("getOnboardingPanelState keeps only workflow pending when repo access works but no review workflow exists", () => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-04-16 - Surface requested onboarding guidance explicitly
+- Pattern: I cleaned up onboarding around checklist steps and install actions, but the user then had to ask for the multi-provider AI review tip and provider links to be shown explicitly during onboarding.
+- Rule: When onboarding touches a setup capability that depends on third-party providers, include the requested explanatory tip and concrete provider links in the onboarding UI instead of assuming buttons or inferred context are sufficient.
+- Prevention checklist:
+  - Re-read the final onboarding copy against the user's requested guidance before closing the task.
+  - If the user names specific providers or docs links, surface those exact links in the relevant onboarding step.
+  - Treat missing instructional copy in onboarding as a product gap, not a follow-up nice-to-have.
+
 ## 2026-04-02 - Honor explicit checkpoint and hang-reporting requests as runtime requirements
 - Pattern: Mid-implementation, the user had to explicitly ask for brief checkpoint updates and for hangs to be reported immediately if tests stall.
 - Rule: When the user sets expectations for progress cadence or hang reporting, adopt those expectations immediately and treat them as part of the task contract.


### PR DESCRIPTION
## Summary
- turn onboarding into a 3-step checklist for GitHub auth, first tracked repo/PR, and first-pass AI review
- add direct Claude/Codex workflow install actions plus the requested multi-provider review tip and guide links
- refresh onboarding state immediately after dashboard/settings changes and expand onboarding state tests

## Verification
- node --import tsx --test server/onboardingPanel.test.ts
- npm run check