### PR TITLE
[codex] Fall back from saved GitHub tokens to gh auth

### DIFF
--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -85,91 +85,77 @@ function readAuthorizationHeader(input: string | URL | Request, init?: RequestIn
   return null;
 }
 
-test("resolveGitHubAuthToken falls back to gh auth status when gh auth token is unavailable", async () => {
-  const originalEnvToken = process.env.GITHUB_TOKEN;
+async function withoutGithubTokenEnv(fn: () => Promise<void>): Promise<void> {
+  const original = process.env.GITHUB_TOKEN;
   delete process.env.GITHUB_TOKEN;
-  let callIndex = 0;
-
   try {
-    const token = await resolveGitHubAuthToken(
-      config,
-      {
-        ignoreCache: true,
-        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
-        runCommandFn: async (_command, args) => {
-          callIndex += 1;
+    await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = original;
+    }
+  }
+}
 
-          if (callIndex === 1) {
-            assert.deepEqual(args, ["gh", "auth", "token"].slice(1));
-            return {
-              stdout: "",
-              stderr: "no oauth token found for github.com",
-              code: 1,
-            };
-          }
+test("resolveGitHubAuthToken falls back to gh auth status when gh auth token is unavailable", async () => {
+  await withoutGithubTokenEnv(async () => {
+    let callIndex = 0;
+    const token = await resolveGitHubAuthToken(config, {
+      ignoreCache: true,
+      runCommandFn: async (_command, args) => {
+        callIndex += 1;
 
-          assert.deepEqual(args, ["gh", "auth", "status", "--hostname", "github.com", "--show-token"].slice(1));
+        if (callIndex === 1) {
+          assert.deepEqual(args, ["auth", "token"]);
           return {
-            stdout: `github.com
+            stdout: "",
+            stderr: "no oauth token found for github.com",
+            code: 1,
+          };
+        }
+
+        assert.deepEqual(args, ["auth", "status", "--hostname", "github.com", "--show-token"]);
+        return {
+          stdout: `github.com
   ✓ Logged in to github.com account octo (keyring)
   - Active account: true
   - Git operations protocol: https
   - Token: gho_status_token
   - Token scopes: 'repo'`,
-            stderr: "",
-            code: 0,
-          };
-        },
+          stderr: "",
+          code: 0,
+        };
       },
-    );
+    });
 
     assert.equal(token, "gho_status_token");
     assert.equal(callIndex, 2);
-  } finally {
-    if (originalEnvToken === undefined) {
-      delete process.env.GITHUB_TOKEN;
-    } else {
-      process.env.GITHUB_TOKEN = originalEnvToken;
-    }
-  }
+  });
 });
 
 test("buildOctokit retries once with gh auth when the saved github token gets 401", async () => {
-  const originalEnvToken = process.env.GITHUB_TOKEN;
-  delete process.env.GITHUB_TOKEN;
-  const authHeaders: string[] = [];
-
-  try {
+  await withoutGithubTokenEnv(async () => {
+    const authHeaders: string[] = [];
     const octokit = await buildOctokit(
-      {
-        ...config,
-        githubToken: "ghp_saved_token",
-      },
+      { ...config, githubToken: "ghp_saved_token" },
       {
         ignoreCache: true,
-        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
         runCommandFn: async (_command, args) => {
           assert.deepEqual(args, ["auth", "token"]);
-          return {
-            stdout: "gho_cli_token\n",
-            stderr: "",
-            code: 0,
-          };
+          return { stdout: "gho_cli_token\n", stderr: "", code: 0 };
         },
         requestFetch: async (input, init) => {
           authHeaders.push(readAuthorizationHeader(input, init) ?? "");
-
-          if (authHeaders.length === 1) {
-            return new Response(JSON.stringify({ message: "Bad credentials" }), {
-              status: 401,
+          const isFirst = authHeaders.length === 1;
+          return new Response(
+            JSON.stringify(isFirst ? { message: "Bad credentials" } : { login: "octo" }),
+            {
+              status: isFirst ? 401 : 200,
               headers: { "content-type": "application/json" },
-            });
-          }
-
-          return new Response(JSON.stringify({ login: "octo" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          });
+            },
+          );
         },
       },
     );
@@ -177,38 +163,18 @@ test("buildOctokit retries once with gh auth when the saved github token gets 40
     const response = await octokit.rest.users.getAuthenticated();
 
     assert.equal(response.data.login, "octo");
-    assert.deepEqual(authHeaders, [
-      "token ghp_saved_token",
-      "token gho_cli_token",
-    ]);
-  } finally {
-    if (originalEnvToken === undefined) {
-      delete process.env.GITHUB_TOKEN;
-    } else {
-      process.env.GITHUB_TOKEN = originalEnvToken;
-    }
-  }
+    assert.deepEqual(authHeaders, ["token ghp_saved_token", "token gho_cli_token"]);
+  });
 });
 
-test("buildOctokit only retries once when the gh auth fallback also gets 401", async () => {
-  const originalEnvToken = process.env.GITHUB_TOKEN;
-  delete process.env.GITHUB_TOKEN;
-  let requestCount = 0;
-
-  try {
+test("buildOctokit does not retry beyond the gh auth fallback when it also gets 401", async () => {
+  await withoutGithubTokenEnv(async () => {
+    let requestCount = 0;
     const octokit = await buildOctokit(
-      {
-        ...config,
-        githubToken: "ghp_saved_token",
-      },
+      { ...config, githubToken: "ghp_saved_token" },
       {
         ignoreCache: true,
-        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
-        runCommandFn: async () => ({
-          stdout: "gho_cli_token\n",
-          stderr: "",
-          code: 0,
-        }),
+        runCommandFn: async () => ({ stdout: "gho_cli_token\n", stderr: "", code: 0 }),
         requestFetch: async () => {
           requestCount += 1;
           return new Response(JSON.stringify({ message: "Bad credentials" }), {
@@ -227,13 +193,7 @@ test("buildOctokit only retries once when the gh auth fallback also gets 401", a
       },
     );
     assert.equal(requestCount, 2);
-  } finally {
-    if (originalEnvToken === undefined) {
-      delete process.env.GITHUB_TOKEN;
-    } else {
-      process.env.GITHUB_TOKEN = originalEnvToken;
-    }
-  }
+  });
 });
 
 test("checkOnboardingStatus reads workflow files with authenticated API content calls", async () => {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Config, FeedbackItem } from "@shared/schema";
 import {
   buildGitHubCloneUrl,
+  buildOctokit,
   GitHubIntegrationError,
   buildFeedbackAuditToken,
   checkOnboardingStatus,
@@ -22,6 +23,7 @@ import {
   postFollowUpForFeedbackItem,
   postStatusReplyForFeedbackItem,
   resolveNextSemverTag,
+  resolveGitHubAuthToken,
   resolveReviewThread,
   selectLatestSemverTag,
   updateStatusReply,
@@ -70,6 +72,169 @@ function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
     ...overrides,
   };
 }
+
+function readAuthorizationHeader(input: string | URL | Request, init?: RequestInit): string | null {
+  if (init?.headers) {
+    return new Headers(init.headers).get("authorization");
+  }
+
+  if (input instanceof Request) {
+    return input.headers.get("authorization");
+  }
+
+  return null;
+}
+
+test("resolveGitHubAuthToken falls back to gh auth status when gh auth token is unavailable", async () => {
+  const originalEnvToken = process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  let callIndex = 0;
+
+  try {
+    const token = await resolveGitHubAuthToken(
+      config,
+      {
+        ignoreCache: true,
+        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
+        runCommandFn: async (_command, args) => {
+          callIndex += 1;
+
+          if (callIndex === 1) {
+            assert.deepEqual(args, ["gh", "auth", "token"].slice(1));
+            return {
+              stdout: "",
+              stderr: "no oauth token found for github.com",
+              code: 1,
+            };
+          }
+
+          assert.deepEqual(args, ["gh", "auth", "status", "--hostname", "github.com", "--show-token"].slice(1));
+          return {
+            stdout: `github.com
+  ✓ Logged in to github.com account octo (keyring)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_status_token
+  - Token scopes: 'repo'`,
+            stderr: "",
+            code: 0,
+          };
+        },
+      },
+    );
+
+    assert.equal(token, "gho_status_token");
+    assert.equal(callIndex, 2);
+  } finally {
+    if (originalEnvToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalEnvToken;
+    }
+  }
+});
+
+test("buildOctokit retries once with gh auth when the saved github token gets 401", async () => {
+  const originalEnvToken = process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  const authHeaders: string[] = [];
+
+  try {
+    const octokit = await buildOctokit(
+      {
+        ...config,
+        githubToken: "ghp_saved_token",
+      },
+      {
+        ignoreCache: true,
+        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
+        runCommandFn: async (_command, args) => {
+          assert.deepEqual(args, ["auth", "token"]);
+          return {
+            stdout: "gho_cli_token\n",
+            stderr: "",
+            code: 0,
+          };
+        },
+        requestFetch: async (input, init) => {
+          authHeaders.push(readAuthorizationHeader(input, init) ?? "");
+
+          if (authHeaders.length === 1) {
+            return new Response(JSON.stringify({ message: "Bad credentials" }), {
+              status: 401,
+              headers: { "content-type": "application/json" },
+            });
+          }
+
+          return new Response(JSON.stringify({ login: "octo" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    );
+
+    const response = await octokit.rest.users.getAuthenticated();
+
+    assert.equal(response.data.login, "octo");
+    assert.deepEqual(authHeaders, [
+      "token ghp_saved_token",
+      "token gho_cli_token",
+    ]);
+  } finally {
+    if (originalEnvToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalEnvToken;
+    }
+  }
+});
+
+test("buildOctokit only retries once when the gh auth fallback also gets 401", async () => {
+  const originalEnvToken = process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  let requestCount = 0;
+
+  try {
+    const octokit = await buildOctokit(
+      {
+        ...config,
+        githubToken: "ghp_saved_token",
+      },
+      {
+        ignoreCache: true,
+        nowFn: () => Number.MAX_SAFE_INTEGER / 2,
+        runCommandFn: async () => ({
+          stdout: "gho_cli_token\n",
+          stderr: "",
+          code: 0,
+        }),
+        requestFetch: async () => {
+          requestCount += 1;
+          return new Response(JSON.stringify({ message: "Bad credentials" }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    );
+
+    await assert.rejects(
+      () => octokit.rest.users.getAuthenticated(),
+      (error: unknown) => {
+        assert.equal((error as { status?: number }).status, 401);
+        return true;
+      },
+    );
+    assert.equal(requestCount, 2);
+  } finally {
+    if (originalEnvToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalEnvToken;
+    }
+  }
+});
 
 test("checkOnboardingStatus reads workflow files with authenticated API content calls", async () => {
   const getContentCalls: Array<{ owner: string; repo: string; path: string }> = [];

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -135,6 +135,46 @@ test("resolveGitHubAuthToken falls back to gh auth status when gh auth token is 
   });
 });
 
+test("resolveGitHubAuthToken reads the active gh auth status token regardless of line order", async () => {
+  await withoutGithubTokenEnv(async () => {
+    let callIndex = 0;
+    const token = await resolveGitHubAuthToken(config, {
+      ignoreCache: true,
+      runCommandFn: async (_command, args) => {
+        callIndex += 1;
+
+        if (callIndex === 1) {
+          assert.deepEqual(args, ["auth", "token"]);
+          return {
+            stdout: "",
+            stderr: "no oauth token found for github.com",
+            code: 1,
+          };
+        }
+
+        assert.deepEqual(args, ["auth", "status", "--hostname", "github.com", "--show-token"]);
+        return {
+          stdout: [
+            "github.com",
+            "  ✓ Logged in to github.com account inactive (keyring)",
+            "  - Token: gho_inactive_token   ",
+            "  - Active account: false",
+            "  ✓ Logged in to github.com account octo (keyring)",
+            "  - Token: gho_active_token   ",
+            "  - Active account: true",
+            "  - Token scopes: 'repo'",
+          ].join("\n"),
+          stderr: "",
+          code: 0,
+        };
+      },
+    });
+
+    assert.equal(token, "gho_active_token");
+    assert.equal(callIndex, 2);
+  });
+});
+
 test("buildOctokit retries once with gh auth when the saved github token gets 401", async () => {
   await withoutGithubTokenEnv(async () => {
     const authHeaders: string[] = [];
@@ -164,6 +204,38 @@ test("buildOctokit retries once with gh auth when the saved github token gets 40
 
     assert.equal(response.data.login, "octo");
     assert.deepEqual(authHeaders, ["token ghp_saved_token", "token gho_cli_token"]);
+  });
+});
+
+test("buildOctokit preserves per-request request options on gh auth retry", async () => {
+  await withoutGithubTokenEnv(async () => {
+    const controller = new AbortController();
+    const signals: Array<AbortSignal | null> = [];
+    const octokit = await buildOctokit(
+      { ...config, githubToken: "ghp_saved_token" },
+      {
+        ignoreCache: true,
+        runCommandFn: async () => ({ stdout: "gho_cli_token\n", stderr: "", code: 0 }),
+        requestFetch: async (_input, init) => {
+          signals.push(init?.signal ?? null);
+          const isFirst = signals.length === 1;
+          return new Response(
+            JSON.stringify(isFirst ? { message: "Bad credentials" } : { login: "octo" }),
+            {
+              status: isFirst ? 401 : 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        },
+      },
+    );
+
+    const response = await octokit.request("GET /user", {
+      request: { signal: controller.signal },
+    });
+
+    assert.equal(response.data.login, "octo");
+    assert.deepEqual(signals, [controller.signal, controller.signal]);
   });
 });
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -199,15 +199,6 @@ type BuildOctokitDeps = GitHubAuthResolutionDeps & {
   requestFetch?: typeof fetch;
 };
 
-function cacheGhAuthToken(token: string, now: number): string {
-  cachedGhAuthToken = {
-    token,
-    expiresAt: now + GH_AUTH_CACHE_TTL_MS,
-  };
-  ghAuthFailureCooldownUntil = 0;
-  return token;
-}
-
 function parseGhAuthStatusToken(stdout: string): string | undefined {
   let activeAccount = false;
 
@@ -227,23 +218,8 @@ function parseGhAuthStatusToken(stdout: string): string | undefined {
   return undefined;
 }
 
-function parseTokenFromAuthorizationHeader(authorization: string | null | undefined): string | undefined {
-  if (!authorization) {
-    return undefined;
-  }
-
-  const trimmed = authorization.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-
-  const match = trimmed.match(/^(?:token|bearer)\s+(.+)$/i);
-  return match?.[1]?.trim() || trimmed;
-}
-
-function isUnauthorizedGitHubError(error: unknown): error is GitHubErrorLike {
-  return typeof (error as GitHubErrorLike | undefined)?.status === "number"
-    && (error as GitHubErrorLike).status === 401;
+function isUnauthorized(error: unknown): boolean {
+  return (error as { status?: number } | undefined)?.status === 401;
 }
 
 async function resolveGhAuthToken(
@@ -254,30 +230,36 @@ async function resolveGhAuthToken(
   const now = nowFn();
   const ignoreCache = deps.ignoreCache ?? false;
 
-  if (!ignoreCache && cachedGhAuthToken && cachedGhAuthToken.expiresAt > now) {
-    return cachedGhAuthToken.token;
+  if (!ignoreCache) {
+    if (cachedGhAuthToken && cachedGhAuthToken.expiresAt > now) {
+      return cachedGhAuthToken.token;
+    }
+    if (ghAuthFailureCooldownUntil > now) {
+      return undefined;
+    }
   }
 
-  if (!ignoreCache && ghAuthFailureCooldownUntil > now) {
-    return undefined;
-  }
+  const persist = (token: string): string => {
+    if (ignoreCache) return token;
+    cachedGhAuthToken = { token, expiresAt: now + GH_AUTH_CACHE_TTL_MS };
+    ghAuthFailureCooldownUntil = 0;
+    return token;
+  };
 
-  const directResult = await runCommandFn("gh", ["auth", "token"], {
-    timeoutMs: 4000,
-  });
+  const directResult = await runCommandFn("gh", ["auth", "token"], { timeoutMs: 4000 });
   const directToken = directResult.stdout.trim();
   if (directResult.code === 0 && directToken) {
-    return ignoreCache ? directToken : cacheGhAuthToken(directToken, now);
+    return persist(directToken);
   }
 
-  const statusResult = await runCommandFn("gh", ["auth", "status", "--hostname", "github.com", "--show-token"], {
-    timeoutMs: 4000,
-  });
-  const statusToken = statusResult.code === 0
-    ? parseGhAuthStatusToken(statusResult.stdout)
-    : undefined;
-  if (statusToken) {
-    return ignoreCache ? statusToken : cacheGhAuthToken(statusToken, now);
+  const statusResult = await runCommandFn(
+    "gh",
+    ["auth", "status", "--hostname", "github.com", "--show-token"],
+    { timeoutMs: 4000 },
+  );
+  if (statusResult.code === 0) {
+    const statusToken = parseGhAuthStatusToken(statusResult.stdout);
+    if (statusToken) return persist(statusToken);
   }
 
   if (!ignoreCache) {
@@ -494,8 +476,6 @@ export async function buildOctokit(
 ): Promise<Octokit> {
   const envToken = process.env.GITHUB_TOKEN?.trim();
   const configuredToken = config.githubToken?.trim();
-  const ghAuthToken = !envToken ? await resolveGhAuthToken(deps) : undefined;
-  const auth = envToken || configuredToken || ghAuthToken;
   const buildClient = (authToken?: string) => new Octokit({
     auth: authToken,
     request: {
@@ -505,35 +485,25 @@ export async function buildOctokit(
       },
     },
   });
-  const octokit = buildClient(auth);
-  const fallbackOctokit = configuredToken && ghAuthToken && ghAuthToken !== configuredToken
-    ? buildClient(ghAuthToken)
-    : null;
 
-  if (fallbackOctokit) {
+  const primaryToken = envToken || configuredToken || (await resolveGhAuthToken(deps));
+  const octokit = buildClient(primaryToken);
+
+  if (!envToken && configuredToken) {
+    let fallbackOctokit: Octokit | null = null;
     octokit.hook.wrap("request", async (request, options) => {
       try {
         return await request(options);
       } catch (error) {
-        if (!isUnauthorizedGitHubError(error)) {
-          throw error;
-        }
+        if (!isUnauthorized(error)) throw error;
 
-        const currentToken = parseTokenFromAuthorizationHeader(
-          new Headers(options.headers as HeadersInit).get("authorization"),
-        );
-        if (currentToken && currentToken !== configuredToken) {
-          throw error;
-        }
+        const ghAuthToken = await resolveGhAuthToken(deps);
+        if (!ghAuthToken || ghAuthToken === configuredToken) throw error;
 
-        const { request: _request, ...retryOptions } = options;
-        const retryHeaders = new Headers(retryOptions.headers as HeadersInit);
-        retryHeaders.delete("authorization");
-
-        return fallbackOctokit.request({
-          ...retryOptions,
-          headers: Object.fromEntries(retryHeaders.entries()),
-        });
+        fallbackOctokit ??= buildClient(ghAuthToken);
+        const { request: _r, ...retryOptions } = options;
+        const { authorization: _a, ...headers } = (retryOptions.headers ?? {}) as Record<string, string>;
+        return fallbackOctokit.request({ ...retryOptions, headers });
       }
     });
   }

--- a/server/github.ts
+++ b/server/github.ts
@@ -189,6 +189,104 @@ type GitHubErrorLike = Error & {
   };
 };
 
+type GitHubAuthResolutionDeps = {
+  ignoreCache?: boolean;
+  runCommandFn?: typeof runCommand;
+  nowFn?: () => number;
+};
+
+type BuildOctokitDeps = GitHubAuthResolutionDeps & {
+  requestFetch?: typeof fetch;
+};
+
+function cacheGhAuthToken(token: string, now: number): string {
+  cachedGhAuthToken = {
+    token,
+    expiresAt: now + GH_AUTH_CACHE_TTL_MS,
+  };
+  ghAuthFailureCooldownUntil = 0;
+  return token;
+}
+
+function parseGhAuthStatusToken(stdout: string): string | undefined {
+  let activeAccount = false;
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const activeMatch = line.match(/Active account:\s*(true|false)/i);
+    if (activeMatch) {
+      activeAccount = activeMatch[1]?.toLowerCase() === "true";
+      continue;
+    }
+
+    const tokenMatch = line.match(/Token:\s*(\S+)/);
+    if (activeAccount && tokenMatch?.[1]) {
+      return tokenMatch[1].trim();
+    }
+  }
+
+  return undefined;
+}
+
+function parseTokenFromAuthorizationHeader(authorization: string | null | undefined): string | undefined {
+  if (!authorization) {
+    return undefined;
+  }
+
+  const trimmed = authorization.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const match = trimmed.match(/^(?:token|bearer)\s+(.+)$/i);
+  return match?.[1]?.trim() || trimmed;
+}
+
+function isUnauthorizedGitHubError(error: unknown): error is GitHubErrorLike {
+  return typeof (error as GitHubErrorLike | undefined)?.status === "number"
+    && (error as GitHubErrorLike).status === 401;
+}
+
+async function resolveGhAuthToken(
+  deps: GitHubAuthResolutionDeps = {},
+): Promise<string | undefined> {
+  const runCommandFn = deps.runCommandFn ?? runCommand;
+  const nowFn = deps.nowFn ?? Date.now;
+  const now = nowFn();
+  const ignoreCache = deps.ignoreCache ?? false;
+
+  if (!ignoreCache && cachedGhAuthToken && cachedGhAuthToken.expiresAt > now) {
+    return cachedGhAuthToken.token;
+  }
+
+  if (!ignoreCache && ghAuthFailureCooldownUntil > now) {
+    return undefined;
+  }
+
+  const directResult = await runCommandFn("gh", ["auth", "token"], {
+    timeoutMs: 4000,
+  });
+  const directToken = directResult.stdout.trim();
+  if (directResult.code === 0 && directToken) {
+    return ignoreCache ? directToken : cacheGhAuthToken(directToken, now);
+  }
+
+  const statusResult = await runCommandFn("gh", ["auth", "status", "--hostname", "github.com", "--show-token"], {
+    timeoutMs: 4000,
+  });
+  const statusToken = statusResult.code === 0
+    ? parseGhAuthStatusToken(statusResult.stdout)
+    : undefined;
+  if (statusToken) {
+    return ignoreCache ? statusToken : cacheGhAuthToken(statusToken, now);
+  }
+
+  if (!ignoreCache) {
+    cachedGhAuthToken = null;
+    ghAuthFailureCooldownUntil = now + GH_AUTH_CACHE_TTL_MS;
+  }
+  return undefined;
+}
+
 export class GitHubIntegrationError extends Error {
   readonly statusCode: number;
 
@@ -298,7 +396,10 @@ export async function fetchCheckSnapshotsForRef(
   });
 }
 
-export async function resolveGitHubAuthToken(config: Config): Promise<string | undefined> {
+export async function resolveGitHubAuthToken(
+  config: Config,
+  deps: GitHubAuthResolutionDeps = {},
+): Promise<string | undefined> {
   const envToken = process.env.GITHUB_TOKEN?.trim();
   if (envToken) {
     return envToken;
@@ -309,32 +410,7 @@ export async function resolveGitHubAuthToken(config: Config): Promise<string | u
     return configuredToken;
   }
 
-  const now = Date.now();
-  if (cachedGhAuthToken && cachedGhAuthToken.expiresAt > now) {
-    return cachedGhAuthToken.token;
-  }
-
-  if (ghAuthFailureCooldownUntil > now) {
-    return undefined;
-  }
-
-  const result = await runCommand("gh", ["auth", "token"], {
-    timeoutMs: 4000,
-  });
-
-  const token = result.stdout.trim();
-  if (result.code === 0 && token) {
-    cachedGhAuthToken = {
-      token,
-      expiresAt: now + GH_AUTH_CACHE_TTL_MS,
-    };
-    ghAuthFailureCooldownUntil = 0;
-    return token;
-  }
-
-  cachedGhAuthToken = null;
-  ghAuthFailureCooldownUntil = now + GH_AUTH_CACHE_TTL_MS;
-  return undefined;
+  return resolveGhAuthToken(deps);
 }
 
 function formatGitHubTarget(resource: ParsedPRUrl | ParsedRepoSlug): string {
@@ -412,17 +488,57 @@ async function withGitHubErrorHandling<T>(
   }
 }
 
-export async function buildOctokit(config: Config): Promise<Octokit> {
-  const auth = await resolveGitHubAuthToken(config);
-
-  return new Octokit({
-    auth,
+export async function buildOctokit(
+  config: Config,
+  deps: BuildOctokitDeps = {},
+): Promise<Octokit> {
+  const envToken = process.env.GITHUB_TOKEN?.trim();
+  const configuredToken = config.githubToken?.trim();
+  const ghAuthToken = !envToken ? await resolveGhAuthToken(deps) : undefined;
+  const auth = envToken || configuredToken || ghAuthToken;
+  const buildClient = (authToken?: string) => new Octokit({
+    auth: authToken,
     request: {
+      ...(deps.requestFetch ? { fetch: deps.requestFetch } : {}),
       headers: {
         "X-GitHub-Api-Version": GITHUB_API_VERSION,
       },
     },
   });
+  const octokit = buildClient(auth);
+  const fallbackOctokit = configuredToken && ghAuthToken && ghAuthToken !== configuredToken
+    ? buildClient(ghAuthToken)
+    : null;
+
+  if (fallbackOctokit) {
+    octokit.hook.wrap("request", async (request, options) => {
+      try {
+        return await request(options);
+      } catch (error) {
+        if (!isUnauthorizedGitHubError(error)) {
+          throw error;
+        }
+
+        const currentToken = parseTokenFromAuthorizationHeader(
+          new Headers(options.headers as HeadersInit).get("authorization"),
+        );
+        if (currentToken && currentToken !== configuredToken) {
+          throw error;
+        }
+
+        const { request: _request, ...retryOptions } = options;
+        const retryHeaders = new Headers(retryOptions.headers as HeadersInit);
+        retryHeaders.delete("authorization");
+
+        return fallbackOctokit.request({
+          ...retryOptions,
+          headers: Object.fromEntries(retryHeaders.entries()),
+        });
+      }
+    });
+  }
+
+  return octokit;
 }
 
 export type CodeReviewPresence = {

--- a/server/github.ts
+++ b/server/github.ts
@@ -200,22 +200,40 @@ type BuildOctokitDeps = GitHubAuthResolutionDeps & {
 };
 
 function parseGhAuthStatusToken(stdout: string): string | undefined {
-  let activeAccount = false;
+  type AccountBlock = {
+    active?: boolean;
+    token?: string;
+  };
+  let currentBlock: AccountBlock = {};
+  let activeToken: string | undefined;
+  const flushCurrentBlock = () => {
+    if (!activeToken && currentBlock.active && currentBlock.token) {
+      activeToken = currentBlock.token;
+    }
+    currentBlock = {};
+  };
 
-  for (const line of stdout.split(/\r?\n/)) {
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (/\bLogged in to\b.*\baccount\b/i.test(line)) {
+      flushCurrentBlock();
+      continue;
+    }
+
     const activeMatch = line.match(/Active account:\s*(true|false)/i);
     if (activeMatch) {
-      activeAccount = activeMatch[1]?.toLowerCase() === "true";
+      currentBlock.active = activeMatch[1]?.toLowerCase() === "true";
       continue;
     }
 
     const tokenMatch = line.match(/Token:\s*(\S+)/);
-    if (activeAccount && tokenMatch?.[1]) {
-      return tokenMatch[1].trim();
+    if (tokenMatch?.[1]) {
+      currentBlock.token = tokenMatch[1].trim();
     }
   }
 
-  return undefined;
+  flushCurrentBlock();
+  return activeToken;
 }
 
 function isUnauthorized(error: unknown): boolean {
@@ -501,9 +519,11 @@ export async function buildOctokit(
         if (!ghAuthToken || ghAuthToken === configuredToken) throw error;
 
         fallbackOctokit ??= buildClient(ghAuthToken);
-        const { request: _r, ...retryOptions } = options;
+        const retryOptions = { ...options };
         const { authorization: _a, ...headers } = (retryOptions.headers ?? {}) as Record<string, string>;
-        return fallbackOctokit.request({ ...retryOptions, headers });
+        const { hook: _h, ...requestOptions } = (retryOptions.request ?? {}) as Record<string, unknown>;
+        const requestOverride = Object.keys(requestOptions).length > 0 ? { request: requestOptions } : {};
+        return fallbackOctokit.request({ ...retryOptions, headers, ...requestOverride });
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a more robust `gh` auth token resolver that falls back to `gh auth status --show-token` when `gh auth token` is unavailable
- retry GitHub API requests once with the `gh` credential when a saved `githubToken` returns `401 Bad credentials`
- add regression tests for the `gh` fallback path and the single-retry guardrail

## Root cause
`oh-my-pr` preferred the saved `config.githubToken` over `gh` auth. If that persisted token had gone stale, requests failed with `401` and never fell through to the valid `gh` login on the machine. On this machine, `gh auth token` also failed even though `gh auth status --show-token` still exposed the active credential, so the existing CLI fallback path was too narrow.

## Impact
Tracked-repo sync and other GitHub API calls can recover from a stale saved token by falling back to the current `gh` session without changing `GITHUB_TOKEN` env precedence.

## Validation
- `node --test --import tsx server/github.test.ts`
- `node --test --import tsx server/*.test.ts`
- `npm run check`
