### PR TITLE
[codex] Add own-PR watch scope

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -198,8 +198,8 @@ compiled output instead:
 
 | Tool name | Description |
 |-----------|-------------|
-| `list_repos` | List all watched repositories |
-| `add_repo` | Add a repo to the watch list |
+| `list_repos` | List watched repositories plus repos inferred from tracked PRs |
+| `add_repo` | Add a repo to the watch list (defaults to `My PRs only` discovery) |
 | `sync_repos` | Queue an immediate durable sync across all watched repos |
 | `list_prs` | List all tracked pull requests |
 | `list_archived_prs` | List archived (closed/merged) PRs |
@@ -247,11 +247,26 @@ Use `PATCH /api/config` to change `autoHealDeployments`,
 #### `GET /api/repos`
 
 Returns the union of explicitly watched repos and repos inferred from tracked PRs.
+Use `GET /api/repos/settings` when you need per-repo settings such as
+`ownPrsOnly`.
 
 **Response** `200`
 ```json
 ["owner/repo-a", "owner/repo-b"]
 ```
+
+---
+
+#### `GET /api/repos/settings`
+
+Returns repo-level settings for explicitly watched repos plus any repos inferred
+from currently tracked PRs.
+
+`ownPrsOnly: true` means the watcher auto-discovers only PRs authored by the
+authenticated GitHub user for that repo. `ownPrsOnly: false` enables team-wide
+discovery and auto-discovers all open PRs in the repo.
+
+**Response** `200` — array of [WatchedRepo objects](#watchedrepo)
 
 ---
 
@@ -265,10 +280,38 @@ Add a repository to the watch list.
 ```
 Accepts `"owner/repo"` slugs or full `https://github.com/owner/repo` URLs.
 
+New watched repos default to `ownPrsOnly: true` (`My PRs only`). To switch a
+repo to team-wide discovery, call `PATCH /api/repos/settings` after adding it.
+
 **Response** `201`
 ```json
 { "repo": "owner/repo" }
 ```
+
+---
+
+#### `PATCH /api/repos/settings`
+
+Update repo-level settings.
+
+`ownPrsOnly: true` keeps auto-discovery limited to PRs authored by the
+authenticated GitHub user. `ownPrsOnly: false` switches the repo to team-wide
+auto-discovery. Changing this setting does not remove PRs that were already
+tracked directly by URL.
+
+**Body**
+```json
+{
+  "repo": "owner/repo",
+  "ownPrsOnly": false,
+  "autoCreateReleases": true
+}
+```
+
+Provide `repo` plus one or both of `ownPrsOnly` and `autoCreateReleases`.
+
+**Response** `200` — updated [WatchedRepo object](#watchedrepo)
+**Response** `400` — invalid body or no settings provided
 
 ---
 
@@ -316,6 +359,9 @@ Get a single PR by its internal Code Factory ID.
 
 Register a GitHub PR by URL. Code Factory fetches the PR summary from GitHub,
 stores it, and queues an initial durable babysit run.
+
+This direct registration path is independent of watched-repo discovery scope,
+so the PR stays tracked even if its repo is configured as `ownPrsOnly: true`.
 
 **Body**
 ```json
@@ -851,6 +897,16 @@ Install the Code Factory code-review GitHub Actions workflow on a repository.
   watchedRepos: string[];
   trustedReviewers: string[];
   ignoredBots: string[];
+}
+```
+
+### WatchedRepo
+
+```typescript
+{
+  repo: string;               // "owner/repo"
+  autoCreateReleases: boolean;
+  ownPrsOnly: boolean;        // true => only auto-discover the authenticated user's PRs
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Oh-my-pr babysits your PRs from your local machine, reads all PR comments and CI
 
 ## Features
 
-- Watch multiple repositories or add a single PR by URL.
-- Auto-register open PRs, archive closed or merged PRs, and keep syncing review activity.
+- Watch multiple repositories with a per-repo auto-discovery scope (`My PRs only` by default, or `My PRs + teammates`) or add a single PR by URL.
+- Auto-register matching open PRs from watched repos, archive closed or merged PRs, and keep syncing review activity.
 - Pause background automation for an individual tracked PR while keeping manual runs available.
 - Store PR state, background jobs, questions, release runs, logs, and social changelogs in SQLite with mirrored log files.
 - Queue repo sync, babysit/apply runs, PR questions, release processing, deployment healing, and social changelog generation in a durable SQLite-backed dispatcher that survives restarts.
@@ -37,13 +37,15 @@ Oh-my-pr babysits your PRs from your local machine, reads all PR comments and CI
 
 ## How It Works
 
-1. Add a repository to the watch list or register a PR directly by URL.
+1. Add a repository to the watch list or register a PR directly by URL. Watched repos default to `My PRs only`, and you can switch a repo to `My PRs + teammates` when you want team-wide discovery.
 2. The watcher enqueues a durable repo-sync job in SQLite.
-3. That sync job polls GitHub, auto-registers open PRs, syncs reviews and comments, archives PRs that closed upstream, records failing CI on the current head SHA, and queues babysitter runs for tracked PRs whose background watch is enabled.
+3. That sync job polls GitHub, auto-registers matching open PRs for each watched repo based on its watch scope, syncs reviews and comments, archives PRs that closed upstream, records failing CI on the current head SHA, and queues babysitter runs for tracked PRs whose background watch is enabled.
 4. Manual apply/babysit requests, PR questions, release processing, and social changelog generation go through the same durable queue before work executes in an app-owned repo cache and isolated git worktree under `~/.oh-my-pr`.
 5. The agent applies fixes, verifies the result, pushes to the PR branch, updates GitHub threads, and writes logs for the full run.
 
 Repo sync, babysit/apply, PR Q&A, release processing, deployment healing, and social changelog generation all run through durable background jobs stored in `state.sqlite`. On startup the dispatcher reclaims expired job leases, and interrupted babysitter runs are resumed from stored run context when possible.
+
+PRs you register directly by URL stay tracked regardless of the watched repo's auto-discovery scope.
 
 ## CI Healing
 

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -90,8 +90,8 @@ export function getOnboardingPanelState(status: OnboardingStatus) {
       id: "repo",
       title: "Track your first repository or PR",
       description: accessibleRepos.length > 0
-        ? `Watching ${accessibleRepos.length} accessible repo${accessibleRepos.length === 1 ? "" : "s"}.`
-        : "Use the Add PR or Watch form below. Adding a PR also adds its repository to the watch list.",
+        ? `Watching ${accessibleRepos.length} accessible repo${accessibleRepos.length === 1 ? "" : "s"}. Choose per repo whether to track only your PRs or your whole team.`
+        : "Use the Add PR or Watch form below. Adding a PR also adds its repository to the watch list, and watched repos let you choose whether to track only your PRs or the whole team.",
       complete: accessibleRepos.length > 0,
     },
     {
@@ -296,7 +296,7 @@ export function OnboardingPanel() {
 
                 {step.id === "repo" && !step.complete && (
                   <div className="pt-1 text-[12px] text-muted-foreground">
-                    The left sidebar is the real entry point. Use <span className="text-foreground">Add</span> for a PR URL or <span className="text-foreground">Watch</span> for an <InlineCode>owner/repo</InlineCode> slug.
+                    The left sidebar is the real entry point. Use <span className="text-foreground">Add</span> for a PR URL or <span className="text-foreground">Watch</span> for an <InlineCode>owner/repo</InlineCode> slug, then choose whether that watched repo should track only your PRs or your whole team.
                   </div>
                 )}
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -57,6 +57,25 @@ function formatPollInterval(pollIntervalMs?: number): string {
   return `${seconds}s`;
 }
 
+const WATCH_SCOPE_OPTIONS = [
+  { value: "mine", label: "My PRs only" },
+  { value: "team", label: "My PRs + teammates" },
+] as const;
+
+type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
+type RepoSettings = WatchedRepo & {
+  ownPrsOnly?: boolean;
+};
+type RepoSettingsUpdate = {
+  repo: string;
+  autoCreateReleases?: boolean;
+  ownPrsOnly?: boolean;
+};
+
+function getWatchScope(ownPrsOnly?: boolean): WatchScope {
+  return ownPrsOnly === false ? "team" : "mine";
+}
+
 const HEALING_TONE_CLASSES: Record<"neutral" | "info" | "warning" | "success" | "danger", string> = {
   neutral: "border-border text-muted-foreground",
   info: "border-foreground text-foreground",
@@ -89,6 +108,58 @@ function WatchPausedIndicator() {
     <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
       watch paused
     </span>
+  );
+}
+
+function WatchScopeControl({
+  value,
+  onChange,
+  disabled,
+  name,
+  testIdPrefix,
+  compact = false,
+}: {
+  value: WatchScope;
+  onChange: (value: WatchScope) => void;
+  disabled?: boolean;
+  name: string;
+  testIdPrefix: string;
+  compact?: boolean;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Automatic PR tracking scope"
+      className={`flex flex-wrap gap-1 ${compact ? "" : "mt-1"}`}
+    >
+      {WATCH_SCOPE_OPTIONS.map((option) => {
+        const active = value === option.value;
+        return (
+          <label
+            key={option.value}
+            data-testid={`${testIdPrefix}-${option.value}`}
+            className={`cursor-pointer border px-2 text-[10px] transition-colors ${
+              compact ? "py-0.5" : "py-1"
+            } ${
+              active
+                ? "border-foreground bg-muted text-foreground"
+                : "border-border text-muted-foreground hover:text-foreground"
+            } ${disabled ? "cursor-not-allowed opacity-50" : ""} whitespace-nowrap`}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={active}
+              onChange={() => onChange(option.value)}
+              disabled={disabled}
+              className="sr-only"
+            />
+            {option.label}
+          </label>
+        );
+      })}
+    </div>
   );
 }
 
@@ -671,6 +742,7 @@ export default function Dashboard() {
   const [selectedPRId, setSelectedPRId] = useState<string | null>(null);
   const [addUrl, setAddUrl] = useState("");
   const [addRepo, setAddRepo] = useState("");
+  const [watchScope, setWatchScope] = useState<WatchScope>("mine");
   const [viewMode, setViewMode] = useState<"active" | "archived">("active");
 
   const { data: prs = [], isLoading } = useQuery<PR[]>({
@@ -694,7 +766,7 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
-  const { data: repos = [] } = useQuery<WatchedRepo[]>({
+  const { data: repos = [] } = useQuery<RepoSettings[]>({
     queryKey: ["/api/repos/settings"],
     refetchInterval: 5000,
   });
@@ -793,41 +865,48 @@ export default function Dashboard() {
     },
   });
 
+  const updateRepoSettingsRequest = async (updates: RepoSettingsUpdate) => {
+    const res = await apiRequest("PATCH", "/api/repos/settings", updates);
+    return res.json();
+  };
+
+  const updateRepoSettingsMutation = useMutation({
+    mutationFn: updateRepoSettingsRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not update repository settings", error);
+    },
+  });
+
   const addRepoMutation = useMutation({
-    mutationFn: async (repo: string) => {
+    mutationFn: async ({ repo }: { repo: string; watchScope: WatchScope }) => {
       const res = await apiRequest("POST", "/api/repos", { repo });
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: async (data: { repo: string }, variables) => {
       queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
       queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
       setAddRepo("");
+      setWatchScope("mine");
+
+      if (variables.watchScope === "team") {
+        try {
+          await updateRepoSettingsRequest({
+            repo: data.repo,
+            ownPrsOnly: false,
+          });
+          queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
+        } catch (error) {
+          showMutationError("Repository added, but could not update tracking scope", error);
+        }
+      }
     },
     onError: (error) => {
       showMutationError("Could not watch repository", error);
-    },
-  });
-
-  const updateRepoSettingsMutation = useMutation({
-    mutationFn: async ({
-      repo,
-      autoCreateReleases,
-    }: {
-      repo: string;
-      autoCreateReleases: boolean;
-    }) => {
-      const res = await apiRequest("PATCH", "/api/repos/settings", {
-        repo,
-        autoCreateReleases,
-      });
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
-    },
-    onError: (error) => {
-      showMutationError("Could not update repository settings", error);
     },
   });
 
@@ -980,7 +1059,10 @@ export default function Dashboard() {
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
-                  if (addRepo.trim()) addRepoMutation.mutate(addRepo.trim());
+                  const repo = addRepo.trim();
+                  if (repo) {
+                    addRepoMutation.mutate({ repo, watchScope });
+                  }
                 }}
                 className="border-b border-border p-3"
               >
@@ -1001,6 +1083,18 @@ export default function Dashboard() {
                   >
                     Watch
                   </button>
+                </div>
+                <div className="mt-3">
+                  <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Track automatically
+                  </div>
+                  <WatchScopeControl
+                    value={watchScope}
+                    onChange={setWatchScope}
+                    disabled={addRepoMutation.isPending}
+                    name="watch-scope"
+                    testIdPrefix="watch-scope"
+                  />
                 </div>
                 <div className="mt-3">
                   <div className="mb-1 flex items-center justify-between">
@@ -1024,7 +1118,7 @@ export default function Dashboard() {
                       {repos.map((repo) => (
                         <div
                           key={repo.repo}
-                          className="flex items-center justify-between gap-3 border border-border/60 px-2 py-1.5"
+                          className="space-y-2 border border-border/60 px-2 py-2"
                         >
                           <a
                             href={getRepoHref(repo.repo)}
@@ -1035,22 +1129,42 @@ export default function Dashboard() {
                           >
                             {repo.repo}
                           </a>
-                          <label className="flex shrink-0 items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                            <input
-                              type="checkbox"
-                              checked={repo.autoCreateReleases}
-                              onChange={(e) =>
-                                updateRepoSettingsMutation.mutate({
-                                  repo: repo.repo,
-                                  autoCreateReleases: e.target.checked,
-                                })
-                              }
-                              disabled={updateRepoSettingsMutation.isPending}
-                              data-testid={`tracked-repo-auto-release-${repo.repo.replace("/", "-")}`}
-                              className="accent-foreground"
-                            />
-                            Auto-release
-                          </label>
+                          <div className="flex flex-wrap items-start justify-between gap-2">
+                            <div>
+                              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                Track automatically
+                              </div>
+                              <WatchScopeControl
+                                value={getWatchScope(repo.ownPrsOnly)}
+                                onChange={(value) =>
+                                  updateRepoSettingsMutation.mutate({
+                                    repo: repo.repo,
+                                    ownPrsOnly: value === "mine",
+                                  })
+                                }
+                                disabled={updateRepoSettingsMutation.isPending}
+                                name={`tracked-repo-scope-${repo.repo}`}
+                                testIdPrefix={`tracked-repo-scope-${repo.repo.replace("/", "-")}`}
+                                compact
+                              />
+                            </div>
+                            <label className="flex shrink-0 self-end items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                              <input
+                                type="checkbox"
+                                checked={repo.autoCreateReleases}
+                                onChange={(e) =>
+                                  updateRepoSettingsMutation.mutate({
+                                    repo: repo.repo,
+                                    autoCreateReleases: e.target.checked,
+                                  })
+                                }
+                                disabled={updateRepoSettingsMutation.isPending}
+                                data-testid={`tracked-repo-auto-release-${repo.repo.replace("/", "-")}`}
+                                className="accent-foreground"
+                              />
+                              Auto-release
+                            </label>
+                          </div>
                         </div>
                       ))}
                     </div>

--- a/docs/plans/2026-04-20-own-prs-only-setting.md
+++ b/docs/plans/2026-04-20-own-prs-only-setting.md
@@ -1,0 +1,182 @@
+# Own PRs Only Setting Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a per-watched-repo setting that limits automatic repo syncing to the authenticated user's own PRs, default it to enabled, and ask for that preference in the web onboarding/watch flow.
+
+**Architecture:** Extend the existing `WatchedRepo` settings model with a new boolean flag, persist it through memory and SQLite storage, and update the repo watcher so it filters auto-discovered PRs by author while preserving explicitly tracked PRs. Expose the setting through `/api/repos/settings`, then add a preselected watch preference control in the dashboard and onboarding copy so new repos default to `My PRs only` but can be switched to team-wide tracking.
+
+**Tech Stack:** TypeScript, React, Express, Zod, Node test runner, SQLite
+
+---
+
+### Task 1: Extend the watched repo data model
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `shared/models.ts`
+- Modify: `server/defaultConfig.ts`
+
+**Step 1: Write the failing test**
+
+Use existing storage and route tests as the first failing coverage so the new schema field is exercised through real call sites instead of standalone type assertions.
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx server/memoryStorage.test.ts server/routes.test.ts`
+Expected: FAIL once tests expect `ownPrsOnly` to exist on watched repo settings.
+
+**Step 3: Write minimal implementation**
+
+Add `ownPrsOnly: z.boolean()` to `watchedRepoSchema`, preserve it in `applyWatchedRepoUpdate`, and make new watched repos default to `true`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx server/memoryStorage.test.ts server/routes.test.ts`
+Expected: PASS for the schema-backed watched repo expectations.
+
+**Step 5: Commit**
+
+```bash
+git add shared/schema.ts shared/models.ts server/defaultConfig.ts server/memoryStorage.test.ts server/routes.test.ts
+git commit -m "feat: add own-prs-only repo setting"
+```
+
+### Task 2: Persist the setting through storage and routes
+
+**Files:**
+- Modify: `server/memoryStorage.ts`
+- Modify: `server/sqliteStorage.ts`
+- Modify: `server/storage.test.ts`
+- Modify: `server/routes.ts`
+- Modify: `server/appRuntime.ts`
+- Test: `server/memoryStorage.test.ts`
+- Test: `server/routes.test.ts`
+
+**Step 1: Write the failing test**
+
+Extend repo settings tests to assert:
+- watched repos default `ownPrsOnly` to `true`
+- `PATCH /api/repos/settings` can flip only `ownPrsOnly`
+- SQLite round-trips preserve the field for fresh and updated rows
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx server/memoryStorage.test.ts server/routes.test.ts server/storage.test.ts`
+Expected: FAIL because the new field is missing from memory storage, SQLite parsing, and route patch handling.
+
+**Step 3: Write minimal implementation**
+
+Update both storage backends and the route parser so repo settings default and persist `ownPrsOnly`, using a SQLite column migration plus `CREATE TABLE` update to keep fresh DBs aligned with migrated DBs.
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx server/memoryStorage.test.ts server/routes.test.ts server/storage.test.ts`
+Expected: PASS with the new repo setting persisted end-to-end.
+
+**Step 5: Commit**
+
+```bash
+git add server/memoryStorage.ts server/sqliteStorage.ts server/storage.test.ts server/routes.ts server/appRuntime.ts server/memoryStorage.test.ts server/routes.test.ts
+git commit -m "feat: persist own-prs-only repo settings"
+```
+
+### Task 3: Filter watcher auto-discovery to the user's PRs
+
+**Files:**
+- Modify: `server/babysitter.ts`
+- Modify: `server/babysitter.test.ts`
+
+**Step 1: Write the failing test**
+
+Add watcher tests that prove:
+- watched repos with `ownPrsOnly: true` auto-add only PRs authored by the authenticated user
+- watched repos with `ownPrsOnly: false` still auto-add teammate PRs
+- already tracked teammate PRs are not archived just because the repo is filtered to own PRs
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: FAIL because the watcher currently auto-discovers every open PR in a watched repo.
+
+**Step 3: Write minimal implementation**
+
+Fetch the authenticated GitHub login once per sync cycle, build a filtered set only for new PR discovery, and continue using the full open PR list for archival decisions so manual or previously tracked teammate PRs remain stable.
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx server/babysitter.test.ts`
+Expected: PASS with own-only discovery behavior and unchanged archival semantics.
+
+**Step 5: Commit**
+
+```bash
+git add server/babysitter.ts server/babysitter.test.ts
+git commit -m "feat: filter watched repos to own PRs by default"
+```
+
+### Task 4: Add the web onboarding and dashboard controls
+
+**Files:**
+- Modify: `client/src/pages/dashboard.tsx`
+- Modify: `client/src/components/OnboardingPanel.tsx`
+
+**Step 1: Write the failing test**
+
+There is no existing client test harness here, so verification for this task is integration-driven:
+- confirm the watch form renders the new choice UI
+- confirm it defaults to `My PRs only`
+- confirm switching to team-wide tracking results in a follow-up repo settings update
+
+**Step 2: Run verification target before the implementation**
+
+Run: `npm run check`
+Expected: PASS before the UI changes, giving a clean baseline for the client edits.
+
+**Step 3: Write minimal implementation**
+
+Add a small watch-scope choice near the repo input, default it to own-only, and keep onboarding copy explicit about the choice. When the user watches a repo with `My PRs + teammates`, call `PATCH /api/repos/settings` after a successful add to set `ownPrsOnly: false`. Show the persisted setting in tracked repo rows so users can change it later.
+
+**Step 4: Run verification after the implementation**
+
+Run: `npm run check`
+Expected: PASS with the new watched repo UI and updated onboarding copy.
+
+**Step 5: Commit**
+
+```bash
+git add client/src/pages/dashboard.tsx client/src/components/OnboardingPanel.tsx
+git commit -m "feat: add own-prs-only onboarding controls"
+```
+
+### Task 5: Run the focused regression suite
+
+**Files:**
+- Test: `server/memoryStorage.test.ts`
+- Test: `server/routes.test.ts`
+- Test: `server/storage.test.ts`
+- Test: `server/babysitter.test.ts`
+- Verify: `client/src/pages/dashboard.tsx`
+- Verify: `client/src/components/OnboardingPanel.tsx`
+
+**Step 1: Run focused backend tests**
+
+Run: `node --test --import tsx server/memoryStorage.test.ts server/routes.test.ts server/storage.test.ts server/babysitter.test.ts`
+Expected: PASS
+
+**Step 2: Run typecheck**
+
+Run: `npm run check`
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run: `git diff --stat`
+Expected: only the planned files change, with no unrelated edits.
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-04-20-own-prs-only-setting.md
+git commit -m "docs: add own-prs-only implementation plan"
+```

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -250,6 +250,34 @@
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>
 <li><strong>Theme</strong> — Toggle between light and dark mode.</li>
 </ul>
+<h2>Repository Watch Settings</h2>
+<p>Watched repositories also have repo-level settings exposed in the dashboard&#39;s repository list and through <code>GET /api/repos/settings</code> plus <code>PATCH /api/repos/settings</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Setting</th>
+<th>Default</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>ownPrsOnly</code></td>
+<td><code>true</code></td>
+<td>Auto-discover only PRs authored by the authenticated GitHub user for that repo. This appears in the dashboard as <strong>My PRs only</strong>.</td>
+</tr>
+<tr>
+<td><code>ownPrsOnly</code></td>
+<td><code>false</code></td>
+<td>Auto-discover all open PRs in that repo. This appears in the dashboard as <strong>My PRs + teammates</strong>.</td>
+</tr>
+<tr>
+<td><code>autoCreateReleases</code></td>
+<td><code>true</code></td>
+<td>Keep release automation enabled for the repo when the rest of the release prerequisites are met.</td>
+</tr>
+</tbody></table>
+<p>New watched repos default to <strong>My PRs only</strong>. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
+<p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting.</p>
 <h2>PR Comment Branding</h2>
 <p>Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, echoed <code>/codefactory</code> agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr. Each comment references the app name and, by default, appends a <code>Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)</code> footer that links back to this repository.</p>
 <table>

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Getting Started</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">Welcome to oh-my-pr — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">Welcome to oh-my-pr — the autonomous PR babysitter that watches the repositories and pull requests you choose, triages review feedback, and dispatches AI agents to fix code.</p>
 </header>
 
 <article class="doc-prose">
@@ -193,10 +193,10 @@
 <pre><code class="language-bash">npm install -g oh-my-pr
 </code></pre>
 <h2>Quick Start</h2>
-<h3>1. Start the dashboard</h3>
+<h3>1. Launch the terminal UI</h3>
 <pre><code class="language-bash">oh-my-pr
 </code></pre>
-<p>This launches the dashboard at <a href="http://localhost:5001">http://localhost:5001</a>.</p>
+<p>This opens the terminal UI. To start the web dashboard instead, run <code>oh-my-pr web</code> — it serves at <a href="http://localhost:5001">http://localhost:5001</a>.</p>
 <h3>Run from source</h3>
 <p>If you prefer to run from source instead:</p>
 <pre><code class="language-bash">git clone https://github.com/yungookim/oh-my-pr.git
@@ -208,17 +208,23 @@ npm run dev
 <ol>
 <li>Open the dashboard in your browser.</li>
 <li>Click <strong>Add Repository</strong> and paste the URL of a GitHub repository you manage.</li>
+<li>Choose <strong>Track automatically</strong>:<ul>
+<li><strong>My PRs only</strong> keeps the repo on the default scope and auto-discovers only PRs authored by your authenticated GitHub account.</li>
+<li><strong>My PRs + teammates</strong> switches the repo to team-wide discovery and auto-discovers every open PR in that repository.</li>
+</ul>
+</li>
 <li>Enter your GitHub Personal Access Token when prompted.</li>
 </ol>
 <h3>3. Watch oh-my-pr work</h3>
 <p>Once connected, oh-my-pr will:</p>
 <ul>
-<li><strong>Monitor</strong> open pull requests in real time.</li>
+<li><strong>Monitor</strong> matching open pull requests in real time based on each watched repo&#39;s scope.</li>
 <li><strong>Sync</strong> review comments and change requests.</li>
 <li><strong>Triage</strong> feedback into actionable tasks.</li>
 <li><strong>Dispatch</strong> AI agents (Claude Code or OpenAI Codex) to fix issues.</li>
 <li><strong>Push</strong> the fixes back to the PR branch.</li>
 </ul>
+<p>PRs added directly by URL are always tracked, even if the repo stays on <strong>My PRs only</strong>.</p>
 <h2>Desktop App</h2>
 <p>oh-my-pr is also available as a native desktop application powered by Tauri:</p>
 <pre><code class="language-bash">npm run tauri:dev    # Development

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -178,13 +178,19 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">PR Babysitter</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">The PR Babysitter is oh-my-pr&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests, takes action on review feedback, and can run bounded CI-healing loops without manual intervention.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">The PR Babysitter is oh-my-pr&#39;s core feature — an autonomous system that continuously monitors your GitHub pull requests, takes action on review feedback, and can run bounded CI-healing and post-merge deployment-healing loops without manual intervention.</p>
 </header>
 
 <article class="doc-prose">
   <h2>How It Works</h2>
 <h3>1. Repository Watching</h3>
-<p>When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests. It tracks:</p>
+<p>When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests that match that repo&#39;s watch scope:</p>
+<ul>
+<li><strong>My PRs only</strong> — the default mode. The watcher auto-discovers only PRs authored by the authenticated GitHub user.</li>
+<li><strong>My PRs + teammates</strong> — team-wide mode. The watcher auto-discovers every open PR in the repository.</li>
+<li><strong>Direct PR URLs</strong> — PRs you add explicitly by URL stay tracked regardless of the repo&#39;s watch scope.</li>
+</ul>
+<p>For tracked PRs, the babysitter syncs:</p>
 <ul>
 <li>New PRs opened against the repository.</li>
 <li>Review comments and change requests on existing PRs.</li>
@@ -249,6 +255,26 @@
 </ul>
 <p>Only <code>healable_in_branch</code> failures queue a dedicated repair attempt. Healing sessions move through explicit states such as <code>triaging</code>, <code>awaiting_repair_slot</code>, <code>repairing</code>, <code>awaiting_ci</code>, <code>verifying</code>, <code>healed</code>, <code>cooldown</code>, <code>blocked</code>, <code>escalated</code>, and <code>superseded</code>.</p>
 <p>The dashboard shows the latest session for each tracked PR, including the current state badge, attempt summary, latest fingerprint, reason text, and current head SHA. The local API exposes session history via <code>GET /api/healing-sessions</code> and <code>GET /api/healing-sessions/:id</code>.</p>
+<h3>6. Deployment Healing</h3>
+<p>When <code>autoHealDeployments</code> is enabled, the babysitter also inspects merged PRs for supported deployment markers and queues a durable <code>heal_deployment</code> job for eligible repositories. Platform detection currently supports:</p>
+<ul>
+<li><strong>Vercel</strong> — <code>vercel.json</code>, <code>.vercel/project.json</code>, or a <code>package.json</code> script containing <code>vercel</code></li>
+<li><strong>Railway</strong> — <code>railway.toml</code>, <code>railway.json</code>, or <code>nixpacks.toml</code></li>
+</ul>
+<p>For a detected platform, the deployment-healing flow is:</p>
+<ol>
+<li>Wait <code>deploymentCheckDelayMs</code> after merge so the deployment can appear upstream.</li>
+<li>Poll the platform CLI until the deployment reaches <code>ready</code>, reaches <code>error</code>, or <code>deploymentCheckTimeoutMs</code> elapses.</li>
+<li>If the deployment fails, capture the deployment logs and create a deployment-healing session.</li>
+<li>Run the configured coding agent from the merge SHA, push a <code>deploy-fix/&lt;platform&gt;-&lt;timestamp&gt;</code> branch, and open a follow-up PR back to the merged base branch.</li>
+<li>Mark the session as <code>fix_submitted</code> on success or <code>escalated</code> when monitoring times out or the repair attempt cannot be completed automatically.</li>
+</ol>
+<p>Deployment-healing sessions move through <code>monitoring</code>, <code>failed</code>, <code>fixing</code>, <code>fix_submitted</code>, and <code>escalated</code>. Operator visibility is currently API- and MCP-based via <code>GET /api/deployment-healing-sessions</code>, <code>GET /api/deployment-healing-sessions/:id</code>, <code>list_deployment_healing_sessions</code>, and <code>get_deployment_healing_session</code>; there is no dedicated dashboard panel yet.</p>
+<p>Deployment healing requires the matching platform CLI to be installed and authenticated on the same machine as oh-my-pr:</p>
+<ul>
+<li><code>vercel</code> for Vercel repositories</li>
+<li><code>railway</code> for Railway repositories</li>
+</ul>
 <h2>Feedback Lifecycle</h2>
 <p>Each feedback item moves through a defined state machine:</p>
 <pre><code>pending → triaged → dispatched → resolved
@@ -272,6 +298,7 @@
 <h2>Configuration</h2>
 <p>You can control babysitter behavior per repository:</p>
 <ul>
+<li><strong>Repo watch scope</strong> — Choose <code>My PRs only</code> (default) or <code>My PRs + teammates</code> for auto-discovery.</li>
 <li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
 <li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
 <li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.</li>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -60,6 +60,20 @@ The settings page in the dashboard provides a UI for:
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
 - **Theme** — Toggle between light and dark mode.
 
+## Repository Watch Settings
+
+Watched repositories also have repo-level settings exposed in the dashboard's repository list and through `GET /api/repos/settings` plus `PATCH /api/repos/settings`.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ownPrsOnly` | `true` | Auto-discover only PRs authored by the authenticated GitHub user for that repo. This appears in the dashboard as **My PRs only**. |
+| `ownPrsOnly` | `false` | Auto-discover all open PRs in that repo. This appears in the dashboard as **My PRs + teammates**. |
+| `autoCreateReleases` | `true` | Keep release automation enabled for the repo when the rest of the release prerequisites are met. |
+
+New watched repos default to **My PRs only**. If you want team-wide tracking for a repository, switch it to **My PRs + teammates** in the dashboard or patch `ownPrsOnly: false` through `/api/repos/settings`.
+
+PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting.
+
 ## PR Comment Branding
 
 Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, echoed `/codefactory` agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr. Each comment references the app name and, by default, appends a `Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)` footer that links back to this repository.

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome to oh-my-pr — the autonomous PR babysitter that watches your repositories, triages review feedback, and dispatches AI agents to fix code.
+Welcome to oh-my-pr — the autonomous PR babysitter that watches the repositories and pull requests you choose, triages review feedback, and dispatches AI agents to fix code.
 
 ## Prerequisites
 
@@ -41,17 +41,22 @@ npm run dev
 
 1. Open the dashboard in your browser.
 2. Click **Add Repository** and paste the URL of a GitHub repository you manage.
-3. Enter your GitHub Personal Access Token when prompted.
+3. Choose **Track automatically**:
+   - **My PRs only** keeps the repo on the default scope and auto-discovers only PRs authored by your authenticated GitHub account.
+   - **My PRs + teammates** switches the repo to team-wide discovery and auto-discovers every open PR in that repository.
+4. Enter your GitHub Personal Access Token when prompted.
 
 ### 3. Watch oh-my-pr work
 
 Once connected, oh-my-pr will:
 
-- **Monitor** open pull requests in real time.
+- **Monitor** matching open pull requests in real time based on each watched repo's scope.
 - **Sync** review comments and change requests.
 - **Triage** feedback into actionable tasks.
 - **Dispatch** AI agents (Claude Code or OpenAI Codex) to fix issues.
 - **Push** the fixes back to the PR branch.
+
+PRs added directly by URL are always tracked, even if the repo stays on **My PRs only**.
 
 ## Desktop App
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -6,7 +6,13 @@ The PR Babysitter is oh-my-pr's core feature — an autonomous system that conti
 
 ### 1. Repository Watching
 
-When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests. It tracks:
+When you add a repository to oh-my-pr, the babysitter begins polling for open pull requests that match that repo's watch scope:
+
+- **My PRs only** — the default mode. The watcher auto-discovers only PRs authored by the authenticated GitHub user.
+- **My PRs + teammates** — team-wide mode. The watcher auto-discovers every open PR in the repository.
+- **Direct PR URLs** — PRs you add explicitly by URL stay tracked regardless of the repo's watch scope.
+
+For tracked PRs, the babysitter syncs:
 
 - New PRs opened against the repository.
 - Review comments and change requests on existing PRs.
@@ -107,6 +113,7 @@ When a PR branch falls behind the base branch, oh-my-pr can automatically:
 
 You can control babysitter behavior per repository:
 
+- **Repo watch scope** — Choose `My PRs only` (default) or `My PRs + teammates` for auto-discovery.
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
 - **Agent preference** — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -372,6 +372,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           byRepo.set(pr.repo, {
             repo: pr.repo,
             autoCreateReleases: true,
+            ownPrsOnly: true,
           });
         }
       }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -143,6 +143,7 @@ function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
     }),
     listFailingStatuses: async () => [],
     checkCISettled: async () => true,
