### PR TITLE
[codex] fix tui overflow layout

### DIFF
--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -15,6 +15,7 @@ import { color, glyph } from "./theme";
 type AppProps = {
   runtime: TuiRuntime;
   screenWidth?: number;
+  screenHeight?: number;
   refreshMs?: number;
 };
 
@@ -40,6 +41,7 @@ export default function App(props: AppProps) {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const width = props.screenWidth ?? stdout.columns ?? 160;
+  const height = props.screenHeight ?? stdout.rows ?? 40;
   const layoutMode = getLayoutMode(width);
 
   const [selectedPrId, setSelectedPrId] = useState<string | null>(null);
@@ -309,19 +311,39 @@ export default function App(props: AppProps) {
     }
   }, { isActive: true });
 
-  const paneWidths = useMemo(() => {
+  const paneLayout = useMemo(() => {
+    const mainHeight = Math.max(layoutMode === "stacked" ? 18 : 12, height - 6);
+
     if (layoutMode === "full") {
       return {
-        list: 40,
-        context: 48,
+        widths: {
+          list: 40,
+          context: 48,
+        },
+        heights: {
+          list: mainHeight,
+          detail: mainHeight,
+          context: mainHeight,
+        },
       };
     }
 
+    const listHeight = Math.max(7, Math.floor(mainHeight * 0.25));
+    const contextHeight = Math.max(7, Math.floor(mainHeight * 0.3));
+    const detailHeight = Math.max(8, mainHeight - listHeight - contextHeight);
+
     return {
-      list: width,
-      context: undefined,
+      widths: {
+        list: width,
+        context: undefined,
+      },
+      heights: {
+        list: listHeight,
+        detail: detailHeight,
+        context: contextHeight,
+      },
     };
-  }, [layoutMode]);
+  }, [height, layoutMode, width]);
 
   if (layoutMode === "compact-warning") {
     return (
@@ -357,7 +379,8 @@ export default function App(props: AppProps) {
             prs={snapshot.prs}
             selectedPrIndex={selection.selectedPrIndex}
             active={selection.activePane === "prs"}
-            width={paneWidths.list}
+            width={paneLayout.widths.list}
+            height={paneLayout.heights.list}
           />
           <PrDetailPane
             pr={selectedPr}
@@ -366,12 +389,14 @@ export default function App(props: AppProps) {
             expandedFeedbackIds={selection.expandedFeedbackIds}
             selectedActionIndex={selectedActionIndex}
             selectedActions={selectedFeedbackActions}
-            width={layoutMode === "full" ? width - paneWidths.list! - paneWidths.context! : undefined}
+            width={layoutMode === "full" ? width - paneLayout.widths.list! - paneLayout.widths.context! : undefined}
+            height={paneLayout.heights.detail}
           />
           <ContextPane
             mode={selection.contextMode}
             active={selection.activePane === "context"}
-            width={paneWidths.context}
+            width={paneLayout.widths.context}
+            height={paneLayout.heights.context}
             logs={snapshot.logs}
             questions={snapshot.questions}
             repos={snapshot.repos}

--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -312,7 +312,7 @@ export default function App(props: AppProps) {
   }, { isActive: true });
 
   const paneLayout = useMemo(() => {
-    const mainHeight = Math.max(layoutMode === "stacked" ? 18 : 12, height - 6);
+    const mainHeight = Math.max(layoutMode === "stacked" ? 22 : 12, height - 6);
 
     if (layoutMode === "full") {
       return {

--- a/server/tui/components/ContextPane.tsx
+++ b/server/tui/components/ContextPane.tsx
@@ -56,7 +56,7 @@ function TabStrip(props: { mode: ContextMode; active: boolean }) {
 
 export function ContextPane(props: ContextPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
-  const innerHeight = Math.max(6, (props.height ?? 16) - 4);
+  const innerHeight = Math.max(2, props.height - 5);
 
   return (
     <Box

--- a/server/tui/components/ContextPane.tsx
+++ b/server/tui/components/ContextPane.tsx
@@ -12,6 +12,7 @@ type ContextPaneProps = {
   mode: ContextMode;
   active: boolean;
   width?: number;
+  height?: number;
   logs: LogEntry[];
   questions: PRQuestion[];
   repos: string[];
@@ -55,6 +56,7 @@ function TabStrip(props: { mode: ContextMode; active: boolean }) {
 
 export function ContextPane(props: ContextPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
+  const innerHeight = Math.max(6, (props.height ?? 16) - 4);
 
   return (
     <Box
@@ -63,15 +65,16 @@ export function ContextPane(props: ContextPaneProps) {
       borderColor={borderColor}
       paddingX={1}
       width={props.width}
+      height={props.height}
     >
-      <Box marginBottom={1} justifyContent="space-between">
+      <Box justifyContent="space-between">
         <Text bold color={props.active ? color.accent : undefined}>
           Context
         </Text>
       </Box>
       <TabStrip mode={props.mode} active={props.active} />
       <Box marginTop={1} flexDirection="column">
-        {props.mode === "logs" && <LogPane logs={props.logs} />}
+        {props.mode === "logs" && <LogPane logs={props.logs} width={Math.max(20, (props.width ?? 40) - 4)} height={innerHeight} />}
         {props.mode === "ask" && (
           <AskPane
             questions={props.questions}

--- a/server/tui/components/FeedbackList.tsx
+++ b/server/tui/components/FeedbackList.tsx
@@ -1,19 +1,34 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { FeedbackItem } from "@shared/schema";
-import { getFeedbackActions, formatFeedbackStatusLabel, wrapText } from "../viewModel";
+import {
+  formatFeedbackStatusLabel,
+  middleTruncateText,
+  truncateText,
+  wrapText,
+} from "../viewModel";
 import { FeedbackActions } from "./FeedbackActions";
 import { color, feedbackGlyph, feedbackTone, glyph } from "../theme";
 
 type FeedbackListProps = {
   items: FeedbackItem[];
   selectedFeedbackIndex: number;
+  width: number;
+};
+
+type FeedbackPreviewProps = {
+  item: FeedbackItem | null;
   active: boolean;
-  expandedFeedbackIds: Set<string>;
+  expanded: boolean;
   selectedActionIndex: number;
   selectedActions: string[];
   width: number;
+  height: number;
 };
+
+function summarizeBody(body: string): string {
+  return body.replace(/\s+/g, " ").trim();
+}
 
 export function FeedbackList(props: FeedbackListProps) {
   if (props.items.length === 0) {
@@ -24,47 +39,86 @@ export function FeedbackList(props: FeedbackListProps) {
     <Box flexDirection="column">
       {props.items.map((item, index) => {
         const selected = index === props.selectedFeedbackIndex;
-        const expanded = props.expandedFeedbackIds.has(item.id);
-        const actions = selected && expanded ? props.selectedActions : getFeedbackActions(item);
-        const wrappedBody = wrapText(item.body, Math.max(20, props.width - 10));
         const tone = feedbackTone(item.status);
         const statusLabel = formatFeedbackStatusLabel(item.status);
+        const availableMetadataWidth = Math.max(12, props.width - 2);
+        const authorBudget = Math.max(8, Math.min(18, Math.floor(availableMetadataWidth * 0.24)));
+        const author = truncateText(item.author, authorBudget);
         const location = item.file ? `${item.file}${item.line ? `:${item.line}` : ""}` : "";
+        const locationText = location
+          ? middleTruncateText(location, Math.max(10, Math.min(24, Math.floor(availableMetadataWidth * 0.34))))
+          : "";
+        const summary = truncateText(
+          [
+            `${feedbackGlyph(item.status)} ${statusLabel}`,
+            locationText,
+            author,
+            summarizeBody(item.body),
+          ].filter(Boolean).join(" │ "),
+          props.width - 2,
+        );
 
         return (
-          <Box key={item.id} flexDirection="column" marginBottom={1}>
-            <Box>
-              <Text color={selected ? color.accent : color.muted}>
-                {selected ? `${glyph.focus} ` : "  "}
-              </Text>
-              <Text color={tone}>{feedbackGlyph(item.status)}</Text>
-              <Text color={tone}>{` ${statusLabel}`}</Text>
-              <Text color={color.muted}>{`  ${item.author}`}</Text>
-              {location && (
-                <>
-                  <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
-                  <Text color={color.muted}>{location}</Text>
-                </>
-              )}
-            </Box>
-            {expanded && (
-              <Box flexDirection="column" marginLeft={4} marginTop={0}>
-                {wrappedBody.map((line, lineIndex) => (
-                  <Text key={`${item.id}-${lineIndex}`} color={color.muted}>
-                    {line}
-                  </Text>
-                ))}
-                {selected && props.active && (
-                  <FeedbackActions
-                    actions={actions}
-                    selectedActionIndex={Math.min(props.selectedActionIndex, actions.length - 1)}
-                  />
-                )}
-              </Box>
-            )}
-          </Box>
+          <Text key={item.id} color={selected ? color.accent : tone}>
+            {selected ? `${glyph.focus} ` : "  "}
+            {summary}
+          </Text>
         );
       })}
+    </Box>
+  );
+}
+
+export function FeedbackPreview(props: FeedbackPreviewProps) {
+  if (!props.item) {
+    return <Text color={color.muted}>Select a feedback item.</Text>;
+  }
+
+  const item = props.item;
+  const tone = feedbackTone(item.status);
+  const statusLabel = formatFeedbackStatusLabel(item.status);
+  const author = truncateText(item.author, Math.max(10, Math.floor(props.width * 0.22)));
+  const location = item.file ? `${item.file}${item.line ? `:${item.line}` : ""}` : "";
+  const metadataLocation = location
+    ? middleTruncateText(location, Math.max(16, Math.floor(props.width * 0.45)))
+    : "";
+  const metadata = truncateText(
+    [
+      `${feedbackGlyph(item.status)} ${statusLabel}`,
+      metadataLocation,
+      author,
+    ].filter(Boolean).join(` ${glyph.sep} `),
+    props.width,
+  );
+  const actionRowCount = props.expanded && props.active ? 1 : 0;
+  const wrappedBody = wrapText(item.body, Math.max(16, props.width));
+  let bodyLineBudget = Math.max(1, props.height - 1 - actionRowCount);
+  let visibleBodyLines = wrappedBody.slice(0, bodyLineBudget);
+  let hiddenLineCount = wrappedBody.length - visibleBodyLines.length;
+
+  if (hiddenLineCount > 0 && props.height - 2 - actionRowCount >= 1) {
+    bodyLineBudget = Math.max(1, props.height - 2 - actionRowCount);
+    visibleBodyLines = wrappedBody.slice(0, bodyLineBudget);
+    hiddenLineCount = wrappedBody.length - visibleBodyLines.length;
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color={tone}>{metadata}</Text>
+      {visibleBodyLines.map((line, lineIndex) => (
+        <Text key={`${item.id}-${lineIndex}`} color={color.muted}>
+          {line}
+        </Text>
+      ))}
+      {hiddenLineCount > 0 && (
+        <Text color={color.muted}>{`↓ ${hiddenLineCount} more line${hiddenLineCount === 1 ? "" : "s"}`}</Text>
+      )}
+      {props.expanded && props.active && (
+        <FeedbackActions
+          actions={props.selectedActions}
+          selectedActionIndex={Math.min(props.selectedActionIndex, props.selectedActions.length - 1)}
+        />
+      )}
     </Box>
   );
 }

--- a/server/tui/components/LogPane.tsx
+++ b/server/tui/components/LogPane.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { LogEntry } from "@shared/schema";
 import { color } from "../theme";
+import { middleTruncateText, truncateText } from "../viewModel";
 
 const LEVEL_TONE: Record<string, string> = {
   error: color.err,
@@ -15,8 +16,10 @@ function formatTime(timestamp: string): string {
   return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
 }
 
-export function LogPane(props: { logs: LogEntry[] }) {
-  const rows = props.logs.slice(-10);
+export function LogPane(props: { logs: LogEntry[]; width: number; height: number }) {
+  const rowCount = Math.max(3, props.height - 2);
+  const rows = props.logs.slice(-rowCount);
+  const hiddenCount = Math.max(0, props.logs.length - rows.length);
 
   if (rows.length === 0) {
     return <Text color={color.muted}>No log entries.</Text>;
@@ -24,14 +27,20 @@ export function LogPane(props: { logs: LogEntry[] }) {
 
   return (
     <Box flexDirection="column">
+      {hiddenCount > 0 && (
+        <Text color={color.muted}>{`↑ ${hiddenCount} earlier log${hiddenCount === 1 ? "" : "s"}`}</Text>
+      )}
       {rows.map((log) => {
         const tone = LEVEL_TONE[log.level.toLowerCase()] ?? color.muted;
+        const phase = log.phase ? middleTruncateText(log.phase, Math.max(8, Math.floor(props.width * 0.2))) : "";
+        const prefix = `${formatTime(log.timestamp)} ${log.level.toUpperCase()}${phase ? ` ${phase}` : ""} `;
+        const message = truncateText(log.message, Math.max(12, props.width - prefix.length));
         return (
           <Text key={log.id}>
             <Text color={color.muted}>{formatTime(log.timestamp)} </Text>
             <Text color={tone} bold>{log.level.toUpperCase()}</Text>
-            {log.phase && <Text color={color.muted}> {log.phase}</Text>}
-            <Text> {log.message}</Text>
+            {phase && <Text color={color.muted}> {phase}</Text>}
+            <Text> {message}</Text>
           </Text>
         );
       })}

--- a/server/tui/components/PrDetailPane.tsx
+++ b/server/tui/components/PrDetailPane.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { PR } from "@shared/schema";
-import { FeedbackList } from "./FeedbackList";
-import { formatStatusLabel } from "../viewModel";
+import { FeedbackList, FeedbackPreview } from "./FeedbackList";
+import {
+  formatStatusLabel,
+  getViewportRange,
+  middleTruncateText,
+  truncateText,
+} from "../viewModel";
 import { color, glyph, prStatusGlyph, prStatusTone } from "../theme";
 
 type PrDetailPaneProps = {
@@ -13,10 +18,46 @@ type PrDetailPaneProps = {
   selectedActionIndex: number;
   selectedActions: string[];
   width?: number;
+  height?: number;
 };
 
 export function PrDetailPane(props: PrDetailPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
+  const innerWidth = Math.max(24, (props.width ?? 80) - 4);
+  const contentHeight = Math.max(10, (props.height ?? 18) - 4);
+
+  if (!props.pr) {
+    return (
+      <Box
+        flexDirection="column"
+        borderStyle={props.active ? "round" : "single"}
+        borderColor={borderColor}
+        paddingX={1}
+        width={props.width}
+        height={props.height}
+        flexGrow={1}
+      >
+        <Box>
+          <Text bold color={props.active ? color.accent : undefined}>
+            PR Detail
+          </Text>
+        </Box>
+        <Text color={color.muted}>Select a PR.</Text>
+      </Box>
+    );
+  }
+
+  const selectedFeedback = props.pr.feedbackItems[props.selectedFeedbackIndex] ?? null;
+  const selectedExpanded = selectedFeedback ? props.expandedFeedbackIds.has(selectedFeedback.id) : false;
+  const actionRowCount = selectedExpanded && props.active ? 1 : 0;
+  const bodyBudget = Math.max(6, contentHeight - 6 - actionRowCount);
+  const listRowCount = Math.max(3, Math.min(8, Math.floor(bodyBudget * 0.45)));
+  const previewHeight = Math.max(3, bodyBudget - listRowCount + actionRowCount);
+  const viewport = getViewportRange(props.pr.feedbackItems.length, props.selectedFeedbackIndex, listRowCount);
+  const visibleFeedbackItems = props.pr.feedbackItems.slice(viewport.start, viewport.end);
+  const selectedVisibleIndex = props.selectedFeedbackIndex - viewport.start;
+  const repoLabel = middleTruncateText(props.pr.repo, Math.max(18, Math.floor(innerWidth * 0.55)));
+  const title = truncateText(props.pr.title, innerWidth);
 
   return (
     <Box
@@ -25,54 +66,64 @@ export function PrDetailPane(props: PrDetailPaneProps) {
       borderColor={borderColor}
       paddingX={1}
       width={props.width}
+      height={props.height}
       flexGrow={1}
     >
-      <Box marginBottom={1}>
+      <Box>
         <Text bold color={props.active ? color.accent : undefined}>
           PR Detail
         </Text>
       </Box>
-      {!props.pr ? (
-        <Text color={color.muted}>Select a PR.</Text>
-      ) : (
-        <>
-          <Box>
-            <Text color={color.muted}>{props.pr.repo}</Text>
-            <Text color={color.muted}>{"  "}</Text>
-            <Text bold color={color.accent}>#{props.pr.number}</Text>
-          </Box>
-          <Box>
-            <Text bold>{props.pr.title}</Text>
-          </Box>
-          <Box marginTop={1}>
-            <Text color={prStatusTone(props.pr.status)}>
-              {prStatusGlyph(props.pr.status)}
-              {" "}
-              {formatStatusLabel(props.pr.status)}
-            </Text>
-            <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
-            <Text color={props.pr.watchEnabled ? color.ok : color.warn}>
-              {props.pr.watchEnabled ? glyph.dot : glyph.pause}
-              {" "}
-              {props.pr.watchEnabled ? "watching" : "paused"}
-            </Text>
-            <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
-            <Text color={color.muted}>feedback </Text>
-            <Text bold>{props.pr.feedbackItems.length}</Text>
-          </Box>
-          <Box marginTop={1}>
-            <FeedbackList
-              items={props.pr.feedbackItems}
-              selectedFeedbackIndex={props.selectedFeedbackIndex}
-              active={props.active}
-              expandedFeedbackIds={props.expandedFeedbackIds}
-              selectedActionIndex={props.selectedActionIndex}
-              selectedActions={props.selectedActions}
-              width={props.width ?? 80}
-            />
-          </Box>
-        </>
-      )}
+      <Box>
+        <Text color={color.muted}>{repoLabel}</Text>
+        <Text color={color.muted}>{"  "}</Text>
+        <Text bold color={color.accent}>#{props.pr.number}</Text>
+      </Box>
+      <Box>
+        <Text bold>{title}</Text>
+      </Box>
+      <Box>
+        <Text color={prStatusTone(props.pr.status)}>
+          {prStatusGlyph(props.pr.status)}
+          {" "}
+          {formatStatusLabel(props.pr.status)}
+        </Text>
+        <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
+        <Text color={props.pr.watchEnabled ? color.ok : color.warn}>
+          {props.pr.watchEnabled ? glyph.dot : glyph.pause}
+          {" "}
+          {props.pr.watchEnabled ? "watching" : "paused"}
+        </Text>
+        <Text color={color.muted}>{`  ${glyph.sep}  `}</Text>
+        <Text color={color.muted}>feedback </Text>
+        <Text bold>{props.pr.feedbackItems.length}</Text>
+      </Box>
+      <Box>
+        <Text color={color.muted}>
+          Feedback
+          {`  ${visibleFeedbackItems.length}/${props.pr.feedbackItems.length}`}
+          {(viewport.hiddenAbove > 0 || viewport.hiddenBelow > 0)
+            ? `  ↑${viewport.hiddenAbove} ↓${viewport.hiddenBelow}`
+            : ""}
+        </Text>
+      </Box>
+      <FeedbackList
+        items={visibleFeedbackItems}
+        selectedFeedbackIndex={Math.max(0, selectedVisibleIndex)}
+        width={innerWidth}
+      />
+      <Box>
+        <Text color={color.muted}>Selected feedback</Text>
+      </Box>
+      <FeedbackPreview
+        item={selectedFeedback}
+        active={props.active}
+        expanded={selectedExpanded}
+        selectedActionIndex={props.selectedActionIndex}
+        selectedActions={props.selectedActions}
+        width={innerWidth}
+        height={previewHeight}
+      />
     </Box>
   );
 }

--- a/server/tui/components/PrDetailPane.tsx
+++ b/server/tui/components/PrDetailPane.tsx
@@ -24,7 +24,7 @@ type PrDetailPaneProps = {
 export function PrDetailPane(props: PrDetailPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
   const innerWidth = Math.max(24, (props.width ?? 80) - 4);
-  const contentHeight = Math.max(10, (props.height ?? 18) - 4);
+  const contentHeight = Math.max(4, props.height - 4);
 
   if (!props.pr) {
     return (

--- a/server/tui/components/PrListPane.tsx
+++ b/server/tui/components/PrListPane.tsx
@@ -2,20 +2,20 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { PR } from "@shared/schema";
 import { color, glyph, prStatusGlyph, prStatusTone } from "../theme";
-import { countActiveFeedbackStatuses, isPRReadyToMerge } from "../viewModel";
+import {
+  countActiveFeedbackStatuses,
+  getViewportRange,
+  isPRReadyToMerge,
+  truncateText,
+} from "../viewModel";
 
 type PrListPaneProps = {
   prs: PR[];
   selectedPrIndex: number;
   active: boolean;
   width?: number;
+  height?: number;
 };
-
-function truncate(input: string, max: number): string {
-  if (max <= 1) return input.slice(0, max);
-  if (input.length <= max) return input;
-  return `${input.slice(0, Math.max(1, max - 1))}…`;
-}
 
 function padNumber(n: number, width: number): string {
   const str = `#${n}`;
@@ -41,42 +41,32 @@ function getBadges(pr: PR): Badge[] {
 
 function PrRow(props: { pr: PR; selected: boolean; width: number }) {
   const { pr, selected, width } = props;
-  const tone = prStatusTone(pr.status);
   const badges = getBadges(pr);
   const numCol = padNumber(pr.number, 5);
   const badgesText = badges.map((b) => b.label).join(" ");
-  const reserved = 2 + 1 + numCol.length + 1 + badgesText.length + 1 + 2;
-  const titleSpace = Math.max(8, width - reserved);
-  const title = truncate(pr.title, titleSpace);
+  const summary = truncateText(
+    [
+      `${prStatusGlyph(pr.status)} ${numCol}`,
+      pr.title,
+      badgesText,
+    ].filter(Boolean).join(" "),
+    width,
+  );
 
   return (
-    <Box>
-      <Text color={selected ? color.accent : color.muted}>
-        {selected ? `${glyph.focus} ` : "  "}
-      </Text>
-      <Text color={tone}>{prStatusGlyph(pr.status)}</Text>
-      <Text color={color.muted}>{` ${numCol} `}</Text>
-      <Text bold={selected} color={selected ? color.accent : undefined}>
-        {title}
-      </Text>
-      {badges.length > 0 && (
-        <>
-          <Text>{" "}</Text>
-          {badges.map((b, i) => (
-            <Text key={i} color={b.tone}>
-              {b.label}
-              {i < badges.length - 1 ? " " : ""}
-            </Text>
-          ))}
-        </>
-      )}
-    </Box>
+    <Text color={selected ? color.accent : prStatusTone(pr.status)} bold={selected}>
+      {selected ? `${glyph.focus} ` : "  "}
+      {summary}
+    </Text>
   );
 }
 
 export function PrListPane(props: PrListPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
   const innerWidth = (props.width ?? 40) - 4;
+  const rowCount = Math.max(3, (props.height ?? 16) - 4);
+  const viewport = getViewportRange(props.prs.length, props.selectedPrIndex, rowCount);
+  const visiblePrs = props.prs.slice(viewport.start, viewport.end);
 
   return (
     <Box
@@ -85,21 +75,25 @@ export function PrListPane(props: PrListPaneProps) {
       borderColor={borderColor}
       paddingX={1}
       width={props.width}
+      height={props.height}
     >
-      <Box marginBottom={1}>
+      <Box>
         <Text bold color={props.active ? color.accent : undefined}>
           Pull Requests
         </Text>
         <Text color={color.muted}>{`  ${props.prs.length}`}</Text>
+        {(viewport.hiddenAbove > 0 || viewport.hiddenBelow > 0) && (
+          <Text color={color.muted}>{`  ↑${viewport.hiddenAbove} ↓${viewport.hiddenBelow}`}</Text>
+        )}
       </Box>
       {props.prs.length === 0 ? (
         <Text color={color.muted}>No tracked PRs.</Text>
       ) : (
-        props.prs.map((pr, index) => (
+        visiblePrs.map((pr, index) => (
           <PrRow
             key={pr.id}
             pr={pr}
-            selected={index === props.selectedPrIndex}
+            selected={viewport.start + index === props.selectedPrIndex}
             width={innerWidth}
           />
         ))

--- a/server/tui/components/PrListPane.tsx
+++ b/server/tui/components/PrListPane.tsx
@@ -50,7 +50,7 @@ function PrRow(props: { pr: PR; selected: boolean; width: number }) {
       pr.title,
       badgesText,
     ].filter(Boolean).join(" "),
-    width,
+    width - 2,
   );
 
   return (

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -191,7 +191,7 @@ export function getViewportRange(count: number, selectedIndex: number, visibleCo
 }
 
 export function wrapText(input: string, width: number): string[] {
-  if (width <= 1) {
+  if (width < 1) {
     return input ? [input] : [""];
   }
 

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -1,6 +1,12 @@
 import type { FeedbackItem, FeedbackStatus, PR } from "@shared/schema";
 
 export type LayoutMode = "full" | "stacked" | "compact-warning";
+export type ViewportRange = {
+  start: number;
+  end: number;
+  hiddenAbove: number;
+  hiddenBelow: number;
+};
 
 export function formatStatusLabel(status: PR["status"]): string {
   if (status === "processing") {
@@ -121,31 +127,106 @@ export function getFeedbackActions(item: FeedbackItem): string[] {
   return actions;
 }
 
+export function truncateText(input: string, max: number): string {
+  if (max <= 0) {
+    return "";
+  }
+
+  if (max === 1) {
+    return input.slice(0, 1);
+  }
+
+  if (input.length <= max) {
+    return input;
+  }
+
+  return `${input.slice(0, Math.max(1, max - 1))}…`;
+}
+
+export function middleTruncateText(input: string, max: number): string {
+  if (max <= 0) {
+    return "";
+  }
+
+  if (max === 1) {
+    return "…";
+  }
+
+  if (input.length <= max) {
+    return input;
+  }
+
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${input.slice(0, head)}…${input.slice(input.length - tail)}`;
+}
+
+export function getViewportRange(count: number, selectedIndex: number, visibleCount: number): ViewportRange {
+  if (count <= 0 || visibleCount <= 0) {
+    return {
+      start: 0,
+      end: 0,
+      hiddenAbove: 0,
+      hiddenBelow: 0,
+    };
+  }
+
+  const clampedVisibleCount = Math.min(count, visibleCount);
+  const clampedSelectedIndex = Math.max(0, Math.min(selectedIndex, count - 1));
+  const half = Math.floor(clampedVisibleCount / 2);
+  let start = Math.max(0, clampedSelectedIndex - half);
+  const maxStart = Math.max(0, count - clampedVisibleCount);
+
+  if (start > maxStart) {
+    start = maxStart;
+  }
+
+  const end = Math.min(count, start + clampedVisibleCount);
+  return {
+    start,
+    end,
+    hiddenAbove: start,
+    hiddenBelow: Math.max(0, count - end),
+  };
+}
+
 export function wrapText(input: string, width: number): string[] {
-  if (width <= 4) {
-    return [input];
+  if (width <= 1) {
+    return input ? [input] : [""];
   }
 
-  const words = input.replace(/\s+/g, " ").trim().split(" ");
-  if (words.length === 1 && words[0] === "") {
-    return [""];
-  }
-
+  const normalized = input.replace(/\r\n/g, "\n");
+  const rawLines = normalized.split("\n");
   const lines: string[] = [];
-  let current = "";
 
-  for (const word of words) {
-    const next = current ? `${current} ${word}` : word;
-    if (next.length > width && current) {
-      lines.push(current);
-      current = word;
-    } else {
-      current = next;
+  for (const rawLine of rawLines) {
+    const collapsed = rawLine.replace(/\s+/g, " ").trim();
+    if (!collapsed) {
+      lines.push("");
+      continue;
+    }
+
+    let remaining = collapsed;
+    while (remaining.length > width) {
+      const candidate = remaining.slice(0, width + 1);
+      let breakAt = candidate.lastIndexOf(" ");
+
+      if (breakAt <= 0) {
+        breakAt = width;
+      }
+
+      const chunk = remaining.slice(0, breakAt).trimEnd();
+      lines.push(chunk);
+      remaining = remaining.slice(breakAt).trimStart();
+    }
+
+    if (remaining) {
+      lines.push(remaining);
     }
   }
 
-  if (current) {
-    lines.push(current);
+  if (lines.length === 0) {
+    return [""];
   }
 
   return lines;

--- a/server/tuiApp.test.tsx
+++ b/server/tuiApp.test.tsx
@@ -9,26 +9,29 @@ async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 
-test("tui renders the PR list, supports arrow selection, tab focus, and context switching", async () => {
+test("tui renders stable panes, moves PR selection, and switches context tabs", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();
-    assert.match(ui.lastFrame() ?? "", /› #1 · feat: first pr/);
+    assert.match(ui.lastFrame() ?? "", /Pull Requests/);
+    assert.match(ui.lastFrame() ?? "", /feat: first pr/);
+    assert.match(ui.lastFrame() ?? "", /Selected feedback/);
+    assert.match(ui.lastFrame() ?? "", /Please rename this variable for/);
 
     ui.stdin.write("\u001B[B");
     await flush();
-    assert.match(ui.lastFrame() ?? "", /› #2 · fix: second pr/);
+    assert.match(ui.lastFrame() ?? "", /fix: second pr/);
 
-    ui.stdin.write("\t");
+    ui.stdin.write("a");
     await flush();
-    assert.match(ui.lastFrame() ?? "", /pane=feedback/);
+    assert.match(ui.lastFrame() ?? "", /Press Enter to ask about/);
+    assert.match(ui.lastFrame() ?? "", /the selected PR\./);
 
     ui.stdin.write("l");
     await flush();
-    assert.match(ui.lastFrame() ?? "", /context=logs/);
-    assert.match(ui.lastFrame() ?? "", /No log entries/);
+    assert.match(ui.lastFrame() ?? "", /No log entries\./);
   } finally {
     ui.unmount();
   }
@@ -36,7 +39,7 @@ test("tui renders the PR list, supports arrow selection, tab focus, and context 
 
 test("tui shows a compact warning when the terminal is too narrow", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={90} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={90} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();

--- a/server/tuiFeedback.test.tsx
+++ b/server/tuiFeedback.test.tsx
@@ -9,20 +9,21 @@ async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 
-test("tui expands feedback rows and applies accept decisions with arrow keys and Enter", async () => {
+test("tui shows selected feedback in a preview and applies accept decisions with Enter", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();
+    assert.match(ui.lastFrame() ?? "", /Selected feedback/);
+    assert.match(ui.lastFrame() ?? "", /Please rename this variable for/);
+
     ui.stdin.write("\t");
     await flush();
     ui.stdin.write("\r");
     await flush();
 
-    assert.match(ui.lastFrame() ?? "", /Please rename this variable for/);
-    assert.match(ui.lastFrame() ?? "", /clarity/);
-    assert.match(ui.lastFrame() ?? "", /Collaps/);
+    assert.match(ui.lastFrame() ?? "", /Collapse/);
 
     ui.stdin.write("\u001B[C");
     await flush();
@@ -38,34 +39,45 @@ test("tui expands feedback rows and applies accept decisions with arrow keys and
   }
 });
 
-test("tui shows retry for failed feedback and refreshes live logs on runtime events", async () => {
+test("tui keeps long feedback collections inside a viewport and truncates long row metadata", async () => {
+  const baseRuntime = createTestRuntime();
+  const basePr = (await baseRuntime.getPR("pr-1"))!;
   const runtime = createTestRuntime({
     prs: [
       {
-        ...(await createTestRuntime().getPR("pr-1"))!,
-        feedbackItems: [
-          {
-            ...(await createTestRuntime().getPR("pr-1"))!.feedbackItems[0]!,
-            status: "failed",
-          },
-        ],
+        ...basePr,
+        feedbackItems: Array.from({ length: 12 }, (_, index) => ({
+          ...basePr.feedbackItems[0]!,
+          id: `feedback-${index}`,
+          author: `reviewer-${index}`,
+          body: index === 0
+            ? "A".repeat(140)
+            : `Feedback item ${index} body text that should stay in the preview pane.`,
+          file: `frontend/src/really/long/path/that/keeps/going/component-${index}.ts`,
+          line: 100 + index,
+        })),
       },
     ],
   });
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={22} refreshMs={0} />);
 
   try {
     await flush();
+    assert.match(ui.lastFrame() ?? "", /3\/12/);
+    assert.match(ui.lastFrame() ?? "", /↓9/);
+    assert.match(ui.lastFrame() ?? "", /frontend\/sr…/);
+    assert.match(ui.lastFrame() ?? "", /…/);
+
     ui.stdin.write("\t");
     await flush();
-    ui.stdin.write("\r");
+    ui.stdin.write("\u001B[B");
+    ui.stdin.write("\u001B[B");
+    ui.stdin.write("\u001B[B");
+    ui.stdin.write("\u001B[B");
     await flush();
 
-    assert.match(ui.lastFrame() ?? "", /Retry/);
-
-    runtime.appendLog("pr-1", "Follow-up log line");
-    await flush();
-    assert.match(ui.lastFrame() ?? "", /Follow-up log line/);
+    assert.match(ui.lastFrame() ?? "", /↑3/);
+    assert.match(ui.lastFrame() ?? "", /reviewer-4/);
   } finally {
     ui.unmount();
   }

--- a/server/tuiOperatorFlows.test.tsx
+++ b/server/tuiOperatorFlows.test.tsx
@@ -11,7 +11,7 @@ async function flush() {
 
 test("tui ask-agent flow queues a question from the context pane", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();
@@ -24,7 +24,7 @@ test("tui ask-agent flow queues a question from the context pane", async () => {
     ui.stdin.write("\r");
     await flush();
 
-    assert.match(ui.lastFrame() ?? "", /Q: Status\?/);
+    assert.match(ui.lastFrame() ?? "", /Q Status\?/);
   } finally {
     ui.unmount();
   }
@@ -32,7 +32,7 @@ test("tui ask-agent flow queues a question from the context pane", async () => {
 
 test("tui repo management can add a watched repository and a PR URL", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();
@@ -67,19 +67,20 @@ test("tui repo management can add a watched repository and a PR URL", async () =
 
 test("tui settings and watch controls mutate the runtime", async () => {
   const runtime = createTestRuntime();
-  const ui = render(<App runtime={runtime} screenWidth={160} refreshMs={0} />);
+  const ui = render(<App runtime={runtime} screenWidth={160} screenHeight={24} refreshMs={0} />);
 
   try {
     await flush();
     ui.stdin.write("w");
     await flush();
-    assert.match(ui.lastFrame() ?? "", /watch=paused/);
+    assert.match(ui.lastFrame() ?? "", /paused/);
 
     ui.stdin.write("s");
     await flush();
     ui.stdin.write("\r");
     await flush();
-    assert.match(ui.lastFrame() ?? "", /Coding agent: codex/);
+    assert.match(ui.lastFrame() ?? "", /Coding agent/);
+    assert.match(ui.lastFrame() ?? "", /codex/);
   } finally {
     ui.unmount();
   }

--- a/server/tuiViewModel.test.ts
+++ b/server/tuiViewModel.test.ts
@@ -7,6 +7,9 @@ import {
   formatStatusLabel,
   getFeedbackActions,
   getLayoutMode,
+  getViewportRange,
+  middleTruncateText,
+  truncateText,
   wrapText,
 } from "./tui/viewModel";
 
@@ -111,7 +114,38 @@ test("formatFeedbackStatusLabel normalizes underscores", () => {
   assert.equal(formatFeedbackStatusLabel("in_progress"), "IN PROGRESS");
 });
 
+test("truncate helpers keep the start or both ends visible", () => {
+  assert.equal(truncateText("frontend/src/router/index.ts", 12), "frontend/sr…");
+  assert.equal(middleTruncateText("abcdefghijklmnopqrstuvwxyz", 9), "abcd…wxyz");
+});
+
+test("getViewportRange keeps the selected row within the visible window", () => {
+  assert.deepEqual(getViewportRange(20, 0, 5), {
+    start: 0,
+    end: 5,
+    hiddenAbove: 0,
+    hiddenBelow: 15,
+  });
+  assert.deepEqual(getViewportRange(20, 10, 5), {
+    start: 8,
+    end: 13,
+    hiddenAbove: 8,
+    hiddenBelow: 7,
+  });
+  assert.deepEqual(getViewportRange(20, 19, 5), {
+    start: 15,
+    end: 20,
+    hiddenAbove: 15,
+    hiddenBelow: 0,
+  });
+});
+
 test("wrapText keeps lines under the requested width", () => {
   const lines = wrapText("one two three four", 7);
   assert.deepEqual(lines, ["one two", "three", "four"]);
+});
+
+test("wrapText hard-wraps long unbroken tokens", () => {
+  const lines = wrapText("abcdefghijklmnopqrstuvwxyz", 8);
+  assert.deepEqual(lines, ["abcdefgh", "ijklmnop", "qrstuvwx", "yz"]);
 });


### PR DESCRIPTION
## Summary

This fixes the TUI overflow behavior when panes contain long content.

- convert the PR list and feedback list to stable single-line viewport rows
- add a dedicated selected-feedback preview with wrapped body text and overflow indicators
- budget pane heights from the terminal size so long lists and logs stop taking over the screen
- add regression coverage for truncation, viewport math, and long-content TUI rendering

## Root Cause

The TUI rendered full collections directly into panes and mixed multiline row content into narrow columns. When feedback bodies, file paths, or long log lines grew, Ink wrapped fragments across pane boundaries and the layout became visually unstable.

## Impact

Long content now stays readable without breaking the overall terminal layout. Operators get a predictable list-plus-preview experience instead of panes stretching unpredictably under long rows.

## Validation

- `npm run check`
- `node --test --import tsx server/tuiViewModel.test.ts server/tuiApp.test.tsx server/tuiFeedback.test.tsx server/tuiOperatorFlows.test.tsx`
