### PR TITLE
docs: refresh public docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ Be respectful and constructive in every interaction. Harassment, discrimination,
 ```bash
 npm run check    # TypeScript typecheck
 npm run lint     # ESLint
-npm run test     # Tests
+npm run test     # Server tests
+npm run test:all # Server plus client lib tests
 ```
 
 ## Code Style
@@ -27,7 +28,7 @@ npm run test     # Tests
 - **2-space indentation**, double quotes, semicolons
 - **camelCase** for server helper functions
 - **kebab-case** for API route paths
-- Tests are colocated with source files in `server/` (e.g., `foo.ts` → `foo.test.ts`)
+- Tests use `*.test.ts`; server tests live in `server/`, and client library tests live beside the relevant files in `client/src/lib/`.
 
 See [AGENTS.md](AGENTS.md) for more detailed repository guidelines and development practices.
 

--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -24,7 +24,6 @@
    - [Deployment healing sessions](#deployment-healing-sessions)
    - [Configuration](#configuration)
    - [App updates](#app-updates)
-   - [Agent models](#agent-models)
    - [Runtime & drain mode](#runtime--drain-mode)
    - [Social changelogs](#social-changelogs)
    - [Releases](#releases)
@@ -218,8 +217,6 @@ compiled output instead:
 | `get_logs` | Get activity logs (optional PR filter) |
 | `get_config` | Read current configuration |
 | `update_config` | Partially update configuration |
-| `get_agent_models` | List available AI models |
-| `refresh_agent_models` | Rediscover installed agent models |
 | `get_runtime` | Get runtime state (drain mode, active queue handlers) |
 | `set_drain_mode` | Enable/disable drain mode for new queue claims |
 | `list_changelogs` | List social-media changelogs |
@@ -229,10 +226,9 @@ compiled output instead:
 | `list_deployment_healing_sessions` | List deployment-healing sessions, optionally filtered by repo |
 | `get_deployment_healing_session` | Get one deployment-healing session by ID |
 
-`update_config` does not yet accept the deployment-healing keys described below.
-Use `PATCH /api/config` to change `autoHealDeployments`,
-`deploymentCheckDelayMs`, `deploymentCheckTimeoutMs`, or
-`deploymentCheckPollIntervalMs`.
+`update_config` exposes the MCP schema's config subset. Use `PATCH /api/config`
+for fields that are REST-writable but not exposed by the MCP schema today,
+including release automation, CI healing, and deployment-healing keys.
 
 ---
 
@@ -370,7 +366,7 @@ so the PR stays tracked even if its repo is configured as `ownPrsOnly: true`.
 ```
 
 **Response** `201` — [PR object](#pr) (newly created)
-**Response** `200` — [PR object](#pr) (already tracked)
+**Response** `201` — [PR object](#pr) (already tracked)
 **Response** `400` — invalid URL
 **Response** `4xx` — GitHub API error
 
@@ -611,9 +607,9 @@ Partially update the configuration.  Only the provided fields are changed.
 
 **Response** `200` — updated [Config object](#config) (tokens redacted)
 
-Deployment-healing configuration is REST-writable today. The MCP
-`update_config` tool still exposes its older field subset, so use this REST
-endpoint when changing the deployment-healing keys.
+Some configuration is REST-writable but not exposed by the MCP `update_config`
+tool schema today. Use this REST endpoint when changing release automation,
+CI-healing, or deployment-healing keys.
 
 ---
 
@@ -651,30 +647,6 @@ with `latestVersion: null`, the releases index URL, and `updateAvailable: false`
   "updateAvailable": false
 }
 ```
-
----
-
-### Agent models
-
-#### `GET /api/agent-models`
-
-Get the cached list of available models for each agent type.
-
-**Response** `200`
-```json
-{
-  "claude": ["claude-sonnet-4-6", "claude-opus-4-6"],
-  "codex": ["codex-mini-latest", "o4-mini"]
-}
-```
-
----
-
-#### `POST /api/agent-models/refresh`
-
-Trigger a fresh model discovery scan (runs `claude model list` / `codex --help`).
-
-**Response** `200` — updated model map (same shape as `GET /api/agent-models`)
 
 ---
 
@@ -800,12 +772,21 @@ oh-my-pr GitHub Actions workflow is installed).
 
 **Response** `200`
 ```json
-[
-  {
-    "repo": "owner/repo",
-    "workflowInstalled": true
-  }
-]
+{
+  "githubConnected": true,
+  "githubUser": "octocat",
+  "repos": [
+    {
+      "repo": "owner/repo",
+      "accessible": true,
+      "codeReviews": {
+        "claude": true,
+        "codex": false,
+        "gemini": false
+      }
+    }
+  ]
+}
 ```
 
 ---
@@ -823,7 +804,13 @@ Install the oh-my-pr code-review GitHub Actions workflow on a repository.
 ```
 `tool` must be `"claude"` or `"codex"`.
 
-**Response** `200` — installation result object
+**Response** `200`
+```json
+{
+  "path": ".github/workflows/claude-code-review.yml",
+  "url": "https://github.com/owner/repo/blob/main/.github/workflows/claude-code-review.yml"
+}
+```
 
 ---
 
@@ -849,6 +836,12 @@ Install the oh-my-pr code-review GitHub Actions workflow on a repository.
   lintPassed: boolean | null;
   lastChecked: string | null;  // ISO 8601
   watchEnabled: boolean;       // false pauses autonomous watcher runs for this PR
+  docsAssessment?: {
+    headSha: string;
+    status: "needed" | "not_needed" | "failed";
+    summary: string;
+    assessedAt: string;        // ISO 8601
+  } | null;
   addedAt: string;             // ISO 8601
 }
 ```
@@ -1114,7 +1107,7 @@ All error responses share this shape:
 | `PORT`               | `5001`         | HTTP port for the oh-my-pr server |
 | `CODEFACTORY_PORT`   | `5001`         | Port the MCP server connects to (MCP only) |
 | `OH_MY_PR_HOME`      | `~/.oh-my-pr` | Directory for SQLite DB, logs, repos, worktrees |
-| `PR_BABYSITTER_ROOT` | —              | Override worktree root directory |
-| `GITHUB_TOKEN`       | —              | GitHub personal access token (falls back to config / `gh auth`) |
+| `CODEFACTORY_HOME`   | —              | Legacy alias used only when `OH_MY_PR_HOME` is not set |
+| `GITHUB_TOKEN`       | —              | Fallback GitHub token after saved app tokens and before `gh auth` |
 | `NODE_ENV`           | `development`  | Set to `production` for production builds |
 | `TAURI_DEV`          | —              | Set to skip auto-opening the browser (used by Tauri) |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The dashboard is available at `http://localhost:5001` by default. All `/api/*` r
 - [Getting Started](docs/public/getting-started.md)
 - [PR Babysitter](docs/public/pr-babysitter.md)
 - [Agent Dispatch](docs/public/agent-dispatch.md)
+- [PR Q&A](docs/public/pr-questions.md)
 - [Configuration](docs/public/configuration.md)
 - [Local API and MCP](LOCAL_API.md)
 - [Contributing](CONTRIBUTING.md)

--- a/docs/public/_site/agent-dispatch.html
+++ b/docs/public/_site/agent-dispatch.html
@@ -178,7 +178,7 @@
     <span>Documentation</span>
   </div>
   <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Agent Dispatch</h1>
-  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">oh-my-pr dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.</p>
+  <p class="mt-4 max-w-3xl text-lg leading-relaxed text-gray-400">oh-my-pr dispatches local AI agents to fix accepted review feedback, failing status checks, documentation tasks, and merge conflicts. Agents run from your machine inside app-owned git worktrees.</p>
 </header>
 
 <article class="doc-prose">
@@ -202,11 +202,12 @@
 <td>Quick fixes, single-file edits, style corrections</td>
 </tr>
 </tbody></table>
-<p>oh-my-pr automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.</p>
+<p>The global coding agent defaults to <code>claude</code>. If the configured CLI is unavailable, oh-my-pr falls back to the other supported CLI when it is installed. If neither <code>claude</code> nor <code>codex</code> is available, the run fails with a clear setup error.</p>
 <h2>How Dispatch Works</h2>
 <h3>1. Worktree Isolation</h3>
-<p>Before an agent runs, oh-my-pr creates a <strong>temporary git worktree</strong>:</p>
-<pre><code>/tmp/pr-babysitter/&lt;repo&gt;/&lt;pr-number&gt;/
+<p>Before an agent runs, oh-my-pr refreshes an app-owned repository cache and creates an isolated git worktree:</p>
+<pre><code>~/.oh-my-pr/repos/&lt;owner&gt;__&lt;repo&gt;/
+~/.oh-my-pr/worktrees/&lt;owner&gt;__&lt;repo&gt;/pr-&lt;pr-number&gt;-&lt;run-id&gt;/
 </code></pre>
 <p>This ensures:</p>
 <ul>
@@ -217,24 +218,24 @@
 <h3>2. Agent Execution</h3>
 <p>The agent receives:</p>
 <ul>
-<li>The <strong>review feedback</strong> to address.</li>
-<li>The <strong>file context</strong> (relevant source files).</li>
-<li>The <strong>PR description</strong> for broader understanding.</li>
-<li>Any <strong>previous agent attempts</strong> (to avoid repeating failed approaches).</li>
+<li>The approved <strong>review-comment tasks</strong> with file, line, source URL, thread, and audit-token metadata.</li>
+<li>The approved <strong>status-check tasks</strong> when CI/status repair is needed.</li>
+<li>The approved <strong>documentation task</strong> summary when the docs assessment says updates are required.</li>
+<li>The PR branch, base/head repository, and remote information needed to commit and push safely.</li>
 </ul>
 <h3>3. Validation</h3>
 <p>After the agent completes:</p>
 <ul>
-<li>Changes are <strong>diffed</strong> against the original branch.</li>
-<li>If configured, <strong>tests are run</strong> to validate the fix.</li>
-<li>The diff is <strong>logged</strong> for human review in the dashboard.</li>
+<li>The agent is expected to run relevant verification and commit/push changed files to the PR branch.</li>
+<li>oh-my-pr checks the worktree state, records logs, updates run metadata, and polls CI when needed.</li>
+<li>GitHub follow-up replies and review-thread resolution are handled by oh-my-pr after the agent returns.</li>
 </ul>
 <h3>4. Commit &amp; Push</h3>
-<p>If validation passes, oh-my-pr:</p>
+<p>When the run succeeds, oh-my-pr:</p>
 <ul>
-<li>Creates a <strong>descriptive commit message</strong> explaining what was fixed.</li>
-<li>Pushes the commit to the <strong>PR branch</strong> on GitHub.</li>
-<li>Updates the <strong>feedback status</strong> to resolved.</li>
+<li>Verifies that the branch advanced or that no changes were necessary.</li>
+<li>Updates the <strong>feedback status</strong> and run metadata.</li>
+<li>Posts reviewer-facing follow-up summaries and resolves eligible review threads.</li>
 </ul>
 <h2>Agent Runs in the Dashboard</h2>
 <p>Every agent run is tracked in the oh-my-pr dashboard:</p>
@@ -244,13 +245,13 @@
 <li><strong>Diff</strong> — Exact changes the agent made.</li>
 <li><strong>Logs</strong> — Full agent output for debugging.</li>
 </ul>
-<h2>Model Discovery</h2>
-<p>oh-my-pr discovers available models from your local CLI installations. You can view and refresh available models from the <strong>Settings</strong> page in the dashboard.</p>
+<h2>Agent Selection</h2>
+<p>The active coding agent is stored in app config as <code>codingAgent</code> and can be changed from the dashboard, terminal UI settings pane, REST API, or MCP <code>update_config</code> tool. Agent reasoning/model behavior follows the selected CLI runtime; oh-my-pr does not expose a separate model-discovery or model-selection surface today.</p>
 <h2>Customization</h2>
-<p>Override the default agent per repository or globally:</p>
+<p>Override the default agent globally:</p>
 <ul>
-<li>Set <code>CODEFACTORY_AGENT=claude</code> or <code>CODEFACTORY_AGENT=codex</code> as an environment variable.</li>
-<li>Configure per-repo preferences in the dashboard under repository settings.</li>
+<li>Change <strong>Coding Agent</strong> in the dashboard or terminal UI settings.</li>
+<li>Patch <code>codingAgent</code> through <code>PATCH /api/config</code> or MCP <code>update_config</code>.</li>
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for all options.</p>
 

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -202,24 +202,19 @@
 <td>Data directory for state and logs</td>
 </tr>
 <tr>
-<td><code>PR_BABYSITTER_ROOT</code></td>
-<td><code>/tmp/pr-babysitter</code></td>
-<td>Root directory for agent worktrees</td>
+<td><code>CODEFACTORY_HOME</code></td>
+<td>—</td>
+<td>Legacy alias used only when <code>OH_MY_PR_HOME</code> is not set</td>
 </tr>
 <tr>
-<td><code>CODEFACTORY_AGENT</code></td>
-<td>(auto)</td>
-<td>Preferred agent: <code>claude</code> or <code>codex</code></td>
-</tr>
-<tr>
-<td><code>DATABASE_URL</code></td>
-<td>(SQLite)</td>
-<td>PostgreSQL connection string (optional)</td>
+<td><code>CODEFACTORY_PORT</code></td>
+<td><code>5001</code></td>
+<td>Port the MCP server connects to</td>
 </tr>
 <tr>
 <td><code>GITHUB_TOKEN</code></td>
 <td>—</td>
-<td>Default GitHub personal access token</td>
+<td>Fallback GitHub token when no dashboard token is configured; <code>gh auth</code> is used after that</td>
 </tr>
 </tbody></table>
 <h2>Storage</h2>
@@ -228,13 +223,6 @@
 <pre><code>~/.oh-my-pr/state.sqlite
 </code></pre>
 <p>No external database is required. This is ideal for single-user setups.</p>
-<h3>PostgreSQL</h3>
-<p>For team deployments, configure a PostgreSQL connection:</p>
-<pre><code class="language-bash">DATABASE_URL=postgresql://user:pass@localhost:5432/oh_my_pr
-</code></pre>
-<p>Then push the schema:</p>
-<pre><code class="language-bash">npm run db:push
-</code></pre>
 <h2>Activity Logs</h2>
 <p>oh-my-pr writes daily activity logs to:</p>
 <pre><code>~/.oh-my-pr/log/
@@ -243,7 +231,7 @@
 <h2>Dashboard Settings</h2>
 <p>The settings page in the dashboard provides a UI for:</p>
 <ul>
-<li><strong>GitHub Token management</strong> — Add, update, or rotate tokens.</li>
+<li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
 <li><strong>CI healing</strong> — Enable autonomous CI repair and tune retry/session limits.</li>
@@ -307,7 +295,7 @@ release check fails, the banner stays hidden and the API falls back quietly.</p>
 </tbody></table>
 <p>This toggle is available in the dashboard settings page and as <code>includeRepositoryLinksInGitHubComments</code> (boolean) in <code>GET /api/config</code>, <code>PATCH /api/config</code>, and the MCP <code>update_config</code> tool. Turning it off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.</p>
 <h2>CI Healing Settings</h2>
-<p>Code Factory can track failing CI checks as first-class healing sessions and, when enabled, dispatch bounded repair attempts in isolated worktrees.</p>
+<p>oh-my-pr can track failing CI checks as first-class healing sessions and, when enabled, dispatch bounded repair attempts in isolated worktrees.</p>
 <table>
 <thead>
 <tr>
@@ -344,7 +332,7 @@ release check fails, the banner stays hidden and the API falls back quietly.</p>
 </tbody></table>
 <p>The dashboard shows healing state on each tracked PR, while the local API exposes <code>GET /api/healing-sessions</code> and <code>GET /api/healing-sessions/:id</code> for external tooling.</p>
 <h2>Deployment Healing Settings</h2>
-<p>Code Factory can monitor merged PRs for failed Vercel or Railway deployments and open a follow-up fix PR when the deployment breaks after merge.</p>
+<p>oh-my-pr can monitor merged PRs for failed Vercel or Railway deployments and open a follow-up fix PR when the deployment breaks after merge.</p>
 <p>A repository is eligible only when platform detection finds one of these markers in the app-owned repo cache:</p>
 <ul>
 <li><strong>Vercel</strong> — <code>vercel.json</code>, <code>.vercel/project.json</code>, or a <code>package.json</code> script containing <code>vercel</code></li>
@@ -380,12 +368,12 @@ release check fails, the banner stays hidden and the API falls back quietly.</p>
 </tr>
 </tbody></table>
 <p>These values map to <code>autoHealDeployments</code>, <code>deploymentCheckDelayMs</code>, <code>deploymentCheckTimeoutMs</code>, and <code>deploymentCheckPollIntervalMs</code> in <code>GET /api/config</code> and <code>PATCH /api/config</code>.</p>
-<p>Deployment healing also requires the matching platform CLI on the machine running Code Factory:</p>
+<p>Deployment healing also requires the matching platform CLI on the machine running oh-my-pr:</p>
 <ul>
 <li>Install and authenticate <code>vercel</code> to heal Vercel deployments.</li>
 <li>Install and authenticate <code>railway</code> to heal Railway deployments.</li>
 </ul>
-<p>Deployment session history is exposed through <code>GET /api/deployment-healing-sessions</code>, <code>GET /api/deployment-healing-sessions/:id</code>, and the matching MCP read tools. The dashboard settings page and MCP <code>update_config</code> tool do not yet expose these deployment-healing knobs on this branch.</p>
+<p>Deployment session history is exposed through <code>GET /api/deployment-healing-sessions</code>, <code>GET /api/deployment-healing-sessions/:id</code>, and the matching MCP read tools. The dashboard settings page and MCP <code>update_config</code> tool do not yet expose these deployment-healing knobs; use <code>PATCH /api/config</code> for them.</p>
 <h2>Build &amp; Deploy</h2>
 <h3>Development</h3>
 <pre><code class="language-bash">npm run dev          # Start dev server with hot reload

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -186,7 +186,8 @@
 <ul>
 <li><strong>Node.js 22+</strong> — <a href="https://nodejs.org/">Download</a></li>
 <li><strong>Git</strong> — installed and configured</li>
-<li><strong>GitHub Personal Access Token</strong> — with <code>repo</code> scope (<a href="https://github.com/settings/tokens">create one</a>)</li>
+<li><strong>GitHub auth</strong> — <code>gh auth login</code>, <code>GITHUB_TOKEN</code>, or one or more saved dashboard tokens</li>
+<li><strong>Local AI agent CLI</strong> — either <code>claude</code> or <code>codex</code> installed and authenticated</li>
 </ul>
 <h2>Installation</h2>
 <p>Install from npm:</p>
@@ -206,14 +207,14 @@ npm run dev
 </code></pre>
 <h3>2. Connect a GitHub repository</h3>
 <ol>
-<li>Open the dashboard in your browser.</li>
-<li>Click <strong>Add Repository</strong> and paste the URL of a GitHub repository you manage.</li>
-<li>Choose <strong>Track automatically</strong>:<ul>
+<li>In the terminal UI, open the repository manager and add a GitHub repository. In the browser dashboard, click <strong>Add Repository</strong>.</li>
+<li>Choose the repository discovery scope:<ul>
 <li><strong>My PRs only</strong> keeps the repo on the default scope and auto-discovers only PRs authored by your authenticated GitHub account.</li>
 <li><strong>My PRs + teammates</strong> switches the repo to team-wide discovery and auto-discovers every open PR in that repository.</li>
 </ul>
 </li>
-<li>Enter your GitHub Personal Access Token when prompted.</li>
+<li>Add a direct PR URL when you want to track one pull request regardless of the repo&#39;s discovery scope.</li>
+<li>Add GitHub credentials through the dashboard settings if you are not using <code>gh auth login</code> or <code>GITHUB_TOKEN</code>.</li>
 </ol>
 <h3>3. Watch oh-my-pr work</h3>
 <p>Once connected, oh-my-pr will:</p>

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -207,34 +207,29 @@
 <li><strong>Review threads</strong> — multi-message conversations about a specific change.</li>
 </ul>
 <h3>3. Feedback Triage</h3>
-<p>Not all feedback is equal. oh-my-pr classifies each piece of feedback:</p>
+<p>Not all feedback is equal. oh-my-pr classifies each piece of feedback into the triage decisions used by the app:</p>
 <table>
 <thead>
 <tr>
-<th>Category</th>
+<th>Decision</th>
 <th>Description</th>
 <th>Action</th>
 </tr>
 </thead>
 <tbody><tr>
-<td><strong>Blocking</strong></td>
-<td>Must be fixed before merge</td>
-<td>Agent dispatched immediately</td>
+<td><strong>accept</strong></td>
+<td>Actionable feedback that should be fixed</td>
+<td>Queued for the configured agent</td>
 </tr>
 <tr>
-<td><strong>Suggestion</strong></td>
-<td>Improvement that should be considered</td>
-<td>Queued for agent review</td>
+<td><strong>reject</strong></td>
+<td>No code change is needed, such as acknowledgements or app-authored follow-ups</td>
+<td>Marked rejected and eligible for thread closure</td>
 </tr>
 <tr>
-<td><strong>Nitpick</strong></td>
-<td>Style or preference issue</td>
-<td>Logged but deprioritized</td>
-</tr>
-<tr>
-<td><strong>Question</strong></td>
-<td>Reviewer needs clarification</td>
-<td>Flagged for human response</td>
+<td><strong>flag</strong></td>
+<td>Actionability is unclear</td>
+<td>Flagged for human review</td>
 </tr>
 </tbody></table>
 <h3>4. Automated Resolution</h3>
@@ -277,21 +272,25 @@
 </ul>
 <h2>Feedback Lifecycle</h2>
 <p>Each feedback item moves through a defined state machine:</p>
-<pre><code>pending → triaged → dispatched → resolved
-                  ↘ skipped
+<pre><code>pending → queued → in_progress → resolved
+      ↘ rejected
+      ↘ flagged
+      ↘ failed / warning
 </code></pre>
 <ul>
 <li><strong>pending</strong> — Feedback just synced from GitHub.</li>
-<li><strong>triaged</strong> — Classified by category and priority.</li>
-<li><strong>dispatched</strong> — An agent is actively working on it.</li>
+<li><strong>queued</strong> — Accepted feedback waiting for an agent run.</li>
+<li><strong>in_progress</strong> — An agent is actively working on it.</li>
 <li><strong>resolved</strong> — The agent successfully addressed the feedback.</li>
-<li><strong>skipped</strong> — Determined to not need automated action.</li>
+<li><strong>rejected</strong> — Determined to not need a code change.</li>
+<li><strong>flagged</strong> — Needs human review before automation should continue.</li>
+<li><strong>failed</strong> / <strong>warning</strong> — The run could not complete cleanly or needs operator attention.</li>
 </ul>
 <h2>Merge Conflict Resolution</h2>
 <p>When a PR branch falls behind the base branch, oh-my-pr can automatically:</p>
 <ol>
 <li>Detect the conflict.</li>
-<li>Rebase the branch.</li>
+<li>Merge the base branch into the PR worktree.</li>
 <li>Use an AI agent to resolve non-trivial merge conflicts.</li>
 <li>Push the resolved branch.</li>
 </ol>
@@ -301,7 +300,7 @@
 <li><strong>Repo watch scope</strong> — Choose <code>My PRs only</code> (default) or <code>My PRs + teammates</code> for auto-discovery.</li>
 <li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
 <li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
-<li><strong>Agent preference</strong> — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.</li>
+<li><strong>Agent preference</strong> — Choose the global coding agent, with CLI fallback when the preferred tool is not installed.</li>
 <li><strong>Per-PR watch toggle</strong> — Pause one tracked PR&#39;s background automation while keeping manual runs available.</li>
 </ul>
 <p>See <a href="./configuration.html">Configuration</a> for details.</p>

--- a/docs/public/_site/pr-questions.html
+++ b/docs/public/_site/pr-questions.html
@@ -190,7 +190,7 @@
 <li>&quot;What are the architectural implications of this change?&quot;</li>
 <li>&quot;Does this PR introduce any security concerns?&quot;</li>
 </ul>
-<p>oh-my-pr uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.</p>
+<p>oh-my-pr queues the question as a durable background job and asks the configured local agent to answer from the PR context currently stored in the app.</p>
 <h2>How to Use</h2>
 <ol>
 <li>Open a PR in the oh-my-pr dashboard.</li>
@@ -199,14 +199,14 @@
 </ol>
 <p>The agent will analyze the PR context and return a detailed answer within seconds.</p>
 <h2>What the Agent Sees</h2>
-<p>When answering a question, the agent has access to:</p>
+<p>When answering a question, the agent receives:</p>
 <ul>
-<li>The <strong>full diff</strong> of the PR.</li>
-<li>All <strong>review comments</strong> and threads.</li>
-<li>The <strong>PR description</strong> and title.</li>
-<li>The <strong>commit history</strong> on the branch.</li>
-<li>The <strong>surrounding code context</strong> in affected files.</li>
+<li>PR metadata such as title, number, repository, branch, author, URL, status, and last check time.</li>
+<li>Current test/lint pass/fail fields when known.</li>
+<li>Feedback items stored on the PR, including status, decision, author, file, line, and a body excerpt.</li>
+<li>The most recent 50 activity log entries for the PR.</li>
 </ul>
+<p>The Q&amp;A agent does not fetch the full diff, commit history, external docs, or issue trackers unless that information is already present in the stored PR context or logs.</p>
 <h2>Use Cases</h2>
 <h3>Code Review Assistance</h3>
 <p>Ask the agent to summarize changes before you start reviewing:</p>

--- a/docs/public/agent-dispatch.md
+++ b/docs/public/agent-dispatch.md
@@ -1,6 +1,6 @@
 # Agent Dispatch
 
-oh-my-pr dispatches local AI agents to fix code based on review feedback. Agents run entirely on your machine — your code never leaves your environment.
+oh-my-pr dispatches local AI agents to fix accepted review feedback, failing status checks, documentation tasks, and merge conflicts. Agents run from your machine inside app-owned git worktrees.
 
 ## Supported Agents
 
@@ -9,16 +9,17 @@ oh-my-pr dispatches local AI agents to fix code based on review feedback. Agents
 | **Claude Code** | `claude` | Complex reasoning, multi-file refactors, architectural changes |
 | **OpenAI Codex** | `codex` | Quick fixes, single-file edits, style corrections |
 
-oh-my-pr automatically detects which CLI tools are available on your system and selects the most appropriate agent for each task.
+The global coding agent defaults to `claude`. If the configured CLI is unavailable, oh-my-pr falls back to the other supported CLI when it is installed. If neither `claude` nor `codex` is available, the run fails with a clear setup error.
 
 ## How Dispatch Works
 
 ### 1. Worktree Isolation
 
-Before an agent runs, oh-my-pr creates a **temporary git worktree**:
+Before an agent runs, oh-my-pr refreshes an app-owned repository cache and creates an isolated git worktree:
 
 ```
-/tmp/pr-babysitter/<repo>/<pr-number>/
+~/.oh-my-pr/repos/<owner>__<repo>/
+~/.oh-my-pr/worktrees/<owner>__<repo>/pr-<pr-number>-<run-id>/
 ```
 
 This ensures:
@@ -29,24 +30,24 @@ This ensures:
 ### 2. Agent Execution
 
 The agent receives:
-- The **review feedback** to address.
-- The **file context** (relevant source files).
-- The **PR description** for broader understanding.
-- Any **previous agent attempts** (to avoid repeating failed approaches).
+- The approved **review-comment tasks** with file, line, source URL, thread, and audit-token metadata.
+- The approved **status-check tasks** when CI/status repair is needed.
+- The approved **documentation task** summary when the docs assessment says updates are required.
+- The PR branch, base/head repository, and remote information needed to commit and push safely.
 
 ### 3. Validation
 
 After the agent completes:
-- Changes are **diffed** against the original branch.
-- If configured, **tests are run** to validate the fix.
-- The diff is **logged** for human review in the dashboard.
+- The agent is expected to run relevant verification and commit/push changed files to the PR branch.
+- oh-my-pr checks the worktree state, records logs, updates run metadata, and polls CI when needed.
+- GitHub follow-up replies and review-thread resolution are handled by oh-my-pr after the agent returns.
 
 ### 4. Commit & Push
 
-If validation passes, oh-my-pr:
-- Creates a **descriptive commit message** explaining what was fixed.
-- Pushes the commit to the **PR branch** on GitHub.
-- Updates the **feedback status** to resolved.
+When the run succeeds, oh-my-pr:
+- Verifies that the branch advanced or that no changes were necessary.
+- Updates the **feedback status** and run metadata.
+- Posts reviewer-facing follow-up summaries and resolves eligible review threads.
 
 ## Agent Runs in the Dashboard
 
@@ -57,15 +58,15 @@ Every agent run is tracked in the oh-my-pr dashboard:
 - **Diff** — Exact changes the agent made.
 - **Logs** — Full agent output for debugging.
 
-## Model Discovery
+## Agent Selection
 
-oh-my-pr discovers available models from your local CLI installations. You can view and refresh available models from the **Settings** page in the dashboard.
+The active coding agent is stored in app config as `codingAgent` and can be changed from the dashboard, terminal UI settings pane, REST API, or MCP `update_config` tool. Agent reasoning/model behavior follows the selected CLI runtime; oh-my-pr does not expose a separate model-discovery or model-selection surface today.
 
 ## Customization
 
-Override the default agent per repository or globally:
+Override the default agent globally:
 
-- Set `CODEFACTORY_AGENT=claude` or `CODEFACTORY_AGENT=codex` as an environment variable.
-- Configure per-repo preferences in the dashboard under repository settings.
+- Change **Coding Agent** in the dashboard or terminal UI settings.
+- Patch `codingAgent` through `PATCH /api/config` or MCP `update_config`.
 
 See [Configuration](./configuration.md) for all options.

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -8,10 +8,9 @@ oh-my-pr is configured through environment variables and the dashboard settings 
 |----------|---------|-------------|
 | `PORT` | `5001` | HTTP server port |
 | `OH_MY_PR_HOME` | `~/.oh-my-pr` | Data directory for state and logs |
-| `PR_BABYSITTER_ROOT` | `/tmp/pr-babysitter` | Root directory for agent worktrees |
-| `CODEFACTORY_AGENT` | (auto) | Preferred agent: `claude` or `codex` |
-| `DATABASE_URL` | (SQLite) | PostgreSQL connection string (optional) |
-| `GITHUB_TOKEN` | — | Default GitHub personal access token |
+| `CODEFACTORY_HOME` | — | Legacy alias used only when `OH_MY_PR_HOME` is not set |
+| `CODEFACTORY_PORT` | `5001` | Port the MCP server connects to |
+| `GITHUB_TOKEN` | — | Fallback GitHub token when no dashboard token is configured; `gh auth` is used after that |
 
 ## Storage
 
@@ -24,20 +23,6 @@ By default, oh-my-pr stores all state in a local SQLite database:
 ```
 
 No external database is required. This is ideal for single-user setups.
-
-### PostgreSQL
-
-For team deployments, configure a PostgreSQL connection:
-
-```bash
-DATABASE_URL=postgresql://user:pass@localhost:5432/oh_my_pr
-```
-
-Then push the schema:
-
-```bash
-npm run db:push
-```
 
 ## Activity Logs
 
@@ -53,7 +38,7 @@ These logs mirror the dashboard activity feed and are useful for debugging or au
 
 The settings page in the dashboard provides a UI for:
 
-- **GitHub Token management** — Add, update, or rotate tokens.
+- **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
@@ -135,7 +120,7 @@ Deployment healing also requires the matching platform CLI on the machine runnin
 - Install and authenticate `vercel` to heal Vercel deployments.
 - Install and authenticate `railway` to heal Railway deployments.
 
-Deployment session history is exposed through `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, and the matching MCP read tools. The dashboard settings page and MCP `update_config` tool do not yet expose these deployment-healing knobs on this branch.
+Deployment session history is exposed through `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, and the matching MCP read tools. The dashboard settings page and MCP `update_config` tool do not yet expose these deployment-healing knobs; use `PATCH /api/config` for them.
 
 ## Build & Deploy
 

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -6,7 +6,8 @@ Welcome to oh-my-pr — the autonomous PR babysitter that watches the repositori
 
 - **Node.js 22+** — [Download](https://nodejs.org/)
 - **Git** — installed and configured
-- **GitHub Personal Access Token** — with `repo` scope ([create one](https://github.com/settings/tokens))
+- **GitHub auth** — `gh auth login`, `GITHUB_TOKEN`, or one or more saved dashboard tokens
+- **Local AI agent CLI** — either `claude` or `codex` installed and authenticated
 
 ## Installation
 
@@ -39,12 +40,12 @@ npm run dev
 
 ### 2. Connect a GitHub repository
 
-1. Open the dashboard in your browser.
-2. Click **Add Repository** and paste the URL of a GitHub repository you manage.
-3. Choose **Track automatically**:
+1. In the terminal UI, open the repository manager and add a GitHub repository. In the browser dashboard, click **Add Repository**.
+2. Choose the repository discovery scope:
    - **My PRs only** keeps the repo on the default scope and auto-discovers only PRs authored by your authenticated GitHub account.
    - **My PRs + teammates** switches the repo to team-wide discovery and auto-discovers every open PR in that repository.
-4. Enter your GitHub Personal Access Token when prompted.
+3. Add a direct PR URL when you want to track one pull request regardless of the repo's discovery scope.
+4. Add GitHub credentials through the dashboard settings if you are not using `gh auth login` or `GITHUB_TOKEN`.
 
 ### 3. Watch oh-my-pr work
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -32,14 +32,13 @@ Every review comment is captured and stored locally. oh-my-pr understands GitHub
 
 ### 3. Feedback Triage
 
-Not all feedback is equal. oh-my-pr classifies each piece of feedback:
+Not all feedback is equal. oh-my-pr classifies each piece of feedback into the triage decisions used by the app:
 
-| Category | Description | Action |
+| Decision | Description | Action |
 |----------|-------------|--------|
-| **Blocking** | Must be fixed before merge | Agent dispatched immediately |
-| **Suggestion** | Improvement that should be considered | Queued for agent review |
-| **Nitpick** | Style or preference issue | Logged but deprioritized |
-| **Question** | Reviewer needs clarification | Flagged for human response |
+| **accept** | Actionable feedback that should be fixed | Queued for the configured agent |
+| **reject** | No code change is needed, such as acknowledgements or app-authored follow-ups | Marked rejected and eligible for thread closure |
+| **flag** | Actionability is unclear | Flagged for human review |
 
 ### 4. Automated Resolution
 
@@ -90,22 +89,26 @@ Deployment healing requires the matching platform CLI to be installed and authen
 Each feedback item moves through a defined state machine:
 
 ```
-pending → triaged → dispatched → resolved
-                  ↘ skipped
+pending → queued → in_progress → resolved
+      ↘ rejected
+      ↘ flagged
+      ↘ failed / warning
 ```
 
 - **pending** — Feedback just synced from GitHub.
-- **triaged** — Classified by category and priority.
-- **dispatched** — An agent is actively working on it.
+- **queued** — Accepted feedback waiting for an agent run.
+- **in_progress** — An agent is actively working on it.
 - **resolved** — The agent successfully addressed the feedback.
-- **skipped** — Determined to not need automated action.
+- **rejected** — Determined to not need a code change.
+- **flagged** — Needs human review before automation should continue.
+- **failed** / **warning** — The run could not complete cleanly or needs operator attention.
 
 ## Merge Conflict Resolution
 
 When a PR branch falls behind the base branch, oh-my-pr can automatically:
 
 1. Detect the conflict.
-2. Rebase the branch.
+2. Merge the base branch into the PR worktree.
 3. Use an AI agent to resolve non-trivial merge conflicts.
 4. Push the resolved branch.
 
@@ -116,7 +119,7 @@ You can control babysitter behavior per repository:
 - **Repo watch scope** — Choose `My PRs only` (default) or `My PRs + teammates` for auto-discovery.
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
-- **Agent preference** — Choose between Claude Code, OpenAI Codex, or let oh-my-pr decide.
+- **Agent preference** — Choose the global coding agent, with CLI fallback when the preferred tool is not installed.
 - **Per-PR watch toggle** — Pause one tracked PR's background automation while keeping manual runs available.
 
 See [Configuration](./configuration.md) for details.

--- a/docs/public/pr-questions.md
+++ b/docs/public/pr-questions.md
@@ -11,7 +11,7 @@ Instead of manually reading through large diffs, you can ask questions like:
 - "What are the architectural implications of this change?"
 - "Does this PR introduce any security concerns?"
 
-oh-my-pr uses an AI agent to analyze the PR diff, review comments, and commit history to provide accurate answers.
+oh-my-pr queues the question as a durable background job and asks the configured local agent to answer from the PR context currently stored in the app.
 
 ## How to Use
 
@@ -23,13 +23,14 @@ The agent will analyze the PR context and return a detailed answer within second
 
 ## What the Agent Sees
 
-When answering a question, the agent has access to:
+When answering a question, the agent receives:
 
-- The **full diff** of the PR.
-- All **review comments** and threads.
-- The **PR description** and title.
-- The **commit history** on the branch.
-- The **surrounding code context** in affected files.
+- PR metadata such as title, number, repository, branch, author, URL, status, and last check time.
+- Current test/lint pass/fail fields when known.
+- Feedback items stored on the PR, including status, decision, author, file, line, and a body excerpt.
+- The most recent 50 activity log entries for the PR.
+
+The Q&A agent does not fetch the full diff, commit history, external docs, or issue trackers unless that information is already present in the stored PR context or logs.
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary
- refresh public docs to match current storage, auth, agent dispatch, PR Q&A, and feedback lifecycle behavior
- remove stale API/model docs and document the current REST/MCP surface
- regenerate published docs HTML and add the PR Q&A page to README docs links

## Verification
- npm run build:public-docs
- node route/tool/link consistency audit
- rg stale public-doc terms
- git diff --check
- npm run check

Note: attempted the repo-required `claude -p "/simplify ..."` pass, but it hung silently for over 60s and had to be killed; it made no file changes.