### PR TITLE
[codex] Fix TUI alignment and truncation handling

### DIFF
--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -335,7 +335,7 @@ export default function App(props: AppProps) {
     return {
       widths: {
         list: width,
-        context: undefined,
+        context: width,
       },
       heights: {
         list: listHeight,

--- a/server/tui/App.tsx
+++ b/server/tui/App.tsx
@@ -411,6 +411,7 @@ export default function App(props: AppProps) {
         contextMode={selection.contextMode}
         statusMessage={statusMessage}
         errorMessage={actionError ?? snapshot.error}
+        width={width}
       />
     </Box>
   );

--- a/server/tui/components/ContextPane.tsx
+++ b/server/tui/components/ContextPane.tsx
@@ -7,6 +7,7 @@ import { AskPane } from "./AskPane";
 import { RepoManagerPane } from "./RepoManagerPane";
 import { SettingsPane } from "./SettingsPane";
 import { color } from "../theme";
+import { truncateText } from "../viewModel";
 
 type ContextPaneProps = {
   mode: ContextMode;
@@ -29,34 +30,31 @@ const TABS: Array<{ key: ContextMode; label: string; hint: string }> = [
   { key: "settings", label: "settings", hint: "s" },
 ];
 
-function TabStrip(props: { mode: ContextMode; active: boolean }) {
+function formatTabLabel(tab: { key: ContextMode; label: string; hint: string }, activeMode: ContextMode): string {
+  if (tab.key === activeMode) {
+    return `[${tab.label}]`;
+  }
+
+  return `${tab.label}[${tab.hint}]`;
+}
+
+function TabStrip(props: { mode: ContextMode; active: boolean; width: number }) {
+  const tabLine = truncateText(
+    TABS.map((tab) => formatTabLabel(tab, props.mode)).join("  "),
+    props.width,
+  );
+
   return (
-    <Box>
-      {TABS.map((tab, index) => {
-        const isActive = tab.key === props.mode;
-        return (
-          <React.Fragment key={tab.key}>
-            {isActive ? (
-              <Text color={props.active ? color.accent : color.muted} inverse bold>
-                {` ${tab.label} `}
-              </Text>
-            ) : (
-              <Text color={color.muted}>
-                {` ${tab.label} `}
-                <Text dimColor>[{tab.hint}]</Text>
-              </Text>
-            )}
-            {index < TABS.length - 1 && <Text color={color.muted}> </Text>}
-          </React.Fragment>
-        );
-      })}
-    </Box>
+    <Text color={props.active ? color.accent : color.muted} bold={props.active} wrap="truncate-end">
+      {tabLine}
+    </Text>
   );
 }
 
 export function ContextPane(props: ContextPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
-  const innerHeight = Math.max(2, props.height - 5);
+  const innerWidth = Math.max(20, (props.width ?? 40) - 4);
+  const innerHeight = Math.max(2, (props.height ?? 12) - 5);
 
   return (
     <Box
@@ -72,9 +70,9 @@ export function ContextPane(props: ContextPaneProps) {
           Context
         </Text>
       </Box>
-      <TabStrip mode={props.mode} active={props.active} />
+      <TabStrip mode={props.mode} active={props.active} width={innerWidth} />
       <Box marginTop={1} flexDirection="column">
-        {props.mode === "logs" && <LogPane logs={props.logs} width={Math.max(20, (props.width ?? 40) - 4)} height={innerHeight} />}
+        {props.mode === "logs" && <LogPane logs={props.logs} width={innerWidth} height={innerHeight} />}
         {props.mode === "ask" && (
           <AskPane
             questions={props.questions}

--- a/server/tui/components/ContextPane.tsx
+++ b/server/tui/components/ContextPane.tsx
@@ -12,8 +12,8 @@ import { truncateText } from "../viewModel";
 type ContextPaneProps = {
   mode: ContextMode;
   active: boolean;
-  width?: number;
-  height?: number;
+  width: number;
+  height: number;
   logs: LogEntry[];
   questions: PRQuestion[];
   repos: string[];
@@ -53,8 +53,8 @@ function TabStrip(props: { mode: ContextMode; active: boolean; width: number }) 
 
 export function ContextPane(props: ContextPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
-  const innerWidth = Math.max(20, (props.width ?? 40) - 4);
-  const innerHeight = Math.max(2, (props.height ?? 12) - 5);
+  const innerWidth = Math.max(20, props.width - 4);
+  const innerHeight = Math.max(2, props.height - 5);
 
   return (
     <Box
@@ -78,7 +78,7 @@ export function ContextPane(props: ContextPaneProps) {
             questions={props.questions}
             inputMode={props.inputMode === "ask"}
             inputValue={props.inputValue}
-            width={props.width ?? 40}
+            width={props.width}
           />
         )}
         {props.mode === "repos" && (

--- a/server/tui/components/FeedbackList.tsx
+++ b/server/tui/components/FeedbackList.tsx
@@ -3,12 +3,13 @@ import { Box, Text } from "ink";
 import type { FeedbackItem } from "@shared/schema";
 import {
   formatFeedbackStatusLabel,
+  padDisplayText,
   middleTruncateText,
   truncateText,
   wrapText,
 } from "../viewModel";
 import { FeedbackActions } from "./FeedbackActions";
-import { color, feedbackGlyph, feedbackTone, glyph } from "../theme";
+import { color, feedbackGlyph, feedbackTone } from "../theme";
 
 type FeedbackListProps = {
   items: FeedbackItem[];
@@ -41,27 +42,29 @@ export function FeedbackList(props: FeedbackListProps) {
         const selected = index === props.selectedFeedbackIndex;
         const tone = feedbackTone(item.status);
         const statusLabel = formatFeedbackStatusLabel(item.status);
-        const availableMetadataWidth = Math.max(12, props.width - 2);
-        const authorBudget = Math.max(8, Math.min(18, Math.floor(availableMetadataWidth * 0.24)));
+        const rowWidth = Math.max(24, props.width - 2);
+        const authorBudget = Math.max(8, Math.min(18, Math.floor(rowWidth * 0.18)));
         const author = truncateText(item.author, authorBudget);
         const location = item.file ? `${item.file}${item.line ? `:${item.line}` : ""}` : "";
         const locationText = location
-          ? middleTruncateText(location, Math.max(10, Math.min(24, Math.floor(availableMetadataWidth * 0.34))))
+          ? middleTruncateText(location, Math.max(10, Math.min(24, Math.floor(rowWidth * 0.3))))
           : "";
-        const summary = truncateText(
-          [
-            `${feedbackGlyph(item.status)} ${statusLabel}`,
-            locationText,
-            author,
-            summarizeBody(item.body),
-          ].filter(Boolean).join(" │ "),
-          props.width - 2,
+        const statusText = `${feedbackGlyph(item.status)} ${statusLabel}`;
+        const primaryMeta = locationText || author || "comment";
+        const secondaryMeta = locationText && author ? author : "";
+        const statusWidth = Math.max(12, Math.min(15, Math.floor(rowWidth * 0.22)));
+        const metaWidth = Math.max(12, Math.min(24, Math.floor(rowWidth * 0.28)));
+        const detailsWidth = Math.max(8, rowWidth - statusWidth - metaWidth - 6);
+        const detailText = truncateText(
+          [secondaryMeta, summarizeBody(item.body)].filter(Boolean).join(" | "),
+          detailsWidth,
         );
+        const row = `${padDisplayText(statusText, statusWidth)} | ${padDisplayText(primaryMeta, metaWidth)} | ${detailText}`;
 
         return (
-          <Text key={item.id} color={selected ? color.accent : tone}>
-            {selected ? `${glyph.focus} ` : "  "}
-            {summary}
+          <Text key={item.id} color={selected ? color.accent : tone} wrap="truncate-end">
+            {selected ? "> " : "  "}
+            {row}
           </Text>
         );
       })}
@@ -87,7 +90,7 @@ export function FeedbackPreview(props: FeedbackPreviewProps) {
       `${feedbackGlyph(item.status)} ${statusLabel}`,
       metadataLocation,
       author,
-    ].filter(Boolean).join(` ${glyph.sep} `),
+    ].filter(Boolean).join(" | "),
     props.width,
   );
   const actionRowCount = props.expanded && props.active ? 1 : 0;
@@ -104,7 +107,7 @@ export function FeedbackPreview(props: FeedbackPreviewProps) {
 
   return (
     <Box flexDirection="column">
-      <Text color={tone}>{metadata}</Text>
+      <Text color={tone} wrap="truncate-end">{metadata}</Text>
       {visibleBodyLines.map((line, lineIndex) => (
         <Text key={`${item.id}-${lineIndex}`} color={color.muted}>
           {line}

--- a/server/tui/components/Footer.tsx
+++ b/server/tui/components/Footer.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { getFooterHints } from "../viewModel";
+import { getDisplayWidth, getFooterHints } from "../viewModel";
 import type { ContextMode } from "../useSelectionState";
 import { color, glyph } from "../theme";
+import { truncateText } from "../viewModel";
 
 type FooterProps = {
   contextMode: ContextMode;
   statusMessage: string | null;
   errorMessage: string | null;
+  width?: number;
 };
 
 export function Footer(props: FooterProps) {
@@ -15,30 +17,27 @@ export function Footer(props: FooterProps) {
   const statusTone = hasError ? color.err : props.statusMessage ? color.ok : color.muted;
   const statusText = props.errorMessage ?? props.statusMessage ?? "Ready";
   const hints = getFooterHints();
+  const innerWidth = Math.max(24, (props.width ?? 100) - 4);
+  const statusLabel = `${glyph.dot} ${statusText}`;
+  const statusWidth = Math.min(Math.max(10, getDisplayWidth(statusLabel)), Math.max(10, Math.floor(innerWidth * 0.28)));
+  const hintsWidth = Math.max(8, innerWidth - statusWidth - 3);
+  const hintLine = truncateText(
+    hints.map((hint) => `${hint.key} ${hint.label}`).join(" | "),
+    hintsWidth,
+  );
 
   return (
     <Box
-      justifyContent="space-between"
       borderStyle="round"
       borderColor={color.muted}
       paddingX={1}
+      width={props.width}
     >
-      <Box>
-        <Text color={statusTone}>{glyph.dot}</Text>
-        <Text> </Text>
-        <Text color={statusTone} bold={hasError}>
-          {statusText}
-        </Text>
-      </Box>
-      <Box>
-        {hints.map((hint, index) => (
-          <React.Fragment key={hint.key}>
-            <Text color={color.accent} inverse bold>{` ${hint.key} `}</Text>
-            <Text color={color.muted}>{` ${hint.label}`}</Text>
-            {index < hints.length - 1 && <Text color={color.muted}>{"  "}</Text>}
-          </React.Fragment>
-        ))}
-      </Box>
+      <Text color={statusTone} bold={hasError} wrap="truncate-end">
+        {truncateText(statusLabel, statusWidth)}
+      </Text>
+      <Text color={color.muted}> | </Text>
+      <Text color={color.muted} wrap="truncate-end">{hintLine}</Text>
     </Box>
   );
 }

--- a/server/tui/components/LogPane.tsx
+++ b/server/tui/components/LogPane.tsx
@@ -36,10 +36,10 @@ export function LogPane(props: { logs: LogEntry[]; width: number; height: number
         const prefix = `${formatTime(log.timestamp)} ${log.level.toUpperCase()}${phase ? ` ${phase}` : ""} `;
         const message = truncateText(log.message, Math.max(12, props.width - prefix.length));
         return (
-          <Text key={log.id}>
-            <Text color={color.muted}>{formatTime(log.timestamp)} </Text>
-            <Text color={tone} bold>{log.level.toUpperCase()}</Text>
-            {phase && <Text color={color.muted}> {phase}</Text>}
+        <Text key={log.id} wrap="truncate-end">
+          <Text color={color.muted}>{formatTime(log.timestamp)} </Text>
+          <Text color={tone} bold>{log.level.toUpperCase()}</Text>
+          {phase && <Text color={color.muted}> {phase}</Text>}
             <Text> {message}</Text>
           </Text>
         );

--- a/server/tui/components/PrDetailPane.tsx
+++ b/server/tui/components/PrDetailPane.tsx
@@ -24,7 +24,7 @@ type PrDetailPaneProps = {
 export function PrDetailPane(props: PrDetailPaneProps) {
   const borderColor = props.active ? color.accent : color.muted;
   const innerWidth = Math.max(24, (props.width ?? 80) - 4);
-  const contentHeight = Math.max(4, props.height - 4);
+  const contentHeight = Math.max(4, (props.height ?? 12) - 4);
 
   if (!props.pr) {
     return (

--- a/server/tui/components/PrListPane.tsx
+++ b/server/tui/components/PrListPane.tsx
@@ -54,7 +54,7 @@ function PrRow(props: { pr: PR; selected: boolean; width: number }) {
   );
 
   return (
-    <Text color={selected ? color.accent : prStatusTone(pr.status)} bold={selected}>
+    <Text color={selected ? color.accent : prStatusTone(pr.status)} bold={selected} wrap="truncate-end">
       {selected ? `${glyph.focus} ` : "  "}
       {summary}
     </Text>

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -289,7 +289,6 @@ export function wrapText(input: string, width: number): string[] {
 
       if (current) {
         lines.push(current);
-        current = "";
       }
 
       const chunks = pushWord(word);

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -272,7 +272,12 @@ export function wrapText(input: string, width: number): string[] {
       const chunks: string[] = [];
       let remaining = word;
       while (remaining) {
-        const chunk = takeDisplayWidth(remaining, width);
+        let chunk = takeDisplayWidth(remaining, width);
+        if (!chunk) {
+          // Width is too small to fit the first grapheme; consume it anyway
+          // so the loop always makes progress.
+          chunk = Array.from(remaining)[0]!;
+        }
         chunks.push(chunk);
         remaining = remaining.slice(chunk.length);
       }

--- a/server/tui/viewModel.ts
+++ b/server/tui/viewModel.ts
@@ -1,4 +1,5 @@
 import type { FeedbackItem, FeedbackStatus, PR } from "@shared/schema";
+import stringWidth from "string-width";
 
 export type LayoutMode = "full" | "stacked" | "compact-warning";
 export type ViewportRange = {
@@ -127,20 +128,69 @@ export function getFeedbackActions(item: FeedbackItem): string[] {
   return actions;
 }
 
+export function getDisplayWidth(input: string): number {
+  return stringWidth(input);
+}
+
+function takeDisplayWidth(input: string, max: number): string {
+  if (max <= 0 || !input) {
+    return "";
+  }
+
+  let output = "";
+  let width = 0;
+
+  for (const char of input) {
+    const charWidth = getDisplayWidth(char);
+    if (width + charWidth > max) {
+      break;
+    }
+
+    output += char;
+    width += charWidth;
+  }
+
+  return output;
+}
+
+function takeDisplayWidthFromEnd(input: string, max: number): string {
+  if (max <= 0 || !input) {
+    return "";
+  }
+
+  const chars = Array.from(input);
+  let output = "";
+  let width = 0;
+
+  for (let index = chars.length - 1; index >= 0; index -= 1) {
+    const char = chars[index]!;
+    const charWidth = getDisplayWidth(char);
+    if (width + charWidth > max) {
+      break;
+    }
+
+    output = `${char}${output}`;
+    width += charWidth;
+  }
+
+  return output;
+}
+
 export function truncateText(input: string, max: number): string {
   if (max <= 0) {
     return "";
   }
 
   if (max === 1) {
-    return input.slice(0, 1);
+    return takeDisplayWidth(input, 1);
   }
 
-  if (input.length <= max) {
+  if (getDisplayWidth(input) <= max) {
     return input;
   }
 
-  return `${input.slice(0, Math.max(1, max - 1))}…`;
+  const head = takeDisplayWidth(input, Math.max(1, max - 1));
+  return `${head}…`;
 }
 
 export function middleTruncateText(input: string, max: number): string {
@@ -152,13 +202,18 @@ export function middleTruncateText(input: string, max: number): string {
     return "…";
   }
 
-  if (input.length <= max) {
+  if (getDisplayWidth(input) <= max) {
     return input;
   }
 
   const head = Math.ceil((max - 1) / 2);
   const tail = Math.floor((max - 1) / 2);
-  return `${input.slice(0, head)}…${input.slice(input.length - tail)}`;
+  return `${takeDisplayWidth(input, head)}…${takeDisplayWidthFromEnd(input, tail)}`;
+}
+
+export function padDisplayText(input: string, width: number): string {
+  const fitted = truncateText(input, width);
+  return `${fitted}${" ".repeat(Math.max(0, width - getDisplayWidth(fitted)))}`;
 }
 
 export function getViewportRange(count: number, selectedIndex: number, visibleCount: number): ViewportRange {
@@ -206,22 +261,46 @@ export function wrapText(input: string, width: number): string[] {
       continue;
     }
 
-    let remaining = collapsed;
-    while (remaining.length > width) {
-      const candidate = remaining.slice(0, width + 1);
-      let breakAt = candidate.lastIndexOf(" ");
+    const words = collapsed.split(" ");
+    let current = "";
 
-      if (breakAt <= 0) {
-        breakAt = width;
+    const pushWord = (word: string) => {
+      if (getDisplayWidth(word) <= width) {
+        return [word];
       }
 
-      const chunk = remaining.slice(0, breakAt).trimEnd();
-      lines.push(chunk);
-      remaining = remaining.slice(breakAt).trimStart();
+      const chunks: string[] = [];
+      let remaining = word;
+      while (remaining) {
+        const chunk = takeDisplayWidth(remaining, width);
+        chunks.push(chunk);
+        remaining = remaining.slice(chunk.length);
+      }
+
+      return chunks;
+    };
+
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (getDisplayWidth(candidate) <= width) {
+        current = candidate;
+        continue;
+      }
+
+      if (current) {
+        lines.push(current);
+        current = "";
+      }
+
+      const chunks = pushWord(word);
+      for (let index = 0; index < chunks.length - 1; index += 1) {
+        lines.push(chunks[index]!);
+      }
+      current = chunks[chunks.length - 1] ?? "";
     }
 
-    if (remaining) {
-      lines.push(remaining);
+    if (current) {
+      lines.push(current);
     }
   }
 

--- a/server/tuiFeedback.test.tsx
+++ b/server/tuiFeedback.test.tsx
@@ -65,7 +65,7 @@ test("tui keeps long feedback collections inside a viewport and truncates long r
     await flush();
     assert.match(ui.lastFrame() ?? "", /3\/12/);
     assert.match(ui.lastFrame() ?? "", /↓9/);
-    assert.match(ui.lastFrame() ?? "", /frontend\/sr…/);
+    assert.match(ui.lastFrame() ?? "", /frontend\/…-0\.ts:1…/);
     assert.match(ui.lastFrame() ?? "", /…/);
 
     ui.stdin.write("\t");
@@ -77,7 +77,7 @@ test("tui keeps long feedback collections inside a viewport and truncates long r
     await flush();
 
     assert.match(ui.lastFrame() ?? "", /↑3/);
-    assert.match(ui.lastFrame() ?? "", /reviewer-4/);
+    assert.match(ui.lastFrame() ?? "", /Feedback item 4 body text/);
   } finally {
     ui.unmount();
   }

--- a/server/tuiViewModel.test.ts
+++ b/server/tuiViewModel.test.ts
@@ -156,3 +156,10 @@ test("wrapText hard-wraps long unbroken tokens", () => {
   const lines = wrapText("abcdefghijklmnopqrstuvwxyz", 8);
   assert.deepEqual(lines, ["abcdefgh", "ijklmnop", "qrstuvwx", "yz"]);
 });
+
+test("wrapText makes progress when width is narrower than a wide glyph", () => {
+  // A single wide CJK character has display width 2; requesting width 1 used
+  // to loop forever because takeDisplayWidth returned "" each iteration.
+  const lines = wrapText("漢字", 1);
+  assert.deepEqual(lines, ["漢", "字"]);
+});

--- a/server/tuiViewModel.test.ts
+++ b/server/tuiViewModel.test.ts
@@ -5,6 +5,7 @@ import {
   formatFeedbackStatusLabel,
   formatPrRow,
   formatStatusLabel,
+  getDisplayWidth,
   getFeedbackActions,
   getLayoutMode,
   getViewportRange,
@@ -117,6 +118,12 @@ test("formatFeedbackStatusLabel normalizes underscores", () => {
 test("truncate helpers keep the start or both ends visible", () => {
   assert.equal(truncateText("frontend/src/router/index.ts", 12), "frontend/sr…");
   assert.equal(middleTruncateText("abcdefghijklmnopqrstuvwxyz", 9), "abcd…wxyz");
+});
+
+test("truncate helpers honor terminal display width for wide glyphs", () => {
+  assert.equal(getDisplayWidth("❯ review"), 8);
+  assert.equal(truncateText("❯ review ready", 9), "❯ review…");
+  assert.equal(middleTruncateText("frontend/❯/component.ts", 12), "fronte…nt.ts");
 });
 
 test("getViewportRange keeps the selected row within the visible window", () => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,14 @@
 # Lessons Learned
 
+## 2026-04-16 - Diagnose Ink alignment bugs with rendered display width, not string length
+- Pattern: The user reported broken TUI alignment from a screenshot, and I initially investigated pane sizing before confirming the real drift came from wide-glyph truncation and fragmented `Text` rows wrapping unexpectedly.
+- Rule: For Ink/TUI alignment bugs, reproduce the rendered frame and audit truncation, padding, and wrapping with terminal display-width semantics before changing pane dimensions.
+- Prevention checklist:
+  - Render or inspect the actual terminal frame before assuming the problem is pane sizing.
+  - Use display-width-aware helpers for any truncation or padding path that can include wide glyphs or Unicode separators.
+  - Keep tab strips, log rows, and footer hints on explicitly truncated single lines instead of relying on default wrapping.
+  - Add a regression test that covers long metadata plus wide glyphs in the affected pane.
+
 ## 2026-04-16 - Surface requested onboarding guidance explicitly
 - Pattern: I cleaned up onboarding around checklist steps and install actions, but the user then had to ask for the multi-provider AI review tip and provider links to be shown explicitly during onboarding.
 - Rule: When onboarding touches a setup capability that depends on third-party providers, include the requested explanatory tip and concrete provider links in the onboarding UI instead of assuming buttons or inferred context are sufficient.


### PR DESCRIPTION
## Summary
- make terminal truncation, padding, and wrapping use display width so wide glyphs do not shift pane content
- keep feedback rows, context tabs, log rows, and footer hints on explicitly truncated single lines instead of fragmented wrapped text
- add regression coverage for long metadata and wide-glyph truncation, plus a lessons entry for future Ink alignment bugs

## Root Cause
The TUI was mixing JavaScript string-length truncation with Ink-rendered Unicode glyphs and fragmented Text nodes. That caused metadata columns and footer/tab content to wrap or drift even when the pane widths themselves were correct.

## Impact
The terminal UI now keeps the three-pane layout visually stable under long PR metadata and feedback rows, matching the broken screenshot case without changing the overall pane structure.

## Validation
- node --test --import tsx server/tuiApp.test.tsx server/tuiFeedback.test.tsx server/tuiOperatorFlows.test.tsx server/tuiViewModel.test.ts
- npm run check
