### PR TITLE
Enrich generic CI check summaries with failed Actions steps

### DIFF
--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -532,6 +532,148 @@ test("fetchCheckSnapshotsForRef includes failed GitHub Actions step names for ge
   assert.equal(snapshots[0]?.description, "Failed steps: Lint");
 });
 
+test("fetchCheckSnapshotsForRef enriches plain generic failed GitHub Actions summaries", async () => {
+  const requestedJobIds: number[] = [];
+  const failedStepsByJobId = new Map<number, string>([
+    [73, "Lint"],
+    [74, "Test"],
+  ]);
+  const octokit = {
+    repos: {
+      getCombinedStatusForRef: async () => ({
+        data: {
+          statuses: [],
+        },
+      }),
+    },
+    checks: {
+      listForRef: async () => ({
+        data: {
+          check_runs: [
+            {
+              id: 73,
+              name: "lint",
+              status: "completed",
+              conclusion: "failure",
+              html_url: "https://github.com/example/repo/actions/runs/1/job/73",
+              output: {
+                title: null,
+                summary: "Failed  ",
+              },
+              app: {
+                slug: "github-actions",
+              },
+              completed_at: "2026-04-01T12:03:00.000Z",
+            },
+            {
+              id: 74,
+              name: "test",
+              status: "completed",
+              conclusion: "failure",
+              html_url: "https://github.com/example/repo/actions/runs/1/job/74",
+              output: {
+                title: null,
+                summary: "Failure\n",
+              },
+              app: {
+                slug: "github-actions",
+              },
+              completed_at: "2026-04-01T12:04:00.000Z",
+            },
+          ],
+        },
+      }),
+    },
+    request: async (route: string, params: Record<string, unknown>) => {
+      assert.equal(route, "GET /repos/{owner}/{repo}/actions/jobs/{job_id}");
+      const jobId = Number(params.job_id);
+      requestedJobIds.push(jobId);
+      return {
+        data: {
+          steps: [
+            { name: failedStepsByJobId.get(jobId), conclusion: "failure" },
+          ],
+        },
+      };
+    },
+  };
+
+  const snapshots = await fetchCheckSnapshotsForRef(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    "pr-1",
+    "abc123",
+  );
+
+  assert.deepEqual(requestedJobIds, [73, 74]);
+  assert.deepEqual(
+    snapshots.map((snapshot) => snapshot.description),
+    ["Failed steps: Lint", "Failed steps: Test"],
+  );
+});
+
+test("fetchCheckSnapshotsForRef bounds parallel GitHub Actions job detail requests", async () => {
+  let activeRequests = 0;
+  let maxActiveRequests = 0;
+  const runCount = 12;
+  const octokit = {
+    repos: {
+      getCombinedStatusForRef: async () => ({
+        data: {
+          statuses: [],
+        },
+      }),
+    },
+    checks: {
+      listForRef: async () => ({
+        data: {
+          check_runs: Array.from({ length: runCount }, (_, index) => ({
+            id: index + 1,
+            name: `job-${index + 1}`,
+            status: "completed",
+            conclusion: "failure",
+            html_url: `https://github.com/example/repo/actions/runs/1/job/${index + 1}`,
+            output: {
+              title: null,
+              summary: null,
+            },
+            app: {
+              slug: "github-actions",
+            },
+            completed_at: "2026-04-01T12:03:00.000Z",
+          })),
+        },
+      }),
+    },
+    request: async () => {
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeRequests -= 1;
+      return {
+        data: {
+          steps: [
+            { name: "Test", conclusion: "failure" },
+          ],
+        },
+      };
+    },
+  };
+
+  const snapshots = await fetchCheckSnapshotsForRef(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    "pr-1",
+    "abc123",
+  );
+
+  assert.equal(snapshots.length, runCount);
+  assert.ok(
+    maxActiveRequests < runCount,
+    `expected fewer than ${runCount} simultaneous job detail requests, saw ${maxActiveRequests}`,
+  );
+});
+
 test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored", async () => {
   let callIndex = 0;
 

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -471,6 +471,67 @@ test("fetchCheckSnapshotsForRef normalizes commit statuses and check runs", asyn
   assert.equal(snapshots[2]?.targetUrl, "https://example.com/check/1");
 });
 
