### PR TITLE
fix: keep docs sidebar visible

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="./public/styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="./index.html">
@@ -331,8 +331,8 @@
   </div>
 </section>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./public/_site/getting-started.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./public/_site/getting-started.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       Quickstart Guide

--- a/docs/public/_site/agent-dispatch.html
+++ b/docs/public/_site/agent-dispatch.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -257,8 +257,8 @@
 
 </article>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-questions.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-questions.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       PR Q&amp;A

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -401,8 +401,8 @@ npm run tauri:build  # Tauri production build
 
 </article>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-babysitter.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./pr-babysitter.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       PR Babysitter

--- a/docs/public/_site/getting-started.html
+++ b/docs/public/_site/getting-started.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -240,8 +240,8 @@ npm run tauri:build  # Production build
 
 </article>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./configuration.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./configuration.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       Configuration

--- a/docs/public/_site/index.html
+++ b/docs/public/_site/index.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -331,8 +331,8 @@
   </div>
 </section>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./getting-started.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./getting-started.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       Quickstart Guide

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -307,8 +307,8 @@
 
 </article>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./agent-dispatch.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="./agent-dispatch.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Next</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       Agent Dispatch

--- a/docs/public/_site/pr-questions.html
+++ b/docs/public/_site/pr-questions.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     <aside class="hidden h-screen w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-dark-800 bg-dark-900 md:flex" data-purpose="sidebar">
   <div class="sticky top-0 z-10 border-b border-dark-800 bg-dark-900/95 p-4 backdrop-blur">
     <div class="mb-4 flex items-center gap-2">
@@ -159,7 +159,7 @@
     </div>
   </nav>
 </aside>
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         <div class="mb-8 flex items-center justify-between rounded-xl border border-dark-800 bg-dark-800/60 px-4 py-3 md:hidden">
   <a class="flex items-center gap-2 text-white" href="../../index.html">
@@ -232,8 +232,8 @@
 
 </article>
       </div>
-      <div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="../../index.html">
+      <div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="../../index.html">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">Overview</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       Documentation Overview

--- a/script/build-public-docs.ts
+++ b/script/build-public-docs.ts
@@ -366,8 +366,8 @@ function renderBottomNav(bottomNav?: BottomNav): string {
     return "";
   }
 
-  return `<div class="pointer-events-none sticky bottom-0 left-0 right-0 mx-auto flex w-full max-w-4xl justify-end bg-gradient-to-t from-dark-900 via-dark-900 to-transparent px-6 pb-8 pt-16 sm:px-8">
-  <a class="pointer-events-auto flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="${bottomNav.href}">
+  return `<div class="mx-auto mt-16 flex w-full max-w-4xl justify-end px-6 pb-8 sm:px-8">
+  <a class="flex w-full min-w-[220px] flex-col items-end rounded-lg bg-brand-500 px-6 py-4 text-white shadow-lg shadow-brand-500/20 transition-colors hover:bg-brand-400 sm:w-auto" href="${bottomNav.href}">
     <span class="mb-1 text-xs font-semibold uppercase tracking-wider text-blue-100">${escapeHtml(bottomNav.label)}</span>
     <span class="flex items-center gap-2 text-lg font-medium">
       ${escapeHtml(bottomNav.title)}
@@ -388,9 +388,9 @@ function renderShell(
 ): string {
   return `${buildHead(title, description, context.stylesheetHref)}
 <body class="antialiased text-sm">
-  <div class="flex min-h-screen overflow-hidden">
+  <div class="flex h-screen overflow-hidden">
     ${renderSidebar(context, activeKey, docs)}
-    <main class="relative w-full flex-1 overflow-y-auto" data-purpose="main-content">
+    <main class="relative h-screen w-full flex-1 overflow-y-auto" data-purpose="main-content">
       <div class="mx-auto max-w-4xl px-6 py-10 pb-28 sm:px-8 sm:py-12 sm:pb-32">
         ${renderMobileHeader(context)}
         ${bodyContent}
@@ -399,7 +399,8 @@ function renderShell(
     </main>
   </div>
 </body>
-</html>`;
+</html>
+`;
 }
 
 function getDocMeta(docs: DocMeta[], slug: string): DocMeta | undefined {


### PR DESCRIPTION
This lil pr only touched the docs, to make the sidebar sticky when you scroll.

When you scroll before:
<img width="1263" height="1027" alt="image" src="https://github.com/user-attachments/assets/577e387c-a0b3-45e3-9c3a-5fa8a43a3180" />

after:
<img width="1410" height="1133" alt="annotely_image (5)" src="https://github.com/user-attachments/assets/cb25d5ed-3f57-454d-8c97-a74239aefa36" />
