### PR TITLE
fix: report agent feedback failure reasons

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -1535,6 +1535,89 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
   }
 });
 
+test("babysitPR posts a concise GitHub status reason when the agent fails to address feedback", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const pullSummary = makePullSummary(pr);
+    let latestStatusReplyBody = "";
+    let postedFollowUps = 0;
+
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [existingItem],
+        fetchPullSummary: async () => pullSummary,
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => {
+          postedFollowUps += 1;
+        },
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async (_octokit, _parsed, item, body) => {
+          latestStatusReplyBody = body;
+          return { commentDatabaseId: 55, replyKind: item.replyKind, body };
+        },
+        updateStatusReply: async (_octokit, _parsed, ref, body) => {
+          ref.body = body;
+          latestStatusReplyBody = body;
+        },
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => ({
+          needsFix: true,
+          reason: "Comment requires a code change",
+        }),
+        applyFixesWithAgent: async () => ({
+          code: 1,
+          stdout: "",
+          stderr: "TypeScript check failed\nstack trace line that should stay out of the GitHub status reply",
+        }),
+        runCommand: makeGitRunCommand(),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const updated = await storage.getPR(pr.id);
+    const failedItem = updated?.feedbackItems.find((item) => item.id === existingItem.id);
+
+    assert.equal(failedItem?.status, "failed");
+    assert.equal(postedFollowUps, 0);
+    assert.match(latestStatusReplyBody, /\u274c \*\*Agent failed\*\* \u2014 TypeScript check failed\./);
+    assert.doesNotMatch(latestStatusReplyBody, /stack trace line/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
 test("babysitPR marks the run as error when app-owned GitHub follow-up fails", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoUpdateDocs: false });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -141,7 +141,9 @@ const defaultBabysitterRuntime: BabysitterRuntime = {
 const STATUS_MESSAGES = {
   accepted: "\u23f3 **Accepted** — this comment requires code changes. Queuing fix...",
   agentRunning: (agent: CodingAgent) => `\ud83e\uddf0 **Agent running** — \`${agent}\` is working on the fix...`,
-  agentFailed: "\u274c **Agent failed** — the coding agent exited with an error.",
+  agentFailed: (reason?: string) => reason
+    ? `\u274c **Agent failed** — ${reason}`
+    : "\u274c **Agent failed** — the coding agent exited with an error.",
   agentCompleted: "\u2705 **Agent completed** — verifying changes...",
   resolved: (headSha: string) => {
     const shortSha = headSha.trim().slice(0, 7);
@@ -797,6 +799,21 @@ function summarizeCommandFailure(result: Awaited<ReturnType<typeof runCommand>>)
 
 function summarizeUnknownError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function formatConciseFailureReason(message: string): string {
+  const detail = message
+    .replace(/^Agent apply failed \(\d+\):\s*/i, "")
+    .replace(/^Agent failed to resolve merge conflicts \(\d+\):\s*/i, "")
+    .replace(/^Error:\s*/i, "");
+  const firstLine = detail
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0)
+    ?? "No failure details were reported";
+  const singleLine = firstLine.replace(/\s+/g, " ");
+  const capped = singleLine.length > 180 ? `${singleLine.slice(0, 177).trimEnd()}...` : singleLine;
+  return /[.!?]$/.test(capped) ? capped : `${capped}.`;
 }
 
 function drainChunkLines(buffer: string, chunk: string): { lines: string[]; buffer: string } {
@@ -2537,7 +2554,8 @@ export class PRBabysitter {
 
             if (applyResult.code !== 0) {
               // Update status replies on failure.
-              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed)));
+              const failureReason = formatConciseFailureReason(applyResult.stderr || applyResult.stdout);
+              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed(failureReason))));
               throw new Error(`Agent apply failed (${applyResult.code}): ${applyResult.stderr || applyResult.stdout}`);
             }
 


### PR DESCRIPTION
Summary: Adds a concise agent failure reason to the GitHub status reply when a feedback-fix agent exits non-zero, and covers the review-thread status reply behavior with a regression test. Verification: npm run check; node --test --import tsx server/babysitter.test.ts; node --test --import tsx server/*.test.ts. Note: the repo-requested /simplify pass was attempted but the local Claude CLI returned 401 invalid credentials.