### PR TITLE
[codex] Fix my PRs only watcher runs

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -4045,7 +4045,7 @@ test("syncAndBabysitTrackedRepos can include teammate PRs when repo setting disa
   assert.equal(queuedTargets.length, 2);
 });
 
-test("syncAndBabysitTrackedRepos keeps explicitly tracked teammate PRs active when own-only filtering is enabled", async () => {
+test("syncAndBabysitTrackedRepos skips already tracked teammate PRs when own-only filtering is enabled", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({
     watchedRepos: ["alex-morgan-o/lolodex"],
@@ -4103,7 +4103,7 @@ test("syncAndBabysitTrackedRepos keeps explicitly tracked teammate PRs active wh
 
   const updated = await storage.getPR(tracked.id);
   assert.equal(updated?.status, "watching");
-  assert.deepEqual(queuedTargets, [tracked.id]);
+  assert.deepEqual(queuedTargets, []);
 });
 
 test("syncAndBabysitTrackedRepos uses the injected clock for fallback healing snapshots", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1178,7 +1178,7 @@ export class PRBabysitter {
       const openNumbers = new Set(openPulls.map((p) => p.number));
       const repoOwnPrsOnly = repoSettingsByRepo.get(repoSlug)?.ownPrsOnly ?? true;
       const authenticatedLogin = repoOwnPrsOnly ? await getAuthenticatedLogin() : null;
-      const discoveryNumbers = new Set(
+      const automationScopeNumbers = new Set(
         openPulls
           .filter((pull) => !repoOwnPrsOnly || (
             authenticatedLogin !== null
@@ -1325,7 +1325,7 @@ export class PRBabysitter {
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
-          if (!discoveryNumbers.has(pull.number)) {
+          if (!automationScopeNumbers.has(pull.number)) {
             continue;
           }
 
@@ -1347,6 +1347,10 @@ export class PRBabysitter {
           });
 
           await this.storage.addLog(local.id, "info", `Auto-registered open PR #${pull.number} from ${repoSlug}`);
+        }
+
+        if (!automationScopeNumbers.has(pull.number)) {
+          continue;
         }
 
         if (!local.watchEnabled) {


### PR DESCRIPTION
## Summary

- Gate automatic watcher babysitter runs with the same author scope used for watched-repo PR discovery.
- Keep teammate PRs from being automatically queued when a repo is set to `My PRs only`, even if that PR was already tracked locally.
- Add regression coverage for an already-tracked teammate PR under `ownPrsOnly=true`.

## Root Cause

`ownPrsOnly` was only applied while discovering new PRs. Once a teammate PR already existed in local storage, the watcher still treated it as eligible for autonomous babysitter runs as long as `watchEnabled` was true.

## Validation

- `npm run check`
- `node --test --import tsx server/*.test.ts`