### PR TITLE
[codex] Import CLAUDE behavioral guidance into AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 # Repository Guidelines
 
 ## Behavioral Guidelines
-Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
-
 Tradeoff: These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
 ### 1. Think Before Coding
@@ -54,8 +52,6 @@ For multi-step tasks, state a brief plan:
 3. [Step] -> verify: [check]
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
-
-These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Project Structure & Module Organization
 `client/src/` hosts the React dashboard, including pages, hooks, and UI primitives. `server/` contains the Express entrypoint, GitHub integration, PR babysitter/worktree logic, storage adapters, and the current `*.test.ts` files. `shared/schema.ts` defines Zod contracts shared across the app. `script/build.ts` builds the production bundle into `dist/`; treat `dist/` as generated output. Planning and QA artifacts live in `docs/plans/`, `dogfood-output/`, and `tasks/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,62 @@
 # Repository Guidelines
 
+## Behavioral Guidelines
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+Tradeoff: These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them; don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it; don't delete it.
+
+When your changes create orphans:
+- Remove imports, variables, and functions that your changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+- "Add validation" -> "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
+- "Refactor X" -> "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
 ## Project Structure & Module Organization
 `client/src/` hosts the React dashboard, including pages, hooks, and UI primitives. `server/` contains the Express entrypoint, GitHub integration, PR babysitter/worktree logic, storage adapters, and the current `*.test.ts` files. `shared/schema.ts` defines Zod contracts shared across the app. `script/build.ts` builds the production bundle into `dist/`; treat `dist/` as generated output. Planning and QA artifacts live in `docs/plans/`, `dogfood-output/`, and `tasks/`.
 


### PR DESCRIPTION
## Summary
- Add the behavioral guidance from the referenced CLAUDE.md into AGENTS.md
- Preserve the existing repository-specific instructions and omit the CLAUDE.md heading line
- Trim the two review-flagged meta-commentary lines so the new section stays instruction-focused

## Why
- Keep the repo agent instructions aligned with the imported guidance without replacing the existing workflow rules
- Reduce prompt noise in the new guidance section

## Validation
- Reviewed the AGENTS.md diff against `main`
- Confirmed the file does not contain `CLAUDE.md` or `CLAUD.md`
- Addressed the two Gemini review comments and resolved both conversations
- No automated tests run; docs-only change
- Attempted `claude -p "/simplify AGENTS.md"`, but the local Claude CLI was rate-limited