+    getAuthenticatedLogin: async () => "octocat",
     listOpenPullsForRepo: async () => [],
     postFollowUpForFeedbackItem: async () => undefined,
     resolveReviewThread: async () => undefined,
@@ -3940,6 +3941,169 @@ test("syncAndBabysitTrackedRepos creates a healing session for failing watched P
   assert.equal(sessions.length, 1);
   assert.equal(sessions[0]?.state, "awaiting_repair_slot");
   assert.equal(sessions[0]?.initialHeadSha, "abc123");
+});
+
+test("syncAndBabysitTrackedRepos auto-registers only the authenticated user's PRs by default", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["alex-morgan-o/lolodex"],
+    autoUpdateDocs: false,
+  });
+
+  const queuedTargets: string[] = [];
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [
+        {
+          number: 106,
+          title: "My PR",
+          branch: "feature/mine",
+          author: "octocat",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+        },
+        {
+          number: 107,
+          title: "Teammate PR",
+          branch: "feature/teammate",
+          author: "teammate",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/107",
+        },
+      ],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (_kind, targetId) => {
+      queuedTargets.push(targetId);
+      return {} as never;
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const prs = await storage.getPRs();
+  assert.equal(prs.length, 1);
+  assert.equal(prs[0]?.number, 106);
+  assert.equal(prs[0]?.author, "octocat");
+  assert.deepEqual(queuedTargets, [prs[0]!.id]);
+});
+
+test("syncAndBabysitTrackedRepos can include teammate PRs when repo setting disables own-only filtering", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["alex-morgan-o/lolodex"],
+    autoUpdateDocs: false,
+  });
+  await storage.updateRepoSettings("alex-morgan-o/lolodex", {
+    ownPrsOnly: false,
+  });
+
+  const queuedTargets: string[] = [];
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [
+        {
+          number: 108,
+          title: "My PR",
+          branch: "feature/mine",
+          author: "octocat",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/108",
+        },
+        {
+          number: 109,
+          title: "Teammate PR",
+          branch: "feature/teammate",
+          author: "teammate",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/109",
+        },
+      ],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (_kind, targetId) => {
+      queuedTargets.push(targetId);
+      return {} as never;
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const prs = await storage.getPRs();
+  assert.equal(prs.length, 2);
+  assert.deepEqual(prs.map((pr) => pr.number).sort((a, b) => a - b), [108, 109]);
+  assert.equal(queuedTargets.length, 2);
+});
+
+test("syncAndBabysitTrackedRepos keeps explicitly tracked teammate PRs active when own-only filtering is enabled", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["alex-morgan-o/lolodex"],
+    autoUpdateDocs: false,
+  });
+  await storage.updateRepoSettings("alex-morgan-o/lolodex", {
+    ownPrsOnly: true,
+  });
+
+  const tracked = await storage.addPR({
+    number: 110,
+    title: "Tracked teammate PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/teammate",
+    author: "teammate",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/110",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const queuedTargets: string[] = [];
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [
+        {
+          number: 110,
+          title: "Tracked teammate PR",
+          branch: "feature/teammate",
+          author: "teammate",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/110",
+        },
+      ],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (_kind, targetId) => {
+      queuedTargets.push(targetId);
+      return {} as never;
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updated = await storage.getPR(tracked.id);
+  assert.equal(updated?.status, "watching");
+  assert.deepEqual(queuedTargets, [tracked.id]);
 });
 
 test("syncAndBabysitTrackedRepos uses the injected clock for fallback healing snapshots", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -72,6 +72,7 @@ type GitHubService = {
   fetchPullCloseState?: typeof fetchPullCloseState;
   fetchPullSummary: typeof fetchPullSummary;
   fetchCheckSnapshotsForRef?: typeof fetchCheckSnapshotsForRef;
+  getAuthenticatedLogin?: (octokit: Awaited<ReturnType<typeof buildOctokit>>) => Promise<string | null>;
   listFailingStatuses: typeof listFailingStatuses;
   listMergedPullsToday?: typeof listMergedPullsToday; // optional — absent in test mocks
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
@@ -113,6 +114,11 @@ const defaultGitHubService: GitHubService = {
   fetchFeedbackItemsForPR,
   fetchPullCloseState,
   fetchPullSummary,
+  getAuthenticatedLogin: async (octokit) => {
+    const { data } = await octokit.rest.users.getAuthenticated();
+    const login = data.login?.trim().toLowerCase();
+    return login ? login : null;
+  },
   listFailingStatuses,
   listMergedPullsToday,
   listOpenPullsForRepo,
@@ -1131,6 +1137,25 @@ export class PRBabysitter {
       ...tracked.map((pr) => pr.repo),
       ...config.watchedRepos,
     ]);
+    const needsAuthenticatedLogin = Array.from(repoCandidates).some(
+      (repo) => (repoSettingsByRepo.get(repo)?.ownPrsOnly ?? true),
+    );
+    let authenticatedLoginPromise: Promise<string | null> | null = null;
+    const getAuthenticatedLogin = async (): Promise<string | null> => {
+      if (!needsAuthenticatedLogin) {
+        return null;
+      }
+
+      if (!authenticatedLoginPromise) {
+        authenticatedLoginPromise = (this.github.getAuthenticatedLogin?.(octokit) ?? Promise.resolve(null))
+          .catch((error) => {
+            console.error("Failed to determine authenticated GitHub login for watcher filtering", error);
+            return null;
+          });
+      }
+
+      return authenticatedLoginPromise;
+    };
 
     const repos = Array.from(repoCandidates)
       .map((repo) => parseRepoSlug(repo))
@@ -1151,6 +1176,16 @@ export class PRBabysitter {
       }
 
       const openNumbers = new Set(openPulls.map((p) => p.number));
+      const repoOwnPrsOnly = repoSettingsByRepo.get(repoSlug)?.ownPrsOnly ?? true;
+      const authenticatedLogin = repoOwnPrsOnly ? await getAuthenticatedLogin() : null;
+      const discoveryNumbers = new Set(
+        openPulls
+          .filter((pull) => !repoOwnPrsOnly || (
+            authenticatedLogin !== null
+            && pull.author.trim().toLowerCase() === authenticatedLogin
+          ))
+          .map((pull) => pull.number),
+      );
 
       // Archive tracked PRs that are no longer open on GitHub
       const trackedForRepo = tracked.filter((pr) => pr.repo === repoSlug);
@@ -1290,6 +1325,10 @@ export class PRBabysitter {
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
+          if (!discoveryNumbers.has(pull.number)) {
+            continue;
+          }
+
           local = await this.storage.addPR({
             number: pull.number,
             title: pull.title,

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -472,17 +472,20 @@ describe("MemStorage", () => {
       assert.deepEqual(repos, [{
         repo: "acme/widgets",
         autoCreateReleases: true,
+        ownPrsOnly: true,
       }]);
     });
 
     it("persists repo-specific release settings and keeps watched repos aligned", async () => {
       const updated = await storage.updateRepoSettings("acme/widgets", {
         autoCreateReleases: false,
+        ownPrsOnly: false,
       });
 
       assert.deepEqual(updated, {
         repo: "acme/widgets",
         autoCreateReleases: false,
+        ownPrsOnly: false,
       });
 
       const config = await storage.getConfig();
@@ -492,6 +495,7 @@ describe("MemStorage", () => {
       assert.deepEqual(repo, {
         repo: "acme/widgets",
         autoCreateReleases: false,
+        ownPrsOnly: false,
       });
     });
   });

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -233,6 +233,7 @@ export class MemStorage implements IStorage {
     const existing = this.repoSettings.get(repo) ?? {
       repo,
       autoCreateReleases: true,
+      ownPrsOnly: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
     this.repoSettings.set(repo, next);
@@ -248,6 +249,7 @@ export class MemStorage implements IStorage {
         this.repoSettings.set(repo, {
           repo,
           autoCreateReleases: true,
+          ownPrsOnly: true,
         });
       }
     }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -146,7 +146,7 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
   }
 });
 
-test("GET/PATCH /api/repos/settings exposes repo-level release settings", async () => {
+test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
   const harness = await createHarness();
   await harness.storage.updateConfig({
     watchedRepos: ["acme/widgets"],
@@ -158,10 +158,12 @@ test("GET/PATCH /api/repos/settings exposes repo-level release settings", async 
     const initial = await initialResponse.json() as Array<{
       repo: string;
       autoCreateReleases: boolean;
+      ownPrsOnly: boolean;
     }>;
     assert.deepEqual(initial, [{
       repo: "acme/widgets",
       autoCreateReleases: true,
+      ownPrsOnly: true,
     }]);
 
     const updateResponse = await fetch(`${harness.baseUrl}/api/repos/settings`, {
@@ -172,22 +174,61 @@ test("GET/PATCH /api/repos/settings exposes repo-level release settings", async 
       body: JSON.stringify({
         repo: "acme/widgets",
         autoCreateReleases: false,
+        ownPrsOnly: false,
       }),
     });
     assert.equal(updateResponse.status, 200);
     const updated = await updateResponse.json() as {
       repo: string;
       autoCreateReleases: boolean;
+      ownPrsOnly: boolean;
     };
     assert.deepEqual(updated, {
       repo: "acme/widgets",
       autoCreateReleases: false,
+      ownPrsOnly: false,
     });
 
     const persisted = await harness.storage.getRepoSettings("acme/widgets");
     assert.deepEqual(persisted, {
       repo: "acme/widgets",
       autoCreateReleases: false,
+      ownPrsOnly: false,
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+test("PATCH /api/repos/settings can update only ownPrsOnly", async () => {
+  const harness = await createHarness();
+  await harness.storage.updateRepoSettings("acme/widgets", {
+    autoCreateReleases: false,
+    ownPrsOnly: true,
+  });
+
+  try {
+    const updateResponse = await fetch(`${harness.baseUrl}/api/repos/settings`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        repo: "acme/widgets",
+        ownPrsOnly: false,
+      }),
+    });
+    assert.equal(updateResponse.status, 200);
+
+    const updated = await updateResponse.json() as {
+      repo: string;
+      autoCreateReleases: boolean;
+      ownPrsOnly: boolean;
+    };
+    assert.deepEqual(updated, {
+      repo: "acme/widgets",
+      autoCreateReleases: false,
+      ownPrsOnly: false,
     });
   } finally {
     await harness.close();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -99,11 +99,16 @@ export async function registerRoutes(
 
   app.patch("/api/repos/settings", async (req, res) => {
     try {
-      const { repo, autoCreateReleases } = z.object({
+      const payload = z.object({
         repo: z.string().min(1),
-        autoCreateReleases: z.boolean(),
-      }).parse(req.body);
-      res.json(await runtime.updateRepoSettings(repo, { autoCreateReleases }));
+        autoCreateReleases: z.boolean().optional(),
+        ownPrsOnly: z.boolean().optional(),
+      }).refine(
+        (value) => value.autoCreateReleases !== undefined || value.ownPrsOnly !== undefined,
+        "At least one repository setting must be provided",
+      ).parse(req.body);
+      const { repo, ...updates } = payload;
+      res.json(await runtime.updateRepoSettings(repo, updates));
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -122,6 +122,7 @@ type PRRow = {
 type WatchedRepoRow = {
   repo: string;
   auto_create_releases: number;
+  own_prs_only: number;
 };
 
 type FeedbackItemRow = {
@@ -488,7 +489,8 @@ export class SqliteStorage implements IStorage {
 
       CREATE TABLE IF NOT EXISTS watched_repos (
         repo TEXT PRIMARY KEY,
-        auto_create_releases INTEGER NOT NULL DEFAULT 1
+        auto_create_releases INTEGER NOT NULL DEFAULT 1,
+        own_prs_only INTEGER NOT NULL DEFAULT 1
       );
 
       CREATE TABLE IF NOT EXISTS prs (
@@ -774,6 +776,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "deployment_check_timeout_ms", "INTEGER NOT NULL DEFAULT 600000");
     this.ensureColumn("config", "deployment_check_poll_interval_ms", "INTEGER NOT NULL DEFAULT 15000");
     this.ensureColumn("watched_repos", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("watched_repos", "own_prs_only", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
 
@@ -841,7 +844,7 @@ export class SqliteStorage implements IStorage {
   private writeConfig(config: Config): void {
     this.withWriteTransaction(() => {
       const watchedRepoSettings = new Map(
-        this.getWatchedRepoRows().map((row) => [row.repo, row.auto_create_releases]),
+        this.getWatchedRepoRows().map((row) => [row.repo, row]),
       );
       const legacyModelValue = (
         this.get<{ model?: string }>("SELECT model FROM config WHERE id = 1")
@@ -924,10 +927,12 @@ export class SqliteStorage implements IStorage {
 
       this.exec("DELETE FROM watched_repos");
       for (const repo of config.watchedRepos) {
+        const settings = watchedRepoSettings.get(repo);
         this.run(
-          "INSERT INTO watched_repos (repo, auto_create_releases) VALUES (?, ?)",
+          "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only) VALUES (?, ?, ?)",
           repo,
-          watchedRepoSettings.get(repo) ?? 1,
+          settings?.auto_create_releases ?? 1,
+          settings?.own_prs_only ?? 1,
         );
       }
     });
@@ -937,12 +942,13 @@ export class SqliteStorage implements IStorage {
     return {
       repo: row.repo,
       autoCreateReleases: Boolean(row.auto_create_releases),
+      ownPrsOnly: Boolean(row.own_prs_only ?? 1),
     };
   }
 
   private getWatchedRepoRows(): WatchedRepoRow[] {
     return this.all<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases FROM watched_repos ORDER BY repo ASC",
+      "SELECT repo, auto_create_releases, own_prs_only FROM watched_repos ORDER BY repo ASC",
     );
   }
 
@@ -1530,7 +1536,7 @@ export class SqliteStorage implements IStorage {
 
   async getRepoSettings(repo: string): Promise<WatchedRepo | undefined> {
     const row = this.get<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases FROM watched_repos WHERE repo = ?",
+      "SELECT repo, auto_create_releases, own_prs_only FROM watched_repos WHERE repo = ?",
       repo,
     );
     return row ? this.parseWatchedRepoRow(row) : undefined;
@@ -1543,19 +1549,22 @@ export class SqliteStorage implements IStorage {
     const existing = (await this.getRepoSettings(repo)) ?? {
       repo,
       autoCreateReleases: true,
+      ownPrsOnly: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
 
     this.withWriteTransaction(() => {
       this.run(
         `
-          INSERT INTO watched_repos (repo, auto_create_releases)
-          VALUES (?, ?)
+          INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only)
+          VALUES (?, ?, ?)
           ON CONFLICT(repo) DO UPDATE SET
-            auto_create_releases = excluded.auto_create_releases
+            auto_create_releases = excluded.auto_create_releases,
+            own_prs_only = excluded.own_prs_only
         `,
         next.repo,
         Number(next.autoCreateReleases),
+        Number(next.ownPrsOnly),
       );
     });
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -87,6 +87,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   });
   await first.updateRepoSettings("alex-morgan-o/lolodex", {
     autoCreateReleases: false,
+    ownPrsOnly: false,
   });
   await first.updateConfig({
     pollIntervalMs: 45000,
@@ -216,6 +217,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.deepEqual(repoSettings, {
     repo: "alex-morgan-o/lolodex",
     autoCreateReleases: false,
+    ownPrsOnly: false,
   });
   assert.equal(runtime.drainMode, true);
   assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
@@ -303,11 +305,13 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
 
     const updated = await storage.updateRepoSettings("acme/widgets", {
       autoCreateReleases: false,
+      ownPrsOnly: false,
     });
 
     assert.deepEqual(updated, {
       repo: "acme/widgets",
       autoCreateReleases: false,
+      ownPrsOnly: false,
     });
 
     const after = await storage.getConfig();
@@ -317,6 +321,7 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
     assert.deepEqual(repo, {
       repo: "acme/widgets",
       autoCreateReleases: false,
+      ownPrsOnly: false,
     });
   } finally {
     storage.close();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -419,5 +419,6 @@ export type Config = z.infer<typeof configSchema>;
 export const watchedRepoSchema = z.object({
   repo: z.string(),
   autoCreateReleases: z.boolean(),
+  ownPrsOnly: z.boolean(),
 });
 export type WatchedRepo = z.infer<typeof watchedRepoSchema>;


### PR DESCRIPTION
## Summary
- add a per-watched-repo `ownPrsOnly` setting that defaults repo syncing to the authenticated user
- filter watcher auto-discovery to own PRs while preserving explicitly tracked teammate PRs
- add dashboard and onboarding controls so users can choose `My PRs only` or `My PRs + teammates` per watched repo

## Why
The existing watched-repo flow pulled teammates PRs too, but the product needed a repo-level way to keep All My PR focused on the current user by default.

## Impact
- new watched repos default to `My PRs only`
- users can switch any watched repo to `My PRs + teammates` later from the dashboard
- manual PR URL adds still work regardless of the repo watch scope

## Validation
- `npm run check`
- `node --import tsx --test server/memoryStorage.test.ts server/routes.test.ts server/storage.test.ts server/babysitter.test.ts`
