### PR TITLE
[codex] add dismissible update alert for oh-my-pr

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -23,6 +23,7 @@
    - [CI healing sessions](#ci-healing-sessions)
    - [Deployment healing sessions](#deployment-healing-sessions)
    - [Configuration](#configuration)
+   - [App updates](#app-updates)
    - [Agent models](#agent-models)
    - [Runtime & drain mode](#runtime--drain-mode)
    - [Social changelogs](#social-changelogs)
@@ -569,6 +570,43 @@ endpoint when changing the deployment-healing keys.
 
 ---
 
+### App updates
+
+#### `GET /api/app-update`
+
+Return the release-check result used by the dashboard update banner.
+
+The server reads the running app version from `APP_VERSION` and falls back to
+`"dev"` when unset. If the current version is a stable semver string, oh-my-pr
+checks the latest stable GitHub release for `yungookim/oh-my-pr`, ignores draft
+and prerelease releases, and compares the versions. If the current build is not
+semver or the GitHub release check fails, the endpoint returns a quiet fallback
+with `latestVersion: null`, the releases index URL, and `updateAvailable: false`.
+
+**Response** `200` — [AppUpdateStatus object](#appupdatestatus)
+
+**Example** `200` — newer release available
+```json
+{
+  "currentVersion": "1.0.0",
+  "latestVersion": "v1.1.0",
+  "latestReleaseUrl": "https://github.com/yungookim/oh-my-pr/releases/tag/v1.1.0",
+  "updateAvailable": true
+}
+```
+
+**Example** `200` — quiet fallback for a non-versioned build or failed check
+```json
+{
+  "currentVersion": "dev",
+  "latestVersion": null,
+  "latestReleaseUrl": "https://github.com/yungookim/oh-my-pr/releases",
+  "updateAvailable": false
+}
+```
+
+---
+
 ### Agent models
 
 #### `GET /api/agent-models`
@@ -851,6 +889,17 @@ Install the Code Factory code-review GitHub Actions workflow on a repository.
   watchedRepos: string[];
   trustedReviewers: string[];
   ignoredBots: string[];
+}
+```
+
+### AppUpdateStatus
+
+```typescript
+{
+  currentVersion: string;          // APP_VERSION or "dev"
+  latestVersion: string | null;    // latest stable GitHub release tag, e.g. "v1.1.0"
+  latestReleaseUrl: string;        // release page or releases index fallback
+  updateAvailable: boolean;        // true when latestVersion is newer than currentVersion
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Oh-my-pr babysits your PRs from your local machine, reads all PR comments and CI
 - Detect merge conflicts and optionally let the agent resolve them automatically.
 - Ask natural-language questions about any tracked PR from the dashboard or via MCP.
 - Configure trusted reviewers, ignored bots, polling, batching, run limits, and CI-healing retry budgets from settings.
+- Show a dashboard update banner for newer stable oh-my-pr releases, with a per-release dismissal that lasts for the current browser session.
 - Enable drain mode to stop claiming new queued work and optionally wait for active queue handlers to finish before deploys or upgrades.
 - Check onboarding status, install Claude or Codex review workflows, and generate social changelogs every 5 PRs merged to `main`.
 - Use the React dashboard, local REST API, MCP server, or optional Tauri desktop shell.

--- a/client/src/components/UpdateBanner.tsx
+++ b/client/src/components/UpdateBanner.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { AppUpdateStatus } from "@shared/schema";
+import {
+  APP_UPDATE_SESSION_STORAGE_KEY,
+  formatAppVersionLabel,
+  getAppUpdateDismissKey,
+  shouldShowAppUpdateBanner,
+} from "@/lib/updateAlert";
+
+export function UpdateBanner() {
+  const [dismissedKey, setDismissedKey] = useState<string | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return window.sessionStorage.getItem(APP_UPDATE_SESSION_STORAGE_KEY);
+  });
+
+  const { data: status } = useQuery<AppUpdateStatus>({
+    queryKey: ["/api/app-update"],
+  });
+
+  if (!status || !shouldShowAppUpdateBanner(status, dismissedKey)) {
+    return null;
+  }
+
+  const dismissalKey = getAppUpdateDismissKey(status);
+  if (!dismissalKey || !status.latestVersion) {
+    return null;
+  }
+
+  return (
+    <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/10">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-3 text-[12px]">
+          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+          <span className="font-medium uppercase tracking-wider text-amber-200">
+            Update available
+          </span>
+          <span className="text-muted-foreground">
+            {`oh-my-pr ${formatAppVersionLabel(status.latestVersion)} is available. You're on ${formatAppVersionLabel(status.currentVersion)}.`}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-[11px]">
+          <a
+            href={status.latestReleaseUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium uppercase tracking-wider text-amber-200 transition-colors hover:text-foreground"
+          >
+            Update oh-my-pr
+          </a>
+          <button
+            onClick={() => {
+              if (typeof window !== "undefined") {
+                window.sessionStorage.setItem(APP_UPDATE_SESSION_STORAGE_KEY, dismissalKey);
+              }
+              setDismissedKey(dismissalKey);
+            }}
+            className="uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          >
+            dismiss for now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/updateAlert.test.ts
+++ b/client/src/lib/updateAlert.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AppUpdateStatus } from "@shared/schema";
+import {
+  formatAppVersionLabel,
+  getAppUpdateDismissKey,
+  shouldShowAppUpdateBanner,
+} from "./updateAlert";
+
+const availableUpdate: AppUpdateStatus = {
+  currentVersion: "1.0.0",
+  latestVersion: "v1.1.0",
+  latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.1.0",
+  updateAvailable: true,
+};
+
+test("formatAppVersionLabel prefixes bare versions once", () => {
+  assert.equal(formatAppVersionLabel("1.0.0"), "v1.0.0");
+  assert.equal(formatAppVersionLabel("v1.0.0"), "v1.0.0");
+});
+
+test("shouldShowAppUpdateBanner stays visible until the current release is dismissed", () => {
+  assert.equal(shouldShowAppUpdateBanner(availableUpdate, null), true);
+  assert.equal(
+    shouldShowAppUpdateBanner(availableUpdate, getAppUpdateDismissKey(availableUpdate)),
+    false,
+  );
+});
+
+test("shouldShowAppUpdateBanner stays hidden when no update is available", () => {
+  assert.equal(
+    shouldShowAppUpdateBanner({
+      ...availableUpdate,
+      updateAvailable: false,
+    }, null),
+    false,
+  );
+});

--- a/client/src/lib/updateAlert.ts
+++ b/client/src/lib/updateAlert.ts
@@ -1,0 +1,23 @@
+import type { AppUpdateStatus } from "@shared/schema";
+
+export const APP_UPDATE_SESSION_STORAGE_KEY = "app-update-dismissed";
+
+export function formatAppVersionLabel(version: string): string {
+  return version.startsWith("v") ? version : `v${version}`;
+}
+
+export function getAppUpdateDismissKey(status: Pick<AppUpdateStatus, "latestVersion">): string | null {
+  return status.latestVersion ? `app-update:${status.latestVersion}` : null;
+}
+
+export function shouldShowAppUpdateBanner(
+  status: AppUpdateStatus | null | undefined,
+  dismissedKey: string | null,
+): boolean {
+  if (!status?.updateAvailable) {
+    return false;
+  }
+
+  const dismissalKey = getAppUpdateDismissKey(status);
+  return dismissalKey !== null && dismissalKey !== dismissedKey;
+}

--- a/client/src/pages/changelogs.tsx
+++ b/client/src/pages/changelogs.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import type { SocialChangelog } from "@shared/schema";
+import { UpdateBanner } from "@/components/UpdateBanner";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -156,6 +157,7 @@ export default function Changelogs() {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
+      <UpdateBanner />
       {/* Header */}
       <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
         <div className="flex items-center gap-3">

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -6,6 +6,7 @@ import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
 import type { Config, FeedbackItem, HealingSession, LogEntry, PR, PRQuestion, WatchedRepo } from "@shared/schema";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
+import { UpdateBanner } from "@/components/UpdateBanner";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -833,6 +834,7 @@ export default function Dashboard() {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
+      <UpdateBanner />
       <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
         <div className="flex items-center gap-3">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-label="PR Feedback Agent">

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import type { ReleaseRun } from "@shared/schema";
 
@@ -257,6 +258,7 @@ export default function Releases() {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
+      <UpdateBanner />
       <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
         <div className="flex items-center gap-3">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-label="Release Management">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import type { Config } from "@shared/schema";
+import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import { Link } from "wouter";
 
@@ -30,6 +31,7 @@ export default function Settings() {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
+      <UpdateBanner />
       <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
         <div className="flex items-center gap-3">
           <Link href="/" className="text-[11px] text-muted-foreground hover:text-foreground">

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -250,6 +250,17 @@
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>
 <li><strong>Theme</strong> — Toggle between light and dark mode.</li>
 </ul>
+<h2>App Update Banner</h2>
+<p>On builds where <code>APP_VERSION</code> is a stable semver string, the dashboard calls
+<code>GET /api/app-update</code> and compares the running version to the latest stable
+GitHub release for <code>yungookim/oh-my-pr</code>. When a newer release exists, the
+dashboard shows an update banner with a link to the matching release page.</p>
+<p>Selecting <code>dismiss for now</code> stores a release-scoped key in browser
+<code>sessionStorage</code>, so the banner stays hidden only for the current browser
+session and only for that specific <code>latestVersion</code>. Opening a new browser
+session or publishing a newer release makes the banner eligible to appear
+again. If the app is running a non-semver build such as <code>dev</code>, or if the
+release check fails, the banner stays hidden and the API falls back quietly.</p>
 <h2>PR Comment Branding</h2>
 <p>Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, echoed <code>/codefactory</code> agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr. Each comment references the app name and, by default, appends a <code>Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)</code> footer that links back to this repository.</p>
 <table>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -60,6 +60,20 @@ The settings page in the dashboard provides a UI for:
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
 - **Theme** — Toggle between light and dark mode.
 
+## App Update Banner
+
+On builds where `APP_VERSION` is a stable semver string, the dashboard calls
+`GET /api/app-update` and compares the running version to the latest stable
+GitHub release for `yungookim/oh-my-pr`. When a newer release exists, the
+dashboard shows an update banner with a link to the matching release page.
+
+Selecting `dismiss for now` stores a release-scoped key in browser
+`sessionStorage`, so the banner stays hidden only for the current browser
+session and only for that specific `latestVersion`. Opening a new browser
+session or publishing a newer release makes the banner eligible to appear
+again. If the app is running a non-semver build such as `dev`, or if the
+release check fails, the banner stays hidden and the API falls back quietly.
+
 ## PR Comment Branding
 
 Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, echoed `/codefactory` agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr. Each comment references the app name and, by default, appends a `Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)` footer that links back to this repository.

--- a/server/appUpdate.test.ts
+++ b/server/appUpdate.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchAppUpdateStatus } from "./appUpdate";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+test("fetchAppUpdateStatus reports a newer stable release", async () => {
+  const status = await fetchAppUpdateStatus("1.0.0", async () =>
+    jsonResponse(200, {
+      tag_name: "v1.2.0",
+      html_url: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.2.0",
+    }),
+  );
+
+  assert.deepEqual(status, {
+    currentVersion: "1.0.0",
+    latestVersion: "v1.2.0",
+    latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.2.0",
+    updateAvailable: true,
+  });
+});
+
+test("fetchAppUpdateStatus skips network checks for non-semver builds", async () => {
+  let called = false;
+
+  const status = await fetchAppUpdateStatus("dev", async () => {
+    called = true;
+    return jsonResponse(200, {
+      tag_name: "v9.9.9",
+      html_url: "https://github.com/yungookim/oh-my-pr/releases/tag/v9.9.9",
+    });
+  });
+
+  assert.equal(called, false);
+  assert.deepEqual(status, {
+    currentVersion: "dev",
+    latestVersion: null,
+    latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases",
+    updateAvailable: false,
+  });
+});
+
+test("fetchAppUpdateStatus falls back quietly when the release check fails", async () => {
+  const status = await fetchAppUpdateStatus("1.0.0", async () => {
+    throw new Error("network down");
+  });
+
+  assert.deepEqual(status, {
+    currentVersion: "1.0.0",
+    latestVersion: null,
+    latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases",
+    updateAvailable: false,
+  });
+});

--- a/server/appUpdate.test.ts
+++ b/server/appUpdate.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fetchAppUpdateStatus } from "./appUpdate";
+import { createAppUpdateChecker, fetchAppUpdateStatus } from "./appUpdate";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -58,4 +58,72 @@ test("fetchAppUpdateStatus falls back quietly when the release check fails", asy
     latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases",
     updateAvailable: false,
   });
+});
+
+test("createAppUpdateChecker caches update status until the ttl expires", async () => {
+  let fetchCalls = 0;
+  let nowMs = 1_000;
+  const checker = createAppUpdateChecker(
+    async () => {
+      fetchCalls += 1;
+      const version = `v1.${fetchCalls}.0`;
+
+      return jsonResponse(200, {
+        tag_name: version,
+        html_url: `https://github.com/yungookim/oh-my-pr/releases/tag/${version}`,
+      });
+    },
+    {
+      cacheTtlMs: 5_000,
+      now: () => nowMs,
+    },
+  );
+
+  const first = await checker("1.0.0");
+  const second = await checker("1.0.0");
+
+  assert.equal(fetchCalls, 1);
+  assert.deepEqual(second, first);
+
+  nowMs += 4_999;
+  const stillCached = await checker("1.0.0");
+  assert.equal(fetchCalls, 1);
+  assert.deepEqual(stillCached, first);
+
+  nowMs += 2;
+  const refreshed = await checker("1.0.0");
+  assert.equal(fetchCalls, 2);
+  assert.deepEqual(refreshed, {
+    currentVersion: "1.0.0",
+    latestVersion: "v1.2.0",
+    latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.2.0",
+    updateAvailable: true,
+  });
+});
+
+test("createAppUpdateChecker deduplicates concurrent release checks", async () => {
+  let fetchCalls = 0;
+  let resolveFetch: ((response: Response) => void) | undefined;
+  const checker = createAppUpdateChecker(async () => {
+    fetchCalls += 1;
+
+    return await new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+  });
+
+  const firstRequest = checker("1.0.0");
+  const secondRequest = checker("1.0.0");
+
+  assert.equal(fetchCalls, 1);
+
+  resolveFetch?.(jsonResponse(200, {
+    tag_name: "v1.1.0",
+    html_url: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.1.0",
+  }));
+
+  const [first, second] = await Promise.all([firstRequest, secondRequest]);
+
+  assert.deepEqual(first, second);
+  assert.equal(fetchCalls, 1);
 });

--- a/server/appUpdate.ts
+++ b/server/appUpdate.ts
@@ -14,6 +14,17 @@ type GitHubLatestReleaseResponse = {
 };
 
 export type AppUpdateChecker = (currentVersion: string) => Promise<AppUpdateStatus>;
+type AppUpdateCheckerOptions = {
+  cacheTtlMs?: number;
+  now?: () => number;
+};
+
+type CachedAppUpdateStatus = {
+  status: AppUpdateStatus;
+  expiresAt: number;
+};
+
+export const APP_UPDATE_CACHE_TTL_MS = 60 * 60 * 1000;
 
 function compareSemverTags(left: string, right: string): number {
   const leftVersion = parseSemverTag(left);
@@ -84,6 +95,41 @@ export async function fetchAppUpdateStatus(
   }
 }
 
-export function createAppUpdateChecker(fetchImpl: FetchLike = fetch): AppUpdateChecker {
-  return (currentVersion: string) => fetchAppUpdateStatus(currentVersion, fetchImpl);
+export function createAppUpdateChecker(
+  fetchImpl: FetchLike = fetch,
+  options: AppUpdateCheckerOptions = {},
+): AppUpdateChecker {
+  const cacheTtlMs = options.cacheTtlMs ?? APP_UPDATE_CACHE_TTL_MS;
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, CachedAppUpdateStatus>();
+  const inFlight = new Map<string, Promise<AppUpdateStatus>>();
+
+  return async (currentVersion: string) => {
+    const cacheKey = currentVersion.trim();
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expiresAt > now()) {
+      return cached.status;
+    }
+
+    const pendingRequest = inFlight.get(cacheKey);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    // Deduplicate concurrent checks so bursts still consume a single GitHub API call.
+    const request = fetchAppUpdateStatus(cacheKey, fetchImpl).then((status) => {
+      cache.set(cacheKey, {
+        status,
+        expiresAt: now() + cacheTtlMs,
+      });
+      inFlight.delete(cacheKey);
+      return status;
+    }, (error: unknown) => {
+      inFlight.delete(cacheKey);
+      throw error;
+    });
+
+    inFlight.set(cacheKey, request);
+    return request;
+  };
 }

--- a/server/appUpdate.ts
+++ b/server/appUpdate.ts
@@ -1,0 +1,89 @@
+import type { AppUpdateStatus } from "@shared/schema";
+import { parseSemverTag } from "./github";
+
+const GITHUB_RELEASES_URL = "https://github.com/yungookim/oh-my-pr/releases";
+const GITHUB_LATEST_RELEASE_API_URL = "https://api.github.com/repos/yungookim/oh-my-pr/releases/latest";
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type GitHubLatestReleaseResponse = {
+  tag_name?: string | null;
+  html_url?: string | null;
+  draft?: boolean;
+  prerelease?: boolean;
+};
+
+export type AppUpdateChecker = (currentVersion: string) => Promise<AppUpdateStatus>;
+
+function compareSemverTags(left: string, right: string): number {
+  const leftVersion = parseSemverTag(left);
+  const rightVersion = parseSemverTag(right);
+
+  if (!leftVersion || !rightVersion) {
+    return 0;
+  }
+
+  if (leftVersion.major !== rightVersion.major) {
+    return leftVersion.major - rightVersion.major;
+  }
+
+  if (leftVersion.minor !== rightVersion.minor) {
+    return leftVersion.minor - rightVersion.minor;
+  }
+
+  return leftVersion.patch - rightVersion.patch;
+}
+
+function createFallbackStatus(currentVersion: string): AppUpdateStatus {
+  return {
+    currentVersion,
+    latestVersion: null,
+    latestReleaseUrl: GITHUB_RELEASES_URL,
+    updateAvailable: false,
+  };
+}
+
+export async function fetchAppUpdateStatus(
+  currentVersion: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<AppUpdateStatus> {
+  const trimmedCurrentVersion = currentVersion.trim();
+  const fallback = createFallbackStatus(trimmedCurrentVersion);
+
+  if (!parseSemverTag(trimmedCurrentVersion)) {
+    return fallback;
+  }
+
+  try {
+    const response = await fetchImpl(GITHUB_LATEST_RELEASE_API_URL, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": `oh-my-pr/${trimmedCurrentVersion}`,
+      },
+    });
+
+    if (!response.ok) {
+      return fallback;
+    }
+
+    const payload = await response.json() as GitHubLatestReleaseResponse;
+    const latestVersion = payload.tag_name?.trim() ?? null;
+
+    if (payload.draft || payload.prerelease || !latestVersion || !parseSemverTag(latestVersion)) {
+      return fallback;
+    }
+
+    return {
+      currentVersion: trimmedCurrentVersion,
+      latestVersion,
+      latestReleaseUrl: payload.html_url?.trim() || GITHUB_RELEASES_URL,
+      updateAvailable: compareSemverTags(latestVersion, trimmedCurrentVersion) > 0,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export function createAppUpdateChecker(fetchImpl: FetchLike = fetch): AppUpdateChecker {
+  return (currentVersion: string) => fetchAppUpdateStatus(currentVersion, fetchImpl);
+}

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import test from "node:test";
 import express from "express";
-import type { NewPR } from "@shared/schema";
+import type { AppUpdateStatus, NewPR } from "@shared/schema";
 import { MemStorage } from "./memoryStorage";
+import type { RouteDependencies } from "./routes";
 import { registerRoutes } from "./routes";
 
 async function seedPR(storage: MemStorage, overrides: Partial<NewPR> = {}) {
@@ -26,7 +27,7 @@ async function seedPR(storage: MemStorage, overrides: Partial<NewPR> = {}) {
   });
 }
 
-async function createHarness(storage = new MemStorage()) {
+async function createHarness(storage = new MemStorage(), dependencies: Partial<RouteDependencies> = {}) {
   const app = express();
   app.use(express.json());
 
@@ -35,6 +36,7 @@ async function createHarness(storage = new MemStorage()) {
     storage,
     startBackgroundServices: false,
     startWatcher: false,
+    ...dependencies,
   });
 
   await new Promise<void>((resolve) => {
@@ -190,6 +192,33 @@ test("GET/PATCH /api/repos/settings exposes repo-level release settings", async 
       autoCreateReleases: false,
     });
   } finally {
+    await harness.close();
+  }
+});
+
+test("GET /api/app-update exposes the app update check result", async () => {
+  const originalVersion = process.env.APP_VERSION;
+  process.env.APP_VERSION = "1.0.0";
+  const expected: AppUpdateStatus = {
+    currentVersion: "1.0.0",
+    latestVersion: "v1.1.0",
+    latestReleaseUrl: "https://github.com/yungookim/oh-my-pr/releases/tag/v1.1.0",
+    updateAvailable: true,
+  };
+  const harness = await createHarness(new MemStorage(), {
+    appUpdateChecker: async (currentVersion) => ({
+      ...expected,
+      currentVersion,
+    }),
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/app-update`);
+    assert.equal(response.status, 200);
+    const payload = await response.json() as AppUpdateStatus;
+    assert.deepEqual(payload, expected);
+  } finally {
+    process.env.APP_VERSION = originalVersion;
     await harness.close();
   }
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,6 +8,7 @@ import {
   type AppRuntimeDependencies,
   isAppRuntimeError,
 } from "./appRuntime";
+import { createAppUpdateChecker, type AppUpdateChecker } from "./appUpdate";
 import { GitHubIntegrationError } from "./github";
 
 function getErrorMessage(error: unknown): string {
@@ -42,6 +43,7 @@ function maskConfig<T extends { githubToken: string }>(config: T): T {
 
 export type RouteDependencies = AppRuntimeDependencies & {
   runtime?: AppRuntime;
+  appUpdateChecker?: AppUpdateChecker;
 };
 
 export async function registerRoutes(
@@ -50,6 +52,7 @@ export async function registerRoutes(
   dependencies: RouteDependencies = {},
 ): Promise<Server> {
   const runtime = dependencies.runtime ?? createAppRuntime(dependencies);
+  const appUpdateChecker = dependencies.appUpdateChecker ?? createAppUpdateChecker();
   await runtime.start();
 
   httpServer.on("close", () => {
@@ -288,6 +291,15 @@ export async function registerRoutes(
 
   app.get("/api/config", async (_req, res) => {
     res.json(maskConfig(await runtime.getConfig()));
+  });
+
+  app.get("/api/app-update", async (_req, res) => {
+    try {
+      const currentVersion = process.env.APP_VERSION || "dev";
+      res.json(await appUpdateChecker(currentVersion));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
   });
 
   app.get("/api/changelogs", async (_req, res) => {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -421,3 +421,11 @@ export const watchedRepoSchema = z.object({
   autoCreateReleases: z.boolean(),
 });
 export type WatchedRepo = z.infer<typeof watchedRepoSchema>;
+
+export const appUpdateStatusSchema = z.object({
+  currentVersion: z.string(),
+  latestVersion: z.string().nullable(),
+  latestReleaseUrl: z.string(),
+  updateAvailable: z.boolean(),
+});
+export type AppUpdateStatus = z.infer<typeof appUpdateStatusSchema>;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-04-20 - Nail alert persistence and dismissal scope before shipping update notices
+- Pattern: I started toward a generic update alert before confirming whether the user wanted a one-time toast or a persistent banner with temporary dismissal.
+- Rule: When adding user-facing alerts or notices, confirm the persistence model and dismissal lifetime before implementation.
+- Prevention checklist:
+  - Classify each new alert as toast, session banner, or durable setting-backed notice before editing code.
+  - Ask whether dismissal should last for the current session, until the next version/change, or permanently.
+  - Keep the implementation aligned with the narrowest scope the user requested instead of defaulting to a broader persistence model.
+
 ## 2026-04-16 - Make visible automation/comment behavior user-configurable when reasonable
 - Pattern: I implemented repository-linked GitHub PR comment branding as always-on behavior, then the user corrected the requirement to allow turning it off in Settings.
 - Rule: When adding visible automation output behavior that changes how the product speaks on a user's behalf, decide before closing whether it should be user-configurable.


### PR DESCRIPTION
## Summary
- add a server-backed app update check against the latest stable oh-my-pr GitHub release
- show a persistent update banner on the main app pages with a session-scoped "dismiss for now" action
- cover the update-check API and banner visibility helpers with tests

## Root cause
The app surfaced no in-product notice when a newer oh-my-pr release was available, so users had no prompt to update.

## Validation
- npm run check
- node --import tsx --test server/appUpdate.test.ts client/src/lib/updateAlert.test.ts
- node --import tsx --test server/routes.test.ts
- npm run build

## Notes
- `/simplify` could not be run because the local Claude CLI was rate-limited during PR preparation.