### PR TITLE
[codex] simplify README pitch and quick start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Code Factory
+# Contributing to oh-my-pr
 
-Thanks for your interest in contributing to Code Factory! This document provides guidelines and information for contributors.
+Thanks for your interest in contributing to oh-my-pr! This document provides guidelines and information for contributors.
 
 ## Code of Conduct
 

--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -1,8 +1,8 @@
-# Code Factory — Local API & MCP Server
+# oh-my-pr — Local API & MCP Server
 
 > **Security notice**: Every API endpoint is restricted to the local machine.
 > Requests arriving from any non-loopback address are rejected with `HTTP 403`.
-> Code Factory is a **local-first** tool; never expose its port to the internet.
+> oh-my-pr is a **local-first** tool; never expose its port to the internet.
 
 ---
 
@@ -36,10 +36,10 @@
 
 ## Overview
 
-Code Factory runs an **Express HTTP server** (default port `5001`) that serves
+oh-my-pr runs an **Express HTTP server** (default port `5001`) that serves
 both its React dashboard and a machine-readable REST API.  The same API surface
 is also exposed as an **MCP (Model Context Protocol) server**, letting any
-MCP-compatible agent (Claude Desktop, OpenClaw, etc.) drive Code Factory through
+MCP-compatible agent (Claude Desktop, OpenClaw, etc.) drive oh-my-pr through
 structured tool calls without writing a single line of HTTP client code.
 
 ```
@@ -52,8 +52,8 @@ structured tool calls without writing a single line of HTTP client code.
 │  │ Desktop  │   :5001/api  │    │
 │  └──────────┘              ▼    │
 │       │              ┌──────────┤
-│       │ stdio MCP    │ Code     │
-│       └─────────────►│ Factory  │
+│       │ stdio MCP    │ oh-my-pr │
+│       └─────────────►│ server   │
 │                       │ server  │
 │                       └─────────┤
 │                            │    │
@@ -74,7 +74,7 @@ resumed from stored run context when possible.
 
 ## Quick start
 
-### 1. Start the Code Factory server
+### 1. Start the oh-my-pr server
 
 ```bash
 # development (auto-reloads)
