### PR TITLE
feat: support ordered GitHub tokens

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -570,9 +570,10 @@ Get one deployment-healing session by its internal Code Factory ID.
 
 #### `GET /api/config`
 
-Read the current configuration.  The GitHub token is redacted to `***xxxx`.
+Read the current configuration. GitHub tokens are redacted to ordered `***xxxx`
+values.
 
-**Response** `200` — [Config object](#config) (token redacted)
+**Response** `200` — [Config object](#config) (tokens redacted)
 
 ---
 
@@ -583,7 +584,7 @@ Partially update the configuration.  Only the provided fields are changed.
 **Body** (all fields optional)
 ```json
 {
-  "githubToken": "ghp_xxxxxxxxxxxx",
+  "githubTokens": ["ghp_xxxxxxxxxxxx", "github_pat_yyyyyyyyyyyy"],
   "codingAgent": "claude",
   "maxTurns": 15,
   "batchWindowMs": 300000,
@@ -608,7 +609,7 @@ Partially update the configuration.  Only the provided fields are changed.
 }
 ```
 
-**Response** `200` — updated [Config object](#config) (token redacted)
+**Response** `200` — updated [Config object](#config) (tokens redacted)
 
 Deployment-healing configuration is REST-writable today. The MCP
 `update_config` tool still exposes its older field subset, so use this REST
@@ -913,7 +914,8 @@ Install the Code Factory code-review GitHub Actions workflow on a repository.
 
 ```typescript
 {
-  githubToken: string;         // Redacted to "***xxxx" in GET responses
+  githubTokens: string[];      // Ordered and redacted to "***xxxx" in GET responses
+  githubToken?: string;        // Legacy single-token field, redacted when present
   codingAgent: "claude" | "codex";
   maxTurns: number;
   batchWindowMs: number;

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -288,7 +288,7 @@ export function OnboardingPanel() {
                         Run <InlineCode>gh auth login</InlineCode> on this machine, or set <InlineCode>GITHUB_TOKEN</InlineCode> before starting the app.
                       </Step>
                       <Step number={2}>
-                        Prefer the built-in token field if you want the app to remember it. Open <Link href="/settings" className="underline underline-offset-2">settings</Link> to paste a Personal Access Token.
+                        Prefer the built-in token list if you want the app to remember it. Open <Link href="/settings" className="underline underline-offset-2">settings</Link> to paste a Personal Access Token.
                       </Step>
                     </div>
                   </div>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -11,8 +11,25 @@ export default function Settings() {
     queryKey: ["/api/config"],
   });
 
-  const [githubToken, setGithubToken] = useState("");
+  const [newGithubToken, setNewGithubToken] = useState("");
   const [showTokenInput, setShowTokenInput] = useState(false);
+  const githubTokens = config?.githubTokens ?? (config?.githubToken ? [config.githubToken] : []);
+
+  const updateGithubTokens = (tokens: string[]) => {
+    updateConfigMutation.mutate({ githubTokens: tokens });
+  };
+  const moveGithubToken = (fromIndex: number, toIndex: number) => {
+    const next = [...githubTokens];
+    const [token] = next.splice(fromIndex, 1);
+    if (!token) {
+      return;
+    }
+    next.splice(toIndex, 0, token);
+    updateGithubTokens(next);
+  };
+  const removeGithubToken = (index: number) => {
+    updateGithubTokens(githubTokens.filter((_, i) => i !== index));
+  };
 
   const updateConfigMutation = useMutation({
     mutationFn: async (updates: Partial<Config>) => {
@@ -208,59 +225,105 @@ export default function Settings() {
             </div>
           </section>
 
-          {/* GitHub Token */}
+          {/* GitHub Tokens */}
           <section>
             <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               GitHub
             </h2>
             <div className="flex flex-col gap-4 rounded border border-border p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-sm">Token</div>
-                  <div className="text-[11px] text-muted-foreground">
-                    {config?.githubToken || "not set"}
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm">Tokens</div>
+                    <div className="text-[11px] text-muted-foreground">
+                      Tried in order before GITHUB_TOKEN and gh auth.
+                    </div>
                   </div>
+                  {!showTokenInput && (
+                    <button
+                      onClick={() => setShowTokenInput(true)}
+                      className="border border-border px-2 py-1 text-xs hover:bg-muted"
+                    >
+                      add
+                    </button>
+                  )}
                 </div>
+                {githubTokens.length ? (
+                  <div className="flex flex-col gap-2">
+                    {githubTokens.map((token, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between gap-3 border border-border px-2 py-1.5"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate font-mono text-xs">{token}</div>
+                          <div className="text-[10px] text-muted-foreground">
+                            priority {index + 1}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <button
+                            onClick={() => moveGithubToken(index, index - 1)}
+                            disabled={index === 0 || updateConfigMutation.isPending}
+                            className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                          >
+                            up
+                          </button>
+                          <button
+                            onClick={() => moveGithubToken(index, index + 1)}
+                            disabled={index === githubTokens.length - 1 || updateConfigMutation.isPending}
+                            className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                          >
+                            down
+                          </button>
+                          <button
+                            onClick={() => removeGithubToken(index)}
+                            disabled={updateConfigMutation.isPending}
+                            className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                          >
+                            remove
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-[11px] text-muted-foreground">none configured</div>
+                )}
                 {showTokenInput ? (
                   <div className="flex items-center gap-2">
                     <input
                       type="password"
-                      value={githubToken}
-                      onChange={(e) => setGithubToken(e.target.value)}
+                      value={newGithubToken}
+                      onChange={(e) => setNewGithubToken(e.target.value)}
                       placeholder="ghp_..."
-                      className="border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none"
+                      className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none"
                     />
                     <button
                       onClick={() => {
-                        if (githubToken) {
-                          updateConfigMutation.mutate({ githubToken });
-                          setGithubToken("");
+                        const token = newGithubToken.trim();
+                        if (token) {
+                          updateGithubTokens([...githubTokens, token]);
+                          setNewGithubToken("");
                           setShowTokenInput(false);
                         }
                       }}
-                      disabled={!githubToken || updateConfigMutation.isPending}
+                      disabled={!newGithubToken.trim() || updateConfigMutation.isPending}
                       className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
                     >
-                      save
+                      add
                     </button>
                     <button
                       onClick={() => {
                         setShowTokenInput(false);
-                        setGithubToken("");
+                        setNewGithubToken("");
                       }}
                       className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
                     >
                       cancel
                     </button>
                   </div>
-                ) : (
-                  <button
-                    onClick={() => setShowTokenInput(true)}
-                    className="border border-border px-2 py-1 text-xs hover:bg-muted"
-                  >
-                    update
-                  </button>
-                )}
+                ) : null}
               </div>
 
               <div className="flex items-center justify-between gap-3">

--- a/docs/plans/2026-04-23-multiple-github-tokens-design.md
+++ b/docs/plans/2026-04-23-multiple-github-tokens-design.md
@@ -1,0 +1,77 @@
+# Multiple GitHub Tokens Design
+
+## Goal
+
+Allow users to save multiple GitHub tokens and control the order in which the app tries them.
+
+## Current State
+
+The app stores one `githubToken` string in config. GitHub auth currently resolves in this order:
+
+1. `GITHUB_TOKEN` from the app process environment.
+2. The saved `config.githubToken`.
+3. Cached `gh auth token`.
+4. A fresh `gh auth token` shell command.
+5. No auth token.
+
+Settings exposes one password input and `/api/config` masks one token as `***last4`.
+
+## Approved Approach
+
+Use an ordered saved-token list as the primary configured auth source. The new order is:
+
+1. Saved GitHub tokens in the order shown in Settings.
+2. `GITHUB_TOKEN` from the app process environment.
+3. Cached `gh auth token`.
+4. A fresh `gh auth token` shell command.
+5. No auth token.
+
+This makes the Settings order meaningful while preserving existing environment and `gh` fallbacks.
+
+## Data Model
+
+Add `githubTokens: string[]` to `Config`. Keep legacy `githubToken` compatibility only where needed for migration and older API clients.
+
+For SQLite, add `github_tokens_json TEXT NOT NULL DEFAULT '[]'` to the `config` table. When reading a row whose ordered token list is empty but legacy `github_token` is not empty, return a one-item `githubTokens` list. When writing config, store the ordered list in `github_tokens_json`; keep `github_token` populated from the first token only for compatibility with existing databases and older code paths during the transition.
+
+## API And Redaction
+
+`GET /api/config` and `PATCH /api/config` must never return raw token values. They should return ordered masked tokens such as `***1234`.
+
+`PATCH /api/config` accepts `githubTokens` for the new behavior. If a request still sends `githubToken`, convert it into a one-item ordered list so existing clients do not break.
+
+## Settings UI
+
+Replace the single-token control with an ordered token list:
+
+- Show each saved token as a masked value.
+- Add a token through a password input.
+- Remove a token.
+- Move tokens up and down to set priority.
+- Save the full ordered list through `/api/config`.
+
+The UI should keep controls compact and consistent with the existing settings page.
+
+## Runtime Behavior
+
+Existing callers that need one token for clone URLs or agent environment variables continue to call the central token resolver. The resolver returns the first non-empty token from `config.githubTokens`, then falls back to the environment and `gh`.
+
+This design does not implement per-request retry on `401` or `403`. That deeper behavior can follow later because it touches Octokit request creation, clone/fetch retry behavior, and error reporting across many GitHub paths.
+
+## Testing
+
+Add or update tests for:
+
+- Default config validates with `githubTokens: []`.
+- SQLite persists and reloads ordered token lists.
+- SQLite migrates legacy `github_token` into a one-item ordered list.
+- REST config responses mask ordered tokens and accept ordered token updates.
+- Auth resolution prefers saved token order before `GITHUB_TOKEN` and `gh auth token`.
+- Existing agent environment and clone URL behavior receives the first configured token.
+
+Run:
+
+```bash
+npm run check
+node --test --import tsx server/*.test.ts
+```

--- a/docs/plans/2026-04-23-multiple-github-tokens.md
+++ b/docs/plans/2026-04-23-multiple-github-tokens.md
@@ -1,0 +1,409 @@
+# Multiple GitHub Tokens Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add ordered, user-configurable GitHub tokens and resolve GitHub auth from that order before environment and `gh` fallbacks.
+
+**Architecture:** Extend shared config with `githubTokens: string[]` while accepting legacy `githubToken` updates. Store ordered tokens in SQLite JSON, mask ordered tokens at the API boundary, and keep all runtime callers on the central GitHub token resolver so clone URLs and agent environments receive the selected token.
+
+**Tech Stack:** TypeScript, Zod, Express, React, TanStack Query, SQLite through `node:sqlite`, Node test runner with `tsx`.
+
+---
+
+### Task 1: Shared Config Shape And Defaults
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `shared/models.ts`
+- Modify: `server/defaultConfig.ts`
+- Modify: `server/defaultConfig.test.ts`
+
+**Step 1: Write the failing default config tests**
+
+Update `server/defaultConfig.test.ts` so the required config fields include `githubTokens`, and replace the single-token assertion with:
+
+```ts
+it("has empty array as default githubTokens", () => {
+  assert.ok(Array.isArray(DEFAULT_CONFIG.githubTokens));
+  assert.deepEqual(DEFAULT_CONFIG.githubTokens, []);
+});
+```
+
+Run:
+
+```bash
+node --test --import tsx server/defaultConfig.test.ts
+```
+
+Expected: FAIL because `githubTokens` is missing.
+
+**Step 2: Add schema/default support**
+
+In `shared/schema.ts`, add:
+
+```ts
+githubTokens: z.array(z.string()),
+githubToken: z.string().optional(),
+```
+
+Keep `githubToken` optional for legacy clients only.
+
+In `server/defaultConfig.ts`, add:
+
+```ts
+githubTokens: [],
+```
+
+Remove the required default `githubToken` field unless TypeScript requires the optional compatibility field to be present.
+
+**Step 3: Normalize legacy updates**
+
+In `shared/models.ts`, update `applyConfigUpdate` to turn a legacy `githubToken` update into a one-item `githubTokens` update when `githubTokens` is not provided:
+
+```ts
+const githubTokens = updates.githubTokens
+  ?? (updates.githubToken !== undefined ? [updates.githubToken] : existing.githubTokens);
+```
+
+Trim empty values before parsing:
+
+```ts
+githubTokens: githubTokens.map((token) => token.trim()).filter(Boolean),
+githubToken: undefined,
+```
+
+**Step 4: Run the focused test**
+
+Run:
+
+```bash
+node --test --import tsx server/defaultConfig.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add shared/schema.ts shared/models.ts server/defaultConfig.ts server/defaultConfig.test.ts
+git commit -m "feat: add ordered github token config"
+```
+
+### Task 2: Storage Persistence And Migration
+
+**Files:**
+- Modify: `server/sqliteStorage.ts`
+- Modify: `server/memoryStorage.ts`
+- Modify: `server/storage.test.ts`
+- Modify: `server/memoryStorage.test.ts`
+- Modify: `server/tui/testRuntime.ts`
+- Modify any test fixtures that fail due to the new required `githubTokens` field.
+
+**Step 1: Write failing storage tests**
+
+In `server/storage.test.ts`, update existing config persistence coverage to save:
+
+```ts
+githubTokens: ["ghs_first", "ghs_second"],
+```
+
+Assert reload returns the same order.
+
+Add a migration test that writes a legacy row with `github_token = 'ghs_legacy'` and no ordered JSON tokens, then asserts:
+
+```ts
+assert.deepEqual(config.githubTokens, ["ghs_legacy"]);
+```
+
+In `server/memoryStorage.test.ts`, update the config update test to use and assert:
+
+```ts
+githubTokens: ["tok_123", "tok_456"],
+```
+
+Run:
+
+```bash
+node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts
+```
+
+Expected: FAIL because storage does not persist `githubTokens`.
+
+**Step 2: Add SQLite column and row mapping**
+
+In `server/sqliteStorage.ts`:
+
+- Add `github_tokens_json: string;` to `ConfigRow`.
+- Add `github_tokens_json TEXT NOT NULL DEFAULT '[]'` to the `CREATE TABLE config` block.
+- Add `this.ensureColumn("config", "github_tokens_json", "TEXT NOT NULL DEFAULT '[]'");`.
+- Select `github_tokens_json` in `getConfig`.
+- Parse the JSON with a safe helper that falls back to `[]` on malformed values.
+- In `parseConfigRow`, derive ordered tokens from `github_tokens_json`, falling back to `[row.github_token]` when the JSON array is empty and the legacy value is non-empty.
+- In `writeConfig`, write `JSON.stringify(config.githubTokens)` and keep `github_token` as `config.githubTokens[0] ?? ""`.
+
+**Step 3: Update in-memory copies**
+
+Ensure `MemoryStorage.getConfig` and `updateConfig` return copied token arrays, not shared array references.
+
+**Step 4: Run storage tests**
+
+Run:
+
+```bash
+node --test --import tsx server/storage.test.ts server/memoryStorage.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add server/sqliteStorage.ts server/memoryStorage.ts server/storage.test.ts server/memoryStorage.test.ts server/tui/testRuntime.ts
+git commit -m "feat: persist ordered github tokens"
+```
+
+### Task 3: Auth Resolver Ordering
+
+**Files:**
+- Modify: `server/github.ts`
+- Modify: `server/github.test.ts`
+- Modify: `server/babysitter.test.ts`
+- Modify: `server/backgroundJobHandlers.test.ts`
+- Modify any server test fixtures that still define only `githubToken`.
+
+**Step 1: Write failing resolver tests**
+
+In `server/github.test.ts`, add direct tests for `resolveGitHubAuthToken`:
+
+```ts
+test("resolveGitHubAuthToken prefers ordered config tokens before env token", async () => {
+  const original = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = "env-token";
+  try {
+    const token = await resolveGitHubAuthToken({
+      ...config,
+      githubTokens: ["first-token", "second-token"],
+    });
+    assert.equal(token, "first-token");
+  } finally {
+    process.env.GITHUB_TOKEN = original;
+  }
+});
+```
+
+Add another test for legacy `githubToken` compatibility and another for environment fallback when no configured tokens exist.
+
+Run:
+
+```bash
+node --test --import tsx server/github.test.ts
+```
+
+Expected: FAIL because the resolver still reads `GITHUB_TOKEN` first and only uses `config.githubToken`.
+
+**Step 2: Implement resolver order**
+
+In `server/github.ts`, change `resolveGitHubAuthToken` to:
+
+1. Return the first non-empty `config.githubTokens` entry.
+2. Fall back to legacy `config.githubToken` if present.
+3. Fall back to `process.env.GITHUB_TOKEN`.
+4. Fall back to cached/fresh `gh auth token`.
+
+**Step 3: Update existing consumer tests**
+
+Update existing test fixtures so `githubTokens: []` is present. Where tests assert agent env or clone URL token behavior, set `githubTokens: ["test-token"]` or keep injected mock resolver behavior unchanged.
+
+**Step 4: Run focused GitHub tests**
+
+Run:
+
+```bash
+node --test --import tsx server/github.test.ts server/backgroundJobHandlers.test.ts server/babysitter.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add server/github.ts server/github.test.ts server/babysitter.test.ts server/backgroundJobHandlers.test.ts
+git commit -m "feat: prefer ordered github tokens"
+```
+
+### Task 4: API Masking And MCP Schema
+
+**Files:**
+- Modify: `server/routes.ts`
+- Modify: `server/routes.test.ts`
+- Modify: `server/mcp.ts`
+
+**Step 1: Write failing route tests**
+
+Add route tests for `/api/config`:
+
+```ts
+const patchResponse = await fetch(`${harness.baseUrl}/api/config`, {
+  method: "PATCH",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ githubTokens: ["ghs_alpha1234", "ghs_beta5678"] }),
+});
+const patched = await patchResponse.json();
+assert.deepEqual(patched.githubTokens, ["***1234", "***5678"]);
+
+const stored = await harness.storage.getConfig();
+assert.deepEqual(stored.githubTokens, ["ghs_alpha1234", "ghs_beta5678"]);
+```
+
+Add a legacy payload test:
+
+```ts
+body: JSON.stringify({ githubToken: "ghs_legacy9999" })
+```
+
+and assert the stored ordered list is `["ghs_legacy9999"]`.
+
+Run:
+
+```bash
+node --test --import tsx server/routes.test.ts
+```
+
+Expected: FAIL because masking and route parsing are single-token only.
+
+**Step 2: Update masking**
+
+In `server/routes.ts`, replace the single-token masking helper with an ordered helper:
+
+```ts
+function maskToken(token: string): string {
+  return token ? `***${token.slice(-4)}` : "";
+}
+```
+
+Return:
+
+```ts
+githubTokens: config.githubTokens.map(maskToken),
+githubToken: config.githubTokens[0] ? maskToken(config.githubTokens[0]) : "",
+```
+
+**Step 3: Update MCP schema text**
+
+In `server/mcp.ts`, change config descriptions and input schema to include:
+
+```ts
+githubTokens: { type: "array", items: { type: "string" } },
+```
+
+Keep `githubToken` documented as legacy-compatible only if desired.
+
+**Step 4: Run route tests**
+
+Run:
+
+```bash
+node --test --import tsx server/routes.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add server/routes.ts server/routes.test.ts server/mcp.ts
+git commit -m "feat: mask ordered github tokens"
+```
+
+### Task 5: Settings UI
+
+**Files:**
+- Modify: `client/src/pages/settings.tsx`
+- Modify: `client/src/components/OnboardingPanel.tsx`
+
+**Step 1: Implement compact ordered token controls**
+
+In `client/src/pages/settings.tsx`:
+
+- Replace single `githubToken` input state with `newGithubToken`.
+- Read `config?.githubTokens ?? []`.
+- Render a row for each masked token.
+- Add `move up`, `move down`, and `remove` buttons.
+- Add a password input and `add` button that appends the new token to the ordered list.
+- PATCH `{ githubTokens: nextTokens }` for every reorder/remove/add action.
+
+Use plain compact buttons matching the existing settings page style.
+
+**Step 2: Avoid leaking masked values as saved tokens**
+
+Only construct PATCH payloads from the current ordered masked list for reordering/removal if the API supports masked tokens as identifiers. Prefer a simple full-list update model using raw values only for adding new tokens is not enough because the client cannot know existing raw tokens. If needed, add dedicated server merge semantics:
+
+- Sending `githubTokens` with masked entries keeps matching existing tokens in that position.
+- Sending a new raw token appends or replaces that entry.
+
+Document and test this behavior in Task 4 before relying on it.
+
+**Step 3: Update onboarding copy**
+
+Change singular copy from “token field” to “token list” in `client/src/components/OnboardingPanel.tsx`.
+
+**Step 4: Run typecheck**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add client/src/pages/settings.tsx client/src/components/OnboardingPanel.tsx server/routes.ts server/routes.test.ts
+git commit -m "feat: manage ordered github tokens in settings"
+```
+
+### Task 6: Full Verification
+
+**Files:**
+- No planned file edits.
+
+**Step 1: Run full static and server test suite**
+
+Run:
+
+```bash
+npm run check
+node --test --import tsx server/*.test.ts
+```
+
+Expected: PASS.
+
+**Step 2: Inspect diff**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- shared/schema.ts shared/models.ts server/github.ts server/routes.ts server/sqliteStorage.ts client/src/pages/settings.tsx
+```
+
+Expected: Diff is limited to config/auth/storage/API/settings/docs/tests for ordered GitHub tokens.
+
+**Step 3: Final commit if needed**
+
+If verification required small fixes:
+
+```bash
+git add <changed-files>
+git commit -m "fix: harden ordered github token handling"
+```
+
+**Step 4: Prepare PR**
+
+Push the branch and open a PR with:
+
+- Behavior summary.
+- Migration note for existing single saved token.
+- Verification commands and results.

--- a/server/ciHealingManager.test.ts
+++ b/server/ciHealingManager.test.ts
@@ -6,7 +6,7 @@ import type { Config, PR } from "@shared/schema";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
-    githubToken: "",
+    githubTokens: [],
     codingAgent: "claude",
     maxTurns: 15,
     batchWindowMs: 300000,

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -18,7 +18,7 @@ import {
 describe("DEFAULT_CONFIG", () => {
   it("has all required fields defined by Config type", () => {
     const requiredFields = [
-      "githubToken",
+      "githubTokens",
       "codingAgent",
       "maxTurns",
       "batchWindowMs",
@@ -77,9 +77,9 @@ describe("DEFAULT_CONFIG", () => {
     assert.equal(DEFAULT_CONFIG.trustedReviewers.length, 0, "trustedReviewers should be empty by default");
   });
 
-  it("has empty string as default githubToken", () => {
-    assert.equal(typeof DEFAULT_CONFIG.githubToken, "string");
-    assert.equal(DEFAULT_CONFIG.githubToken, "");
+  it("has empty array as default githubTokens", () => {
+    assert.ok(Array.isArray(DEFAULT_CONFIG.githubTokens));
+    assert.deepEqual(DEFAULT_CONFIG.githubTokens, []);
   });
 
   it("has positive numbers for numeric fields", () => {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -1,7 +1,7 @@
 import type { Config } from "@shared/schema";
 
 export const DEFAULT_CONFIG: Config = {
-  githubToken: "",
+  githubTokens: [],
   codingAgent: "claude",
   maxTurns: 15,
   batchWindowMs: 300000,

--- a/server/deploymentHealingManager.test.ts
+++ b/server/deploymentHealingManager.test.ts
@@ -6,7 +6,7 @@ import type { Config } from "@shared/schema";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
-    githubToken: "", codingAgent: "claude", maxTurns: 15, batchWindowMs: 300000,
+    githubTokens: [], codingAgent: "claude", maxTurns: 15, batchWindowMs: 300000,
     pollIntervalMs: 120000, maxChangesPerRun: 20, autoResolveMergeConflicts: true,
     autoCreateReleases: true, autoUpdateDocs: true, autoHealCI: false,
     maxHealingAttemptsPerSession: 3, maxHealingAttemptsPerFingerprint: 2,

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -21,6 +21,7 @@ import {
   parseRepoSlug,
   postFollowUpForFeedbackItem,
   postStatusReplyForFeedbackItem,
+  resolveGitHubAuthToken,
   resolveNextSemverTag,
   resolveReviewThread,
   selectLatestSemverTag,
@@ -28,7 +29,7 @@ import {
 } from "./github";
 
 const config: Config = {
-  githubToken: "",
+  githubTokens: [],
   codingAgent: "claude",
   maxTurns: 15,
   batchWindowMs: 300000,
@@ -46,6 +47,15 @@ const config: Config = {
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],
 };
+
+function restoreEnvValue(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
 
 function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
   return {
@@ -70,6 +80,55 @@ function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
     ...overrides,
   };
 }
+
+test("resolveGitHubAuthToken prefers ordered config tokens before env token", async () => {
+  const original = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = "env-token";
+
+  try {
+    const token = await resolveGitHubAuthToken({
+      ...config,
+      githubTokens: ["first-token", "second-token"],
+    });
+
+    assert.equal(token, "first-token");
+  } finally {
+    restoreEnvValue("GITHUB_TOKEN", original);
+  }
+});
+
+test("resolveGitHubAuthToken supports legacy single-token config", async () => {
+  const original = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = "env-token";
+
+  try {
+    const token = await resolveGitHubAuthToken({
+      ...config,
+      githubTokens: [],
+      githubToken: "legacy-token",
+    });
+
+    assert.equal(token, "legacy-token");
+  } finally {
+    restoreEnvValue("GITHUB_TOKEN", original);
+  }
+});
+
+test("resolveGitHubAuthToken falls back to env token after configured tokens", async () => {
+  const original = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = "env-token";
+
+  try {
+    const token = await resolveGitHubAuthToken({
+      ...config,
+      githubTokens: [],
+    });
+
+    assert.equal(token, "env-token");
+  } finally {
+    restoreEnvValue("GITHUB_TOKEN", original);
+  }
+});
 
 test("checkOnboardingStatus reads workflow files with authenticated API content calls", async () => {
   const getContentCalls: Array<{ owner: string; repo: string; path: string }> = [];

--- a/server/github.ts
+++ b/server/github.ts
@@ -299,14 +299,21 @@ export async function fetchCheckSnapshotsForRef(
 }
 
 export async function resolveGitHubAuthToken(config: Config): Promise<string | undefined> {
+  const configuredToken = config.githubTokens
+    .map((token) => token.trim())
+    .find(Boolean);
+  if (configuredToken) {
+    return configuredToken;
+  }
+
+  const legacyConfiguredToken = config.githubToken?.trim();
+  if (legacyConfiguredToken) {
+    return legacyConfiguredToken;
+  }
+
   const envToken = process.env.GITHUB_TOKEN?.trim();
   if (envToken) {
     return envToken;
-  }
-
-  const configuredToken = config.githubToken?.trim();
-  if (configuredToken) {
-    return configuredToken;
   }
 
   const now = Date.now();

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -301,20 +301,21 @@ const TOOLS: Tool[] = [
   {
     name: "get_config",
     description:
-      "Read the current Code Factory configuration. GitHub token is redacted.",
+      "Read the current Code Factory configuration. GitHub tokens are redacted.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "update_config",
     description:
       "Partially update Code Factory configuration. All fields are optional; only provided " +
-      "fields are changed. Available fields: githubToken, codingAgent, maxTurns, " +
+      "fields are changed. Available fields: githubTokens, githubToken (legacy), codingAgent, maxTurns, " +
       "batchWindowMs, pollIntervalMs, maxChangesPerRun, autoResolveMergeConflicts, autoUpdateDocs, " +
       "includeRepositoryLinksInGitHubComments, " +
       "watchedRepos, trustedReviewers, ignoredBots.",
     inputSchema: {
       type: "object",
       properties: {
+        githubTokens: { type: "array", items: { type: "string" } },
         githubToken: { type: "string" },
         codingAgent: { type: "string", enum: ["claude", "codex"] },
         maxTurns: { type: "number" },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -449,7 +449,7 @@ describe("MemStorage", () => {
 
     it("returns the updated config", async () => {
       const updated = await storage.updateConfig({
-        githubToken: "tok_123",
+        githubTokens: ["tok_123", "tok_456"],
         includeRepositoryLinksInGitHubComments: false,
         autoHealCI: true,
         maxHealingAttemptsPerSession: 5,
@@ -459,6 +459,7 @@ describe("MemStorage", () => {
       });
       const fetched = await storage.getConfig();
       assert.deepEqual(updated, fetched);
+      assert.deepEqual(fetched.githubTokens, ["tok_123", "tok_456"]);
     });
   });
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -71,6 +71,10 @@ export class MemStorage implements IStorage {
   private deploymentHealingSessions: Map<string, DeploymentHealingSession> = new Map();
   private repoSettings: Map<string, WatchedRepo> = new Map();
 
+  private cloneConfig(config: Config): Config {
+    return structuredClone(config);
+  }
+
   private cloneHealingSession(session: HealingSession): HealingSession {
     return { ...session };
   }
@@ -200,13 +204,13 @@ export class MemStorage implements IStorage {
   }
 
   async getConfig(): Promise<Config> {
-    return { ...this.config };
+    return this.cloneConfig(this.config);
   }
 
   async updateConfig(updates: Partial<Config>): Promise<Config> {
     this.config = applyConfigUpdate(this.config, updates);
     this.syncRepoSettings();
-    return { ...this.config };
+    return this.cloneConfig(this.config);
   }
 
   async listRepoSettings(): Promise<WatchedRepo[]> {

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -9,7 +9,7 @@ import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
-    githubToken: "",
+    githubTokens: [],
     codingAgent: "claude",
     maxTurns: 15,
     batchWindowMs: 300000,

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -67,6 +67,81 @@ async function createHarness(storage = new MemStorage(), dependencies: Partial<R
   };
 }
 
+test("GET/PATCH /api/config masks and persists ordered github tokens", async () => {
+  const harness = await createHarness();
+
+  try {
+    const patchResponse = await fetch(`${harness.baseUrl}/api/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubTokens: ["ghs_alpha1234", "ghs_beta5678"] }),
+    });
+
+    assert.equal(patchResponse.status, 200);
+    const patched = await patchResponse.json() as { githubTokens: string[]; githubToken: string };
+    assert.deepEqual(patched.githubTokens, ["***1234", "***5678"]);
+    assert.equal(patched.githubToken, "***1234");
+
+    const stored = await harness.storage.getConfig();
+    assert.deepEqual(stored.githubTokens, ["ghs_alpha1234", "ghs_beta5678"]);
+
+    const getResponse = await fetch(`${harness.baseUrl}/api/config`);
+    assert.equal(getResponse.status, 200);
+    const fetched = await getResponse.json() as { githubTokens: string[]; githubToken: string };
+    assert.deepEqual(fetched.githubTokens, ["***1234", "***5678"]);
+    assert.equal(fetched.githubToken, "***1234");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("PATCH /api/config preserves masked github tokens when reordering", async () => {
+  const harness = await createHarness();
+
+  try {
+    await harness.storage.updateConfig({
+      githubTokens: ["ghs_alpha1234", "ghs_beta5678"],
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubTokens: ["***5678", "***1234", "ghs_gamma9999"] }),
+    });
+
+    assert.equal(response.status, 200);
+    const patched = await response.json() as { githubTokens: string[] };
+    assert.deepEqual(patched.githubTokens, ["***5678", "***1234", "***9999"]);
+
+    const stored = await harness.storage.getConfig();
+    assert.deepEqual(stored.githubTokens, ["ghs_beta5678", "ghs_alpha1234", "ghs_gamma9999"]);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("PATCH /api/config accepts legacy single githubToken updates", async () => {
+  const harness = await createHarness();
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubToken: "ghs_legacy9999" }),
+    });
+
+    assert.equal(response.status, 200);
+    const patched = await response.json() as { githubTokens: string[]; githubToken: string };
+    assert.deepEqual(patched.githubTokens, ["***9999"]);
+    assert.equal(patched.githubToken, "***9999");
+
+    const stored = await harness.storage.getConfig();
+    assert.deepEqual(stored.githubTokens, ["ghs_legacy9999"]);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/prs/:id/questions enqueues a durable answer_pr_question job", async () => {
   const harness = await createHarness();
   const pr = await seedPR(harness.storage);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express, Response } from "express";
 import type { Server } from "http";
 import { z } from "zod";
 import { configSchema } from "@shared/schema";
+import type { Config } from "@shared/schema";
 import {
   createAppRuntime,
   type AppRuntime,
@@ -10,6 +11,8 @@ import {
 } from "./appRuntime";
 import { createAppUpdateChecker, type AppUpdateChecker } from "./appUpdate";
 import { GitHubIntegrationError } from "./github";
+
+const TOKEN_MASK_PREFIX = "***";
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -34,10 +37,57 @@ function sendAppAwareError(res: Response, error: unknown): void {
   res.status(500).json({ error: getErrorMessage(error) });
 }
 
-function maskConfig<T extends { githubToken: string }>(config: T): T {
+function maskToken(token: string): string {
+  return token ? `${TOKEN_MASK_PREFIX}${token.slice(-4)}` : "";
+}
+
+function resolveMaskedGithubTokens(currentTokens: string[], requestedTokens: string[]): string[] {
+  const existing = currentTokens.map((token) => ({
+    token,
+    masked: maskToken(token),
+    used: false,
+  }));
+
+  return requestedTokens
+    .map((requestedToken) => {
+      const trimmed = requestedToken.trim();
+      if (!trimmed) {
+        return "";
+      }
+
+      if (trimmed.startsWith(TOKEN_MASK_PREFIX)) {
+        const match = existing.find((entry) => !entry.used && entry.masked === trimmed);
+        if (match) {
+          match.used = true;
+          return match.token;
+        }
+      }
+
+      return trimmed;
+    })
+    .filter(Boolean);
+}
+
+function resolveConfigSecrets(current: Config, updates: Partial<Config>): Partial<Config> {
+  const requestedTokens = updates.githubTokens
+    ?? (updates.githubToken !== undefined ? [updates.githubToken] : undefined);
+  if (requestedTokens === undefined) {
+    return updates;
+  }
+
+  const { githubToken: _legacyGithubToken, ...rest } = updates;
+  return {
+    ...rest,
+    githubTokens: resolveMaskedGithubTokens(current.githubTokens, requestedTokens),
+  };
+}
+
+function maskConfig(config: Config): Config {
+  const githubTokens = config.githubTokens.map(maskToken);
   return {
     ...config,
-    githubToken: config.githubToken ? `***${config.githubToken.slice(-4)}` : "",
+    githubTokens,
+    githubToken: githubTokens[0] ?? "",
   };
 }
 
@@ -350,7 +400,8 @@ export async function registerRoutes(
   app.patch("/api/config", async (req, res) => {
     try {
       const updates = configSchema.partial().parse(req.body);
-      res.json(maskConfig(await runtime.updateConfig(updates)));
+      const current = await runtime.getConfig();
+      res.json(maskConfig(await runtime.updateConfig(resolveConfigSecrets(current, updates))));
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -59,6 +59,7 @@ import { appendLogFile } from "./logFiles";
 
 type ConfigRow = {
   github_token: string;
+  github_tokens_json: string;
   coding_agent: Config["codingAgent"];
   model: string;
   max_turns: number;
@@ -91,6 +92,26 @@ const DEFAULT_RUNTIME_STATE: RuntimeState = {
   drainRequestedAt: null,
   drainReason: null,
 };
+
+function parseStringArrayJson(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
 
 type SqliteError = Error & {
   code?: string;
@@ -468,6 +489,7 @@ export class SqliteStorage implements IStorage {
       CREATE TABLE IF NOT EXISTS config (
         id INTEGER PRIMARY KEY CHECK (id = 1),
         github_token TEXT NOT NULL,
+        github_tokens_json TEXT NOT NULL DEFAULT '[]',
         coding_agent TEXT NOT NULL,
         model TEXT NOT NULL,
         max_turns INTEGER NOT NULL,
@@ -762,6 +784,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("feedback_items", "audit_token", "TEXT NOT NULL DEFAULT ''");
     this.ensureColumn("feedback_items", "status", "TEXT NOT NULL DEFAULT 'pending'");
     this.ensureColumn("feedback_items", "status_reason", "TEXT");
+    this.ensureColumn("config", "github_tokens_json", "TEXT NOT NULL DEFAULT '[]'");
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
@@ -813,8 +836,14 @@ export class SqliteStorage implements IStorage {
       };
     }
 
+    const parsedGithubTokens = parseStringArrayJson(row.github_tokens_json);
+    const legacyGithubToken = row.github_token.trim();
+    const githubTokens = parsedGithubTokens.length > 0
+      ? parsedGithubTokens
+      : legacyGithubToken ? [legacyGithubToken] : [];
+
     return {
-      githubToken: row.github_token,
+      githubTokens,
       codingAgent: row.coding_agent,
       maxTurns: row.max_turns,
       batchWindowMs: row.batch_window_ms,
@@ -854,6 +883,7 @@ export class SqliteStorage implements IStorage {
         INSERT INTO config (
           id,
           github_token,
+          github_tokens_json,
           coding_agent,
           model,
           max_turns,
@@ -875,9 +905,10 @@ export class SqliteStorage implements IStorage {
           deployment_check_poll_interval_ms,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
+          github_tokens_json = excluded.github_tokens_json,
           coding_agent = excluded.coding_agent,
           model = excluded.model,
           max_turns = excluded.max_turns,
@@ -898,10 +929,11 @@ export class SqliteStorage implements IStorage {
           deployment_check_timeout_ms = excluded.deployment_check_timeout_ms,
           deployment_check_poll_interval_ms = excluded.deployment_check_poll_interval_ms,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
-          ignored_bots_json = excluded.ignored_bots_json
+        ignored_bots_json = excluded.ignored_bots_json
       `,
         1,
-        config.githubToken,
+        config.githubTokens[0] ?? "",
+        JSON.stringify(config.githubTokens),
         config.codingAgent,
         legacyModelValue,
         config.maxTurns,
@@ -1510,7 +1542,7 @@ export class SqliteStorage implements IStorage {
 
   async getConfig(): Promise<Config> {
     const row = this.get<ConfigRow>(`
-      SELECT github_token, coding_agent, model, max_turns, batch_window_ms,
+      SELECT github_token, github_tokens_json, coding_agent, model, max_turns, batch_window_ms,
              poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
              auto_update_docs, include_repository_links_in_github_comments, auto_heal_ci, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -74,6 +74,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
   const first = new SqliteStorage(root);
   await first.updateConfig({
+    githubTokens: ["ghs_first", "ghs_second"],
     pollIntervalMs: 45000,
     autoCreateReleases: false,
     autoUpdateDocs: false,
@@ -213,6 +214,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(config.maxHealingAttemptsPerFingerprint, 4);
   assert.equal(config.maxConcurrentHealingRuns, 2);
   assert.equal(config.healingCooldownMs, 123456);
+  assert.deepEqual(config.githubTokens, ["ghs_first", "ghs_second"]);
   assert.deepEqual(config.watchedRepos, ["alex-morgan-o/lolodex"]);
   assert.deepEqual(repoSettings, {
     repo: "alex-morgan-o/lolodex",
@@ -255,7 +257,7 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
 
   try {
     await storage.updateConfig({
-      githubToken: "tok_123",
+      githubTokens: ["tok_123", "tok_456"],
       autoCreateReleases: false,
       autoUpdateDocs: false,
       includeRepositoryLinksInGitHubComments: false,
@@ -289,6 +291,23 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
       drainRequestedAt: null,
       drainReason: null,
     });
+  } finally {
+    db.close();
+    storage.close();
+  }
+});
+
+test("SqliteStorage migrates legacy github_token into ordered githubTokens", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+  const db = createRawDatabase(root);
+
+  try {
+    db.exec("UPDATE config SET github_token = 'ghs_legacy', github_tokens_json = '[]' WHERE id = 1");
+
+    const config = await storage.getConfig();
+
+    assert.deepEqual(config.githubTokens, ["ghs_legacy"]);
   } finally {
     db.close();
     storage.close();

--- a/server/tui/testRuntime.ts
+++ b/server/tui/testRuntime.ts
@@ -284,7 +284,7 @@ export function createTestRuntime(params?: Partial<TestRuntimeState>): TestTuiRu
     ],
     repos: params?.repos ?? ["acme/widgets"],
     config: params?.config ?? {
-      githubToken: "",
+      githubTokens: [],
       codingAgent: "claude",
       maxTurns: 15,
       batchWindowMs: 300000,

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -334,9 +334,17 @@ export function applyDeploymentHealingSessionUpdate(
 // ── Config ────────────────────────────────────────────────────────────────────
 
 export function applyConfigUpdate(existing: Config, updates: Partial<Config>): Config {
+  const updatedGithubTokens = updates.githubTokens
+    ?? (updates.githubToken !== undefined ? [updates.githubToken] : existing.githubTokens);
+  const normalizedGithubTokens = updatedGithubTokens
+    .map((token) => token.trim())
+    .filter(Boolean);
+
   return configSchema.parse({
     ...existing,
     ...updates,
+    githubTokens: normalizedGithubTokens,
+    githubToken: undefined,
     watchedRepos: updates.watchedRepos ?? existing.watchedRepos,
     trustedReviewers: updates.trustedReviewers ?? existing.trustedReviewers,
     ignoredBots: updates.ignoredBots ?? existing.ignoredBots,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -391,7 +391,8 @@ export const deploymentHealingSessionSchema = z.object({
 export type DeploymentHealingSession = z.infer<typeof deploymentHealingSessionSchema>;
 
 export const configSchema = z.object({
-  githubToken: z.string(),
+  githubTokens: z.array(z.string()),
+  githubToken: z.string().optional(),
   codingAgent: z.enum(["codex", "claude"]),
   maxTurns: z.number(),
   batchWindowMs: z.number(),


### PR DESCRIPTION
## Summary
- add ordered GitHub token config with legacy single-token compatibility
- persist ordered tokens in SQLite and migrate existing github_token values
- mask ordered tokens in REST/MCP config responses and manage ordering in Settings

## Verification
- npm run check
- node --test --import tsx server/*.test.ts
- npm run build
- curl -s http://127.0.0.1:5010/api/config