+test("fetchCheckSnapshotsForRef includes failed GitHub Actions step names for generic check runs", async () => {
+  const octokit = {
+    repos: {
+      getCombinedStatusForRef: async () => ({
+        data: {
+          statuses: [],
+        },
+      }),
+    },
+    checks: {
+      listForRef: async () => ({
+        data: {
+          check_runs: [
+            {
+              id: 73,
+              name: "ci",
+              status: "completed",
+              conclusion: "failure",
+              html_url: "https://github.com/example/repo/actions/runs/1/job/73",
+              output: {
+                title: null,
+                summary: null,
+              },
+              app: {
+                slug: "github-actions",
+              },
+              completed_at: "2026-04-01T12:03:00.000Z",
+            },
+          ],
+        },
+      }),
+    },
+    request: async (route: string, params: Record<string, unknown>) => {
+      assert.equal(route, "GET /repos/{owner}/{repo}/actions/jobs/{job_id}");
+      assert.equal(params.owner, "owner");
+      assert.equal(params.repo, "repo");
+      assert.equal(params.job_id, 73);
+      return {
+        data: {
+          steps: [
+            { name: "Install dependencies", conclusion: "success" },
+            { name: "Lint", conclusion: "failure" },
+            { name: "Typecheck", conclusion: "skipped" },
+          ],
+        },
+      };
+    },
+  };
+
+  const snapshots = await fetchCheckSnapshotsForRef(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    "pr-1",
+    "abc123",
+  );
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.context, "ci");
+  assert.equal(snapshots[0]?.description, "Failed steps: Lint");
+});
+
 test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored", async () => {
   let callIndex = 0;
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -73,6 +73,8 @@ type GitHubActionsJobResponse = {
   steps?: GitHubActionsJobStepResponse[] | null;
 };
 
+const GITHUB_ACTIONS_JOB_ENRICHMENT_BATCH_SIZE = 4;
+
 export type GitHubPullCloseState = {
   number: number;
   title: string;
@@ -397,6 +399,14 @@ function summarizeFailedGitHubActionsSteps(job: GitHubActionsJobResponse): strin
   return `Failed steps: ${Array.from(new Set(failedStepNames)).join(", ")}`;
 }
 