@@ -107,7 +107,7 @@ curl -X POST http://localhost:5001/api/prs \
 ### 3. Use the MCP server
 
 ```bash
-# Start the MCP server (talks to the running Code Factory on port 5001)
+# Start the MCP server (talks to the running oh-my-pr server on port 5001)
 npm run mcp
 
 # Custom port
@@ -139,7 +139,7 @@ It checks the resolved IP address of each incoming request:
 
 ### Running behind a reverse proxy
 
-If you put Nginx or Caddy in front of Code Factory, make sure it forwards
+If you put Nginx or Caddy in front of oh-my-pr, make sure it forwards
 `X-Forwarded-For` and that Express's `trust proxy` setting is configured
 appropriately.  If `trust proxy` is not set, `req.ip` will always be
 `127.0.0.1` (the proxy itself) — which is fine for a purely local setup but
@@ -154,7 +154,7 @@ The MCP server (`server/mcp.ts`) implements the
 the standard transport used by Claude Desktop and most agent frameworks.
 
 It translates every MCP tool call into an HTTP request to `127.0.0.1:5001`,
-so the Code Factory main server must be running for any tool to work.
+so the oh-my-pr main server must be running for any tool to work.
 
 ### Claude Desktop / OpenClaw config
 
@@ -164,9 +164,9 @@ Add the following block to your MCP host's configuration file
 ```json
 {
   "mcpServers": {
-    "codefactory": {
+    "oh-my-pr": {
       "command": "npx",
-      "args": ["tsx", "/absolute/path/to/codefactory/server/mcp.ts"],
+      "args": ["tsx", "/absolute/path/to/oh-my-pr/server/mcp.ts"],
       "env": {
         "CODEFACTORY_PORT": "5001"
       }
@@ -175,7 +175,7 @@ Add the following block to your MCP host's configuration file
 }
 ```
 
-Replace `/absolute/path/to/codefactory` with the actual path.
+Replace `/absolute/path/to/oh-my-pr` with the actual path.
 
 If you have already built the project (`npm run build`), you can use the
 compiled output instead:
@@ -183,9 +183,9 @@ compiled output instead:
 ```json
 {
   "mcpServers": {
-    "codefactory": {
+    "oh-my-pr": {
       "command": "node",
-      "args": ["/absolute/path/to/codefactory/dist/mcp.cjs"],
+      "args": ["/absolute/path/to/oh-my-pr/dist/mcp.cjs"],
       "env": {
         "CODEFACTORY_PORT": "5001"
       }
@@ -348,7 +348,7 @@ List archived (closed/merged) PRs.
 
 #### `GET /api/prs/:id`
 
-Get a single PR by its internal Code Factory ID.
+Get a single PR by its internal oh-my-pr ID.
 
 **Response** `200` — [PR object](#pr)
 **Response** `404` — `{ "error": "PR not found" }`
@@ -357,7 +357,7 @@ Get a single PR by its internal Code Factory ID.
 
 #### `POST /api/prs`
 
-Register a GitHub PR by URL. Code Factory fetches the PR summary from GitHub,
+Register a GitHub PR by URL. oh-my-pr fetches the PR summary from GitHub,
 stores it, and queues an initial durable babysit run.
 
 This direct registration path is independent of watched-repo discovery scope,
@@ -528,7 +528,7 @@ List all persisted healing sessions, newest first.
 
 #### `GET /api/healing-sessions/:id`
 
-Get one healing session by its internal Code Factory ID.
+Get one healing session by its internal oh-my-pr ID.
 
 **Response** `200` — [HealingSession object](#healingsession)
 **Response** `404` — `{ "error": "Healing session not found" }`
@@ -558,7 +558,7 @@ List persisted deployment-healing sessions, newest first.
 
 #### `GET /api/deployment-healing-sessions/:id`
 
-Get one deployment-healing session by its internal Code Factory ID.
+Get one deployment-healing session by its internal oh-my-pr ID.
 
 **Response** `200` — [DeploymentHealingSession object](#deploymenthealingsession)
 **Response** `404` — `{ "error": "Deployment healing session not found" }`
@@ -695,7 +695,7 @@ APIs may still enqueue work that remains pending until drain mode is disabled.
 ### Social changelogs
 
 Social changelog generation is automatic and durable. When a merge-count
-milestone is reached, Code Factory creates a changelog row with
+milestone is reached, oh-my-pr creates a changelog row with
 `status: "generating"` and then fills in `content` from a queued background
 job. If the app restarts before completion, the queued job is reclaimed from
 SQLite.
@@ -720,8 +720,8 @@ Get a single social-media changelog by ID.
 ### Releases
 
 Release evaluation and publishing are also durable background jobs. When a
-tracked PR is archived as merged and automatic releases are enabled, Code
-Factory persists a release run and queues background processing. Retrying a
+tracked PR is archived as merged and automatic releases are enabled, oh-my-pr
+persists a release run and queues background processing. Retrying a
 failed release run resets it to `detected` and re-queues processing.
 
 #### `GET /api/releases`
@@ -734,7 +734,7 @@ List all persisted release runs, newest first.
 
 #### `GET /api/releases/:id`
 
-Get one release run by its internal Code Factory ID.
+Get one release run by its internal oh-my-pr ID.
 
 **Response** `200` — [ReleaseRun object](#releaserun)
 **Response** `404` — not found
@@ -757,7 +757,7 @@ queued job will not be claimed until drain mode is disabled.
 #### `GET /api/onboarding/status`
 
 Check the onboarding status of all watched repositories (e.g., whether the
-Code Factory GitHub Actions workflow is installed).
+oh-my-pr GitHub Actions workflow is installed).
 
 **Response** `200`
 ```json
@@ -773,7 +773,7 @@ Code Factory GitHub Actions workflow is installed).
 
 #### `POST /api/onboarding/install-review`
 
-Install the Code Factory code-review GitHub Actions workflow on a repository.
+Install the oh-my-pr code-review GitHub Actions workflow on a repository.
 
 **Body**
 ```json
@@ -1060,7 +1060,7 @@ All error responses share this shape:
 
 | Variable             | Default        | Description |
 |----------------------|----------------|-------------|
-| `PORT`               | `5001`         | HTTP port for the Code Factory server |
+| `PORT`               | `5001`         | HTTP port for the oh-my-pr server |
 | `CODEFACTORY_PORT`   | `5001`         | Port the MCP server connects to (MCP only) |
 | `OH_MY_PR_HOME`      | `~/.oh-my-pr` | Directory for SQLite DB, logs, repos, worktrees |
 | `PR_BABYSITTER_ROOT` | —              | Override worktree root directory |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ oh-my-pr is a local-first GitHub PR babysitter. It watches the pull requests you
 
 If you regularly lose time to review comments, flaky checks, merge conflicts, and back-and-forth cleanup before merge, this is the tool for that.
 
+<img width="1365" height="686" alt="Code Factory dashboard" src="https://github.com/user-attachments/assets/66dfa082-c732-4989-8b05-f19aa550acb5" />
+
 ## Why It Exists
 
 Pull requests often stall for boring reasons:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
-# Oh-my-PR
-**This project is going to save you tons of time by automating the whole PR process.**
-
-**Local-first GitHub PR babysitter for Codex and Claude**
-
-<p align="center">
-  <img width="409" height="409" alt="Code Factory logo" src="https://github.com/user-attachments/assets/ca339a71-40d9-4619-900f-55825f30a57f" />
-</p>
+# oh-my-pr
 
 [![npm version](https://img.shields.io/npm/v/oh-my-pr.svg)](https://www.npmjs.com/package/oh-my-pr)
 [![CI](https://github.com/yungookim/oh-my-pr/actions/workflows/ci.yml/badge.svg)](https://github.com/yungookim/oh-my-pr/actions/workflows/ci.yml)
@@ -13,80 +6,118 @@
 [![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-green.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue.svg)](https://www.typescriptlang.org/)
 
-Oh-my-pr babysits your PRs from your local machine, reads all PR comments and CI/CD logs, resolves conflicts, and gets your PR ready for merge to main. It uses your local Claude Code or Codex to address any issues identified in the PR or CI/CD pipeline and to ensure that any documentation is up to date. You can push a PR, walk away, and come back to a clean PR ready to be merged.
+oh-my-pr is a local-first GitHub PR babysitter. It watches the pull requests you care about, reads review feedback and CI failures, then uses your local Codex or Claude CLI to make fixes in isolated worktrees and push them back to the PR branch.
 
-<img width="1365" height="686" alt="Code Factory dashboard" src="https://github.com/user-attachments/assets/66dfa082-c732-4989-8b05-f19aa550acb5" />
+If you regularly lose time to review comments, flaky checks, merge conflicts, and back-and-forth cleanup before merge, this is the tool for that.
 
-## Features
+## Why It Exists
 
-- Watch multiple repositories with a per-repo auto-discovery scope (`My PRs only` by default, or `My PRs + teammates`) or add a single PR by URL.
-- Auto-register matching open PRs from watched repos, archive closed or merged PRs, and keep syncing review activity.
-- Pause background automation for an individual tracked PR while keeping manual runs available.
-- Store PR state, background jobs, questions, release runs, logs, and social changelogs in SQLite with mirrored log files.
-- Queue repo sync, babysit/apply runs, PR questions, release processing, deployment healing, and social changelog generation in a durable SQLite-backed dispatcher that survives restarts.
-- Triage feedback into `accept`, `reject`, or `flag`, with manual overrides and retry for failed or warned items.
-- Run `codex` or `claude` in isolated worktrees under `~/.oh-my-pr`, then push verified fixes back to the PR branch.
-- Evaluate review comments and failing CI statuses, post GitHub follow-ups, resolve review threads, and heal CI failures through persisted CI healing sessions per PR head.
-- Monitor merged Vercel or Railway deployments, capture deployment logs on failure, and open follow-up `deploy-fix/*` PRs when deployment healing is enabled.
-- Detect merge conflicts and optionally let the agent resolve them automatically.
-- Ask natural-language questions about any tracked PR from the dashboard or via MCP.
-- Configure trusted reviewers, ignored bots, polling, batching, run limits, and CI-healing retry budgets from settings.
-- Enable drain mode to stop claiming new queued work and optionally wait for active queue handlers to finish before deploys or upgrades.
-- Check onboarding status, install Claude or Codex review workflows, and generate social changelogs every 5 PRs merged to `main`.
-- Use the React dashboard, local REST API, MCP server, or optional Tauri desktop shell.
+Pull requests often stall for boring reasons:
 
-## How It Works
+- review comments arrive after you have switched context
+- CI fails after you think the work is done
+- fixes require reopening local context and rebuilding the same mental model
+- merge prep becomes repetitive babysitting instead of real development
 
-1. Add a repository to the watch list or register a PR directly by URL. Watched repos default to `My PRs only`, and you can switch a repo to `My PRs + teammates` when you want team-wide discovery.
-2. The watcher enqueues a durable repo-sync job in SQLite.
-3. That sync job polls GitHub, auto-registers matching open PRs for each watched repo based on its watch scope, syncs reviews and comments, archives PRs that closed upstream, records failing CI on the current head SHA, and queues babysitter runs for tracked PRs whose background watch is enabled.
-4. Manual apply/babysit requests, PR questions, release processing, and social changelog generation go through the same durable queue before work executes in an app-owned repo cache and isolated git worktree under `~/.oh-my-pr`.
-5. The agent applies fixes, verifies the result, pushes to the PR branch, updates GitHub threads, and writes logs for the full run.
-
-Repo sync, babysit/apply, PR Q&A, release processing, deployment healing, and social changelog generation all run through durable background jobs stored in `state.sqlite`. On startup the dispatcher reclaims expired job leases, and interrupted babysitter runs are resumed from stored run context when possible.
-
-PRs you register directly by URL stay tracked regardless of the watched repo's auto-discovery scope.
-
-## CI Healing
-
-When `Automatic CI healing` is enabled, Code Factory creates a healing session for each failing PR head SHA, classifies failures as safe to fix in-branch or blocked external, and runs bounded repair attempts in isolated worktrees. The dashboard surfaces the current session state and retry budget, and the local API exposes `GET /api/healing-sessions` plus `GET /api/healing-sessions/:id` for operator visibility.
-
-## Deployment Healing
-
-When deployment healing is enabled through `PATCH /api/config`, Code Factory inspects merged PRs for supported deployment markers, waits for the post-merge deployment to appear, and polls the matching platform CLI for success or failure. On failure, it captures deployment logs, runs the configured agent from the merge commit in the app-owned repo cache, pushes a `deploy-fix/<platform>-<timestamp>` branch, and opens a follow-up PR against the merged base branch.
-
-Deployment healing currently supports Vercel and Railway repositories detected from common repo-local config files. It requires the matching CLI in `PATH` and authenticated on the same machine running Code Factory. Session history is exposed through `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, and the matching MCP read tools.
+oh-my-pr keeps that loop moving from your machine. You push a branch, let it watch the PR, and come back to something much closer to merge-ready.
 
 ## Quick Start
+
+You need:
+
+- Node.js 22+
+- `git`
+- GitHub auth via `gh auth login` or `GITHUB_TOKEN`
+- either the `codex` CLI or `claude` CLI installed and authenticated locally
+
+Install and launch:
 
 ```bash
 npm install -g oh-my-pr
 oh-my-pr
 ```
 
-That's it. The terminal UI launches in your shell. Run `oh-my-pr web` to start the web dashboard instead.
-
-### Prerequisites
-
-- **Node.js 22+** (tested with Node v24.12.0)
-- **git**
-- GitHub auth via `gh auth login`, `GITHUB_TOKEN`, app config, or a saved dashboard token
-- Either the `codex` CLI or `claude` CLI installed and authenticated locally
-- Optional for deployment healing: the `vercel` CLI and/or `railway` CLI installed and authenticated for repositories you want to auto-heal after merge
-
-### CLI Usage
+That opens the terminal UI. If you prefer the browser dashboard, run:
 
 ```bash
-oh-my-pr              Launch the terminal UI (default)
-oh-my-pr web          Start the web dashboard server (opens browser)
-oh-my-pr mcp          Start the MCP server for Claude Desktop / OpenClaw
-oh-my-pr --help       Show help message
-oh-my-pr --version    Print the version
+oh-my-pr web
+```
+
+Then:
+
+1. Add a GitHub repository you want to watch.
+2. Choose whether to auto-discover only your PRs or your team's PRs too.
+3. Add a PR directly by URL if you want to track just one pull request.
+4. Let oh-my-pr sync comments, checks, and follow-up work.
+
+## What It Does
+
+- Watches repositories and tracked PRs for review activity, comments, and failing checks
+- Triages feedback into actionable items
+- Runs `codex` or `claude` in isolated worktrees under `~/.oh-my-pr`
+- Replies to GitHub PR comments on your behalf and resolves conversations to keep the thread clean
+- Pushes verified fixes back to the PR branch
+- Can automatically create a GitHub release when a merged PR is important enough to justify a version bump
+- Keeps logs, run history, and PR state on your machine
+- Exposes the same system through a dashboard, local API, and MCP server
+
+## Technical Details
+
+### Local-First
+
+oh-my-pr runs on your machine and works with your local agent CLI. Repository caches, worktrees, logs, and app state live under `~/.oh-my-pr` by default. Set `OH_MY_PR_HOME` if you want a different location.
+
+### Isolation
+
+Each fix run happens in an app-owned repository cache and an isolated git worktree. That keeps agent changes scoped to the PR branch instead of mutating your day-to-day checkout.
+
+### GitHub Auth
+
+You can authenticate with:
+
+- `gh auth login`
+- `GITHUB_TOKEN`
+- app config in the dashboard
+- a saved dashboard token
+
+### Watch Scope
+
+Watched repositories default to `My PRs only`. You can switch a repo to `My PRs + teammates`, or skip auto-discovery entirely and register a single PR by URL.
+
+### Interfaces
+
+oh-my-pr can be used in a few ways:
+
+- terminal UI: `oh-my-pr`
+- web dashboard: `oh-my-pr web`
+- MCP server: `oh-my-pr mcp`
+- local REST API: see [LOCAL_API.md](LOCAL_API.md)
+- optional Tauri desktop shell
+
+### Optional Automation
+
+If you enable them, oh-my-pr can also:
+
+- attempt bounded CI healing for failing PR heads
+- monitor merged deployments and open follow-up fix PRs for supported Vercel and Railway failures
+- create GitHub releases automatically for merged changes that are worthy of a new version
+- answer natural-language questions about tracked PRs through the dashboard or MCP
+
+Those features are optional and documented in the linked docs below.
+
+## Commands
+
+```bash
+oh-my-pr              # terminal UI
+oh-my-pr web          # web dashboard
+oh-my-pr mcp          # MCP server
+oh-my-pr --help       # help
+oh-my-pr --version    # version
 ```
 
 Set `PORT` to change the default web server port (`5001`).
 
-### Run From Source
+## Run From Source
 
 ```bash
 git clone https://github.com/yungookim/oh-my-pr.git
@@ -95,17 +126,7 @@ npm install
 npm run dev
 ```
 
-The dashboard is served on port `5001` by default. All `/api/*` routes are restricted to loopback callers.
-
-## MCP and API
-
-Oh-my-pr exposes the same local system through REST and MCP.
-
-```bash
-oh-my-pr mcp
-```
-
-Use it with MCP hosts such as Claude Desktop or OpenClaw, or call the REST API directly from local tooling. Full endpoint and tool docs live in [LOCAL_API.md](LOCAL_API.md).
+The dashboard serves on `http://localhost:5001` by default. All `/api/*` routes are restricted to loopback callers.
 
 ## Docs
 
@@ -114,6 +135,7 @@ Use it with MCP hosts such as Claude Desktop or OpenClaw, or call the REST API d
 - [Agent Dispatch](docs/public/agent-dispatch.md)
 - [Configuration](docs/public/configuration.md)
 - [Local API and MCP](LOCAL_API.md)
+- [Contributing](CONTRIBUTING.md)
 
 ## Development
 
@@ -128,21 +150,6 @@ Use it with MCP hosts such as Claude Desktop or OpenClaw, or call the REST API d
 | `npm run test` | Run the server test suite |
 | `npm run tauri:dev` | Start the Tauri desktop app in development |
 | `npm run tauri:build` | Build the Tauri desktop app |
-
-## Local State
-
-By default Code Factory stores its runtime data in `~/.oh-my-pr`:
-
-- `state.sqlite` for durable app state, runtime flags, background jobs, questions, releases, and changelogs
-- `log/` for mirrored activity logs
-- `repos/` for app-owned repository caches
-- `worktrees/` for isolated PR worktrees
-
-Set `OH_MY_PR_HOME` to override the root path. The legacy `CODEFACTORY_HOME` name is still supported for compatibility.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # oh-my-pr
 
 <p align="center">
-  <img width="409" height="409" alt="Code Factory logo" src="https://github.com/user-attachments/assets/ca339a71-40d9-4619-900f-55825f30a57f" />
+  <img width="409" height="409" alt="oh-my-pr logo" src="https://github.com/user-attachments/assets/ca339a71-40d9-4619-900f-55825f30a57f" />
 </p>
 
 [![npm version](https://img.shields.io/npm/v/oh-my-pr.svg)](https://www.npmjs.com/package/oh-my-pr)
@@ -14,7 +14,7 @@ oh-my-pr is a local-first GitHub PR babysitter. It watches the pull requests you
 
 If you regularly lose time to review comments, flaky checks, merge conflicts, and back-and-forth cleanup before merge, this is the tool for that.
 
-<img width="1365" height="686" alt="Code Factory dashboard" src="https://github.com/user-attachments/assets/66dfa082-c732-4989-8b05-f19aa550acb5" />
+<img width="1365" height="686" alt="oh-my-pr dashboard" src="https://github.com/user-attachments/assets/66dfa082-c732-4989-8b05-f19aa550acb5" />
 
 ## Why It Exists
 
@@ -71,7 +71,7 @@ Then:
 
 ### Local-First
 
-oh-my-pr runs on your machine and works with your local agent CLI. Repository caches, worktrees, logs, and app state live under `~/.oh-my-pr` by default. Set `OH_MY_PR_HOME` if you want a different location.
+oh-my-pr runs on your machine and works with your local agent CLI. Repository caches (`repos/`), worktrees (`worktrees/`), logs (`log/`), and app state (`state.sqlite`) live under `~/.oh-my-pr` by default. Set `OH_MY_PR_HOME` if you want a different location.
 
 ### Isolation
 
@@ -132,7 +132,7 @@ npm install
 npm run dev
 ```
 
-The dashboard serves on `http://localhost:5001` by default. All `/api/*` routes are restricted to loopback callers.
+The dashboard is available at `http://localhost:5001` by default. All `/api/*` routes are restricted to loopback callers.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # oh-my-pr
 
+<p align="center">
+  <img width="409" height="409" alt="Code Factory logo" src="https://github.com/user-attachments/assets/ca339a71-40d9-4619-900f-55825f30a57f" />
+</p>
+
 [![npm version](https://img.shields.io/npm/v/oh-my-pr.svg)](https://www.npmjs.com/package/oh-my-pr)
 [![CI](https://github.com/yungookim/oh-my-pr/actions/workflows/ci.yml/badge.svg)](https://github.com/yungookim/oh-my-pr/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -86,7 +86,7 @@ This toggle is available in the dashboard settings page and as `includeRepositor
 
 ## CI Healing Settings
 
-Code Factory can track failing CI checks as first-class healing sessions and, when enabled, dispatch bounded repair attempts in isolated worktrees.
+oh-my-pr can track failing CI checks as first-class healing sessions and, when enabled, dispatch bounded repair attempts in isolated worktrees.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -100,7 +100,7 @@ The dashboard shows healing state on each tracked PR, while the local API expose
 
 ## Deployment Healing Settings
 
-Code Factory can monitor merged PRs for failed Vercel or Railway deployments and open a follow-up fix PR when the deployment breaks after merge.
+oh-my-pr can monitor merged PRs for failed Vercel or Railway deployments and open a follow-up fix PR when the deployment breaks after merge.
 
 A repository is eligible only when platform detection finds one of these markers in the app-owned repo cache:
 
@@ -116,7 +116,7 @@ A repository is eligible only when platform detection finds one of these markers
 
 These values map to `autoHealDeployments`, `deploymentCheckDelayMs`, `deploymentCheckTimeoutMs`, and `deploymentCheckPollIntervalMs` in `GET /api/config` and `PATCH /api/config`.
 
-Deployment healing also requires the matching platform CLI on the machine running Code Factory:
+Deployment healing also requires the matching platform CLI on the machine running oh-my-pr:
 
 - Install and authenticate `vercel` to heal Vercel deployments.
 - Install and authenticate `railway` to heal Railway deployments.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -314,3 +314,12 @@
   - Inventory existing images and diagrams and decide which are essential before deleting them.
   - If the goal is "more concise," default to shortening copy first and preserving high-signal visuals.
   - Call out any planned visual removals in the execution update when they are not explicitly requested.
+
+## 2026-04-22 - Keep core user-visible automation outcomes in simplified product docs
+- Pattern: I simplified the README structure correctly, but the user had to correct me to restore two core product behaviors: replying to PR comments and resolving threads on the user's behalf, and auto-creating GitHub releases for version-worthy changes.
+- Rule: When simplifying top-level product documentation, preserve the highest-value user-visible automation outcomes, not just the infrastructure and setup details.
+- Prevention checklist:
+  - Before finalizing a rewritten README, list the product's core "why this matters" behaviors and confirm each still appears near the top.
+  - Favor outcome-level bullets such as "replies on your behalf" and "creates releases automatically" over only implementation-level bullets such as queues, worktrees, or storage.
+  - Compare the rewritten feature summary against release docs, onboarding copy, and settings surfaces to catch dropped capabilities.
+  - Treat outbound automation and shipping automation as first-class behaviors in summaries because they answer common buyer objections.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -323,3 +323,11 @@
   - Favor outcome-level bullets such as "replies on your behalf" and "creates releases automatically" over only implementation-level bullets such as queues, worktrees, or storage.
   - Compare the rewritten feature summary against release docs, onboarding copy, and settings surfaces to catch dropped capabilities.
   - Treat outbound automation and shipping automation as first-class behaviors in summaries because they answer common buyer objections.
+
+## 2026-04-22 - Keep the product screenshot above the README rationale section
+- Pattern: After simplifying the README, I removed the app screenshot from the top flow and the user had to correct me to keep it before `Why It Exists`.
+- Rule: When tightening the README for this repo, keep the main app screenshot in the top section as proof of the product before the rationale/details sections unless the user explicitly asks to remove or relocate it.
+- Prevention checklist:
+  - Treat the main app screenshot as part of the README narrative, not decorative filler.
+  - When reorganizing the top of the README, verify the order is pitch, product proof, then rationale.
+  - If I remove or relocate a high-signal screenshot, call it out explicitly before finalizing instead of assuming the user wants a text-only intro.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -83,10 +83,10 @@
   - Ask a scope question only when the named text maps to multiple equally plausible surfaces.
 
 ## 2026-03-28 - Design product features around user repositories, not this repo's own workflow
-- Pattern: I framed a new PR-documentation feature as if it were about Code Factory's own repository and CI/docs pipeline, when the user intended a product capability that agents apply to any tracked repository.
-- Rule: When designing or implementing Code Factory behavior, default to repository-agnostic product semantics unless the user explicitly scopes the request to this repo's own operations.
+- Pattern: I framed a new PR-documentation feature as if it were about oh-my-pr's own repository and CI/docs pipeline, when the user intended a product capability that agents apply to any tracked repository.
+- Rule: When designing or implementing oh-my-pr behavior, default to repository-agnostic product semantics unless the user explicitly scopes the request to this repo's own operations.
 - Prevention checklist:
-  - Restate whether a request targets Code Factory's product behavior or this repository's internal workflow before proposing a design.
+  - Restate whether a request targets oh-my-pr's product behavior or this repository's internal workflow before proposing a design.
   - Validate that prompt contracts, defaults, and storage shape make sense for arbitrary user repositories, not just `README.md` or docs layout in this repo.
   - Avoid deriving product requirements from this repo's local docs/build pipeline unless the user explicitly wants repo-specific behavior.
   - Check whether the feature needs to generalize across heterogeneous repositories before choosing fixed file paths or heuristics.


### PR DESCRIPTION
## Summary
- simplify the README so it starts with a short pitch, why the project exists, and the fastest path to getting started
- move implementation detail and optional automation into a lower technical-details section
- restore two core product outcomes in the top-level summary: replying to PR comments and resolving threads on the user's behalf, and auto-creating GitHub releases for version-worthy changes
- record the README omission lesson in `tasks/lessons.md`

## Why
The previous README was accurate but hard to scan because it mixed product pitch, setup, architecture, and long feature inventory near the top. This rewrite makes the README easier for first-time readers while preserving the details that answer technical objections.

## Impact
New readers should understand what oh-my-pr is, what problem it solves, and how to try it within the first screen. More technical readers can still find auth, worktree, local-state, API, and optional automation details further down.

## Validation
- `git diff --check -- README.md tasks/lessons.md`
- manual review of the rewritten README structure and top-level feature summary
- attempted `claude -p "/simplify README.md tasks/lessons.md"` per repo guidance, but the local Claude session reported a usage-limit block before it could review the files
