### PR TITLE
fix: prevent blank desktop launch

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -6,6 +6,7 @@ import { rm, readFile } from "fs/promises";
 // which helps cold start times
 const allowlist = [
   "@google/generative-ai",
+  "@octokit/rest",
   "axios",
   "connect-pg-simple",
   "cors",
@@ -16,6 +17,7 @@ const allowlist = [
   "express-rate-limit",
   "express-session",
   "jsonwebtoken",
+  "marked",
   "memorystore",
   "multer",
   "nanoid",
@@ -24,6 +26,8 @@ const allowlist = [
   "passport",
   "passport-local",
   "pg",
+  "postcss",
+  "sanitize-html",
   "stripe",
   "uuid",
   "ws",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
 import { localOnlyMiddleware } from "./localOnly";
 import { createServer } from "http";
-import open from "open";
 
 const app = express();
 const httpServer = createServer(app);
@@ -36,6 +35,11 @@ export function log(message: string, source = "express") {
     hour12: true,
   });
   console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+async function openDashboard(url: string) {
+  const { default: open } = await import("open");
+  await open(url);
 }
 
 (async () => {
@@ -89,8 +93,8 @@ export function log(message: string, source = "express") {
       }
 
       // Auto-open browser (skip when Tauri manages the window)
-      if (!process.env.TAURI_DEV) {
-        open(url).catch((err) => {
+      if (!process.env.TAURI_DEV && !process.env.OH_MY_PR_DESKTOP) {
+        openDashboard(url).catch((err) => {
           log(`Could not open browser automatically: ${err.message}`);
         });
       }

--- a/server/packagedBundle.test.ts
+++ b/server/packagedBundle.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { builtinModules } from "node:module";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const builtins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+]);
+const optionalPackageRequires = new Set([
+  // debug probes this in a try/catch for terminal colors; it is not required
+  // for the packaged server to start.
+  "supports-color",
+]);
+
+function isPackageRequire(specifier: string) {
+  return !specifier.startsWith(".")
+    && !specifier.startsWith("/")
+    && !builtins.has(specifier);
+}
+
+test("production server bundle is self-contained for desktop resources", async (t) => {
+  const bundlePath = path.resolve("dist/index.cjs");
+  if (!existsSync(bundlePath)) {
+    t.skip("run npm run build before checking the packaged server bundle");
+    return;
+  }
+
+  const bundle = await readFile(bundlePath, "utf-8");
+  const packageRequires = Array.from(bundle.matchAll(/require\(["']([^"']+)["']\)/g))
+    .map((match) => match[1])
+    .filter((specifier): specifier is string => specifier !== undefined
+      && isPackageRequire(specifier)
+      && !optionalPackageRequires.has(specifier));
+
+  assert.deepEqual([...new Set(packageRequires)].sort(), []);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ fn start_server(resource_dir: PathBuf, port: u16) -> Result<Child, String> {
     Command::new(&node)
         .arg(&server_script)
         .env("NODE_ENV", "production")
+        .env("OH_MY_PR_DESKTOP", "1")
         .env("PORT", port.to_string())
         .current_dir(&resource_dir)
         .spawn()


### PR DESCRIPTION
## Summary
- bundle the runtime packages required by the production server so Tauri's dist-only resource directory can start it
- mark packaged desktop launches with OH_MY_PR_DESKTOP and lazy-load browser opening so the server does not crash or open an external browser from the app
- add a regression test that fails when dist/index.cjs contains non-optional package requires

## Verification
- npm run build
- npm run check
- node --import tsx --test server/packagedBundle.test.ts
- npm test
- dist-only resource smoke: NODE_ENV=production OH_MY_PR_DESKTOP=1 PORT=5126 node dist/index.cjs, then curl / and /api/config returned 200
- npm run tauri:build -- --bundles app