+function isGenericCheckRunFailureSummary(summary: string | null | undefined): boolean {
+  const currentSummary = summary?.trim() ?? "";
+  return (
+    currentSummary === "" ||
+    /^(?:check run(?: [a-z_]+)?|failed|failure)$/i.test(currentSummary)
+  );
+}
+
 function mergeCheckRunFailureSummary(
   run: GitHubCheckRunResponse,
   failedStepsSummary: string | null,
@@ -405,8 +415,7 @@ function mergeCheckRunFailureSummary(
     return run;
   }
 
-  const currentSummary = run.output?.summary?.trim() ?? "";
-  if (currentSummary && !/^check run(?: [a-z_]+)?$/i.test(currentSummary)) {
+  if (!isGenericCheckRunFailureSummary(run.output?.summary)) {
     return run;
   }
 
@@ -427,6 +436,9 @@ async function enrichCheckRunWithGitHubActionsSteps(
   if (!isGitHubActionsCheckRun(run) || run.conclusion !== "failure") {
     return run;
   }
+  if (!isGenericCheckRunFailureSummary(run.output?.summary)) {
+    return run;
+  }
 
   try {
     const response = await octokit.request("GET /repos/{owner}/{repo}/actions/jobs/{job_id}", {
@@ -442,6 +454,23 @@ async function enrichCheckRunWithGitHubActionsSteps(
   } catch {
     return run;
   }
+}
+
+async function enrichCheckRunsWithGitHubActionsSteps(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  runs: GitHubCheckRunResponse[],
+): Promise<GitHubCheckRunResponse[]> {
+  const enrichedRuns: GitHubCheckRunResponse[] = [];
+
+  for (let index = 0; index < runs.length; index += GITHUB_ACTIONS_JOB_ENRICHMENT_BATCH_SIZE) {
+    const batch = runs.slice(index, index + GITHUB_ACTIONS_JOB_ENRICHMENT_BATCH_SIZE);
+    enrichedRuns.push(...(await Promise.all(
+      batch.map((run) => enrichCheckRunWithGitHubActionsSteps(octokit, repo, run)),
+    )));
+  }
+
+  return enrichedRuns;
 }
 
 export async function fetchCheckSnapshotsForRef(
@@ -465,10 +494,10 @@ export async function fetchCheckSnapshotsForRef(
     })),
   ]);
 
-  const checkRuns = await Promise.all(
-    ((checkRunsResponse.data.check_runs ?? []) as GitHubCheckRunResponse[]).map((run) =>
-      enrichCheckRunWithGitHubActionsSteps(octokit, repo, run),
-    ),
+  const checkRuns = await enrichCheckRunsWithGitHubActionsSteps(
+    octokit,
+    repo,
+    (checkRunsResponse.data.check_runs ?? []) as GitHubCheckRunResponse[],
   );
 
   return normalizeCheckSnapshotsFromRef({

--- a/server/github.ts
+++ b/server/github.ts
@@ -47,6 +47,7 @@ type GitHubCommitStatusResponse = {
 };
 
 type GitHubCheckRunResponse = {
+  id?: number | null;
   name?: string | null;
   status?: string | null;
   conclusion?: string | null;
@@ -58,6 +59,18 @@ type GitHubCheckRunResponse = {
     title?: string | null;
     summary?: string | null;
   } | null;
+  app?: {
+    slug?: string | null;
+  } | null;
+};
+
+type GitHubActionsJobStepResponse = {
+  name?: string | null;
+  conclusion?: string | null;
+};
+
+type GitHubActionsJobResponse = {
+  steps?: GitHubActionsJobStepResponse[] | null;
 };
 
 export type GitHubPullCloseState = {
@@ -367,6 +380,70 @@ export function buildFeedbackAuditToken(feedbackId: string): string {
   return `codefactory-feedback:${feedbackId}`;
 }
 
+function isGitHubActionsCheckRun(run: GitHubCheckRunResponse): run is GitHubCheckRunResponse & { id: number } {
+  return run.app?.slug === "github-actions" && typeof run.id === "number";
+}
+
+function summarizeFailedGitHubActionsSteps(job: GitHubActionsJobResponse): string | null {
+  const failedStepNames = (job.steps ?? [])
+    .filter((step) => step.conclusion === "failure")
+    .map((step) => step.name?.trim())
+    .filter((name): name is string => Boolean(name));
+
+  if (failedStepNames.length === 0) {
+    return null;
+  }
+
+  return `Failed steps: ${Array.from(new Set(failedStepNames)).join(", ")}`;
+}
+
+function mergeCheckRunFailureSummary(
+  run: GitHubCheckRunResponse,
+  failedStepsSummary: string | null,
+): GitHubCheckRunResponse {
+  if (!failedStepsSummary) {
+    return run;
+  }
+
+  const currentSummary = run.output?.summary?.trim() ?? "";
+  if (currentSummary && !/^check run(?: [a-z_]+)?$/i.test(currentSummary)) {
+    return run;
+  }
+
+  return {
+    ...run,
+    output: {
+      ...(run.output ?? {}),
+      summary: failedStepsSummary,
+    },
+  };
+}
+
+async function enrichCheckRunWithGitHubActionsSteps(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  run: GitHubCheckRunResponse,
+): Promise<GitHubCheckRunResponse> {
+  if (!isGitHubActionsCheckRun(run) || run.conclusion !== "failure") {
+    return run;
+  }
+
+  try {
+    const response = await octokit.request("GET /repos/{owner}/{repo}/actions/jobs/{job_id}", {
+      owner: repo.owner,
+      repo: repo.repo,
+      job_id: run.id,
+    });
+
+    return mergeCheckRunFailureSummary(
+      run,
+      summarizeFailedGitHubActionsSteps(response.data as GitHubActionsJobResponse),
+    );
+  } catch {
+    return run;
+  }
+}
+
 export async function fetchCheckSnapshotsForRef(
   octokit: Octokit,
   repo: ParsedRepoSlug,
@@ -388,11 +465,17 @@ export async function fetchCheckSnapshotsForRef(
     })),
   ]);
 
+  const checkRuns = await Promise.all(
+    ((checkRunsResponse.data.check_runs ?? []) as GitHubCheckRunResponse[]).map((run) =>
+      enrichCheckRunWithGitHubActionsSteps(octokit, repo, run),
+    ),
+  );
+
   return normalizeCheckSnapshotsFromRef({
     prId,
     sha: headSha,
     statuses: (statusResponse.data.statuses ?? []) as GitHubCommitStatusResponse[],
-    checkRuns: (checkRunsResponse.data.check_runs ?? []) as GitHubCheckRunResponse[],
+    checkRuns,
   });
 }
 


### PR DESCRIPTION
## What changed

This updates CI check ingestion so generic GitHub Actions check runs such as `ci` with a summary like `Check run failure`
are enriched with the failed job step names when available.

For example, a generic failure can now become `Failed steps: Lint` before it reaches the healing classifier.

## Why

The CI healing classifier already recognizes signals like `lint`, `test`, and `build`, but in PR #6 the failing GitHub
Actions check only surfaced a generic `ci` / `Check run failure` summary.

That caused the failure to be classified as `unknown`, so no repair attempt was started even though the real failure was
healable in-branch.

## Impact

This keeps the existing classifier and healing flow intact, while making GitHub Actions failures more informative at
ingestion time.

As a result, healable failures hidden behind generic check run summaries are more likely to enter the normal CI healing
loop.

## Root cause

The ingestion layer stored only the top-level check run name and summary.

For GitHub Actions jobs, that dropped the actual failing step signal, so the classifier never saw keywords like `Lint`.
