### PR TITLE
feat: add manual repo release trigger

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
-import type { Config, FeedbackItem, HealingSession, LogEntry, PR, PRQuestion, WatchedRepo } from "@shared/schema";
+import type { Config, FeedbackItem, HealingSession, LogEntry, PR, PRQuestion, ReleaseRun, WatchedRepo } from "@shared/schema";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -866,6 +866,20 @@ export default function Dashboard() {
     },
   });
 
+  const manualReleaseMutation = useMutation({
+    mutationFn: async (repo: string) => {
+      const res = await apiRequest("POST", "/api/repos/release", { repo });
+      return res.json() as Promise<ReleaseRun>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/releases"] });
+      toast({ description: "Release queued." });
+    },
+    onError: (error) => {
+      showMutationError("Could not create release", error);
+    },
+  });
+
   const updateRepoSettingsRequest = async (updates: RepoSettingsUpdate) => {
     const res = await apiRequest("PATCH", "/api/repos/settings", updates);
     return res.json();
@@ -1117,58 +1131,74 @@ export default function Dashboard() {
                     <div className="text-[11px] text-muted-foreground">No repositories being watched yet.</div>
                   ) : (
                     <div className="space-y-1 text-[12px]">
-                      {repos.map((repo) => (
-                        <div
-                          key={repo.repo}
-                          className="space-y-2 border border-border/60 px-2 py-2"
-                        >
-                          <a
-                            href={getRepoHref(repo.repo)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            data-testid={`tracked-repo-${repo.repo.replace("/", "-")}`}
-                            className="min-w-0 break-all text-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+                      {repos.map((repo) => {
+                        const manualReleasePending = manualReleaseMutation.isPending
+                          && manualReleaseMutation.variables === repo.repo;
+
+                        return (
+                          <div
+                            key={repo.repo}
+                            className="space-y-2 border border-border/60 px-2 py-2"
                           >
-                            {repo.repo}
-                          </a>
-                          <div className="flex flex-wrap items-start justify-between gap-2">
-                            <div>
-                              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                                Track automatically
+                            <a
+                              href={getRepoHref(repo.repo)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              data-testid={`tracked-repo-${repo.repo.replace("/", "-")}`}
+                              className="min-w-0 break-all text-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+                            >
+                              {repo.repo}
+                            </a>
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div>
+                                <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                  Track automatically
+                                </div>
+                                <WatchScopeControl
+                                  value={getWatchScope(repo.ownPrsOnly)}
+                                  onChange={(value) =>
+                                    updateRepoSettingsMutation.mutate({
+                                      repo: repo.repo,
+                                      ownPrsOnly: value === "mine",
+                                    })
+                                  }
+                                  disabled={updateRepoSettingsMutation.isPending}
+                                  name={`tracked-repo-scope-${repo.repo}`}
+                                  testIdPrefix={`tracked-repo-scope-${repo.repo.replace("/", "-")}`}
+                                  compact
+                                />
                               </div>
-                              <WatchScopeControl
-                                value={getWatchScope(repo.ownPrsOnly)}
-                                onChange={(value) =>
-                                  updateRepoSettingsMutation.mutate({
-                                    repo: repo.repo,
-                                    ownPrsOnly: value === "mine",
-                                  })
-                                }
-                                disabled={updateRepoSettingsMutation.isPending}
-                                name={`tracked-repo-scope-${repo.repo}`}
-                                testIdPrefix={`tracked-repo-scope-${repo.repo.replace("/", "-")}`}
-                                compact
-                              />
+                              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 self-end">
+                                <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                                  <input
+                                    type="checkbox"
+                                    checked={repo.autoCreateReleases}
+                                    onChange={(e) =>
+                                      updateRepoSettingsMutation.mutate({
+                                        repo: repo.repo,
+                                        autoCreateReleases: e.target.checked,
+                                      })
+                                    }
+                                    disabled={updateRepoSettingsMutation.isPending}
+                                    data-testid={`tracked-repo-auto-release-${repo.repo.replace("/", "-")}`}
+                                    className="accent-foreground"
+                                  />
+                                  Auto-release
+                                </label>
+                                <button
+                                  type="button"
+                                  onClick={() => manualReleaseMutation.mutate(repo.repo)}
+                                  disabled={manualReleaseMutation.isPending}
+                                  data-testid={`tracked-repo-manual-release-${repo.repo.replace("/", "-")}`}
+                                  className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background disabled:opacity-30"
+                                >
+                                  {manualReleasePending ? "Releasing…" : "Release"}
+                                </button>
+                              </div>
                             </div>
-                            <label className="flex shrink-0 self-end items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                              <input
-                                type="checkbox"
-                                checked={repo.autoCreateReleases}
-                                onChange={(e) =>
-                                  updateRepoSettingsMutation.mutate({
-                                    repo: repo.repo,
-                                    autoCreateReleases: e.target.checked,
-                                  })
-                                }
-                                disabled={updateRepoSettingsMutation.isPending}
-                                data-testid={`tracked-repo-auto-release-${repo.repo.replace("/", "-")}`}
-                                className="accent-foreground"
-                              />
-                              Auto-release
-                            </label>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   )}
                 </div>

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -278,6 +278,9 @@
 </tbody></table>
 <p>New watched repos default to <strong>My PRs only</strong>. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
 <p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting.</p>
+<h2>Manual Repository Releases</h2>
+<p>Each watched repository row in the dashboard includes a <strong>Release</strong> button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.</p>
+<p>Manual release runs are allowed even when <code>autoCreateReleases</code> is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns <code>409</code> and no release run is created.</p>
 <h2>App Update Banner</h2>
 <p>On builds where <code>APP_VERSION</code> is a stable semver string, the dashboard calls
 <code>GET /api/app-update</code> and compares the running version to the latest stable

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -64,6 +64,12 @@ New watched repos default to **My PRs only**. If you want team-wide tracking for
 
 PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting.
 
+## Manual Repository Releases
+
+Each watched repository row in the dashboard includes a **Release** button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.
+
+Manual release runs are allowed even when `autoCreateReleases` is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns `409` and no release run is created.
+
 ## App Update Banner
 
 On builds where `APP_VERSION` is a stable semver string, the dashboard calls

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { NewPR } from "@shared/schema";
-import { createAppRuntime } from "./appRuntime";
+import { createAppRuntime, mapMergedPullsToReleaseSummaries } from "./appRuntime";
 import { MemStorage } from "./memoryStorage";
 
 async function seedPR(storage: MemStorage, overrides: Partial<NewPR> = {}) {
@@ -144,4 +144,39 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
   assert.equal(config.codingAgent, "codex");
   assert.equal(config.autoUpdateDocs, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
+});
+
+test("runtime release adapter skips merged PRs without a merge commit SHA", () => {
+  const summaries = mapMergedPullsToReleaseSummaries([
+    {
+      number: 12,
+      title: "Missing merge SHA",
+      url: "https://github.com/acme/widgets/pull/12",
+      author: "alice",
+      repo: "acme/widgets",
+      mergedAt: "2026-04-26T12:00:00.000Z",
+      mergeCommitSha: null,
+    },
+    {
+      number: 13,
+      title: "Real release target",
+      url: "https://github.com/acme/widgets/pull/13",
+      author: "bob",
+      repo: "acme/widgets",
+      mergedAt: "2026-04-26T13:00:00.000Z",
+      mergeCommitSha: "  abc123  ",
+    },
+  ]);
+
+  assert.deepEqual(summaries, [
+    {
+      number: 13,
+      title: "Real release target",
+      url: "https://github.com/acme/widgets/pull/13",
+      author: "bob",
+      repo: "acme/widgets",
+      mergedAt: "2026-04-26T13:00:00.000Z",
+      mergeSha: "abc123",
+    },
+  ]);
 });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -23,6 +23,7 @@ import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
 import { ReleaseManager } from "./releaseManager";
+import type { ReleaseAgentPullSummary } from "./releaseAgent";
 import { DeploymentHealingManager } from "./deploymentHealingManager";
 import {
   buildOctokit,
@@ -36,6 +37,7 @@ import {
   installCodeReviewWorkflow,
   listReleasesForRepo,
   listUnreleasedMergedPulls,
+  type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
   resolveNextSemverTag,
@@ -129,6 +131,25 @@ function assertFound<T>(value: T | undefined, message: string): T {
   return value;
 }
 
+export function mapMergedPullsToReleaseSummaries(pulls: MergedPRSummary[]): ReleaseAgentPullSummary[] {
+  return pulls.flatMap((pull) => {
+    const mergeSha = pull.mergeCommitSha?.trim();
+    if (!mergeSha) {
+      return [];
+    }
+
+    return [{
+      number: pull.number,
+      title: pull.title,
+      url: pull.url,
+      author: pull.author,
+      repo: pull.repo,
+      mergedAt: pull.mergedAt,
+      mergeSha,
+    }];
+  });
+}
+
 export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): AppRuntime {
   const storage = dependencies.storage ?? getDefaultStorage();
   const events = new EventEmitter();
@@ -154,15 +175,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           baseRef: options.baseBranch,
         });
 
-        return merged.map((pull) => ({
-          number: pull.number,
-          title: pull.title,
-          url: pull.url,
-          author: pull.author,
-          repo: pull.repo,
-          mergedAt: pull.mergedAt,
-          mergeSha: pull.mergeCommitSha ?? `${pull.repo}#${pull.number}`,
-        }));
+        return mapMergedPullsToReleaseSummaries(merged);
       },
       listMergedPullsForReleaseCandidate: async (octokit, repo, options) => {
         const merged = await listUnreleasedMergedPulls(octokit, repo, {
@@ -170,17 +183,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         });
         const cutoffMs = Date.parse(options.untilMergedAt);
 
-        return merged
-          .filter((pull) => !Number.isFinite(cutoffMs) || Date.parse(pull.mergedAt) <= cutoffMs)
-          .map((pull) => ({
-            number: pull.number,
-            title: pull.title,
-            url: pull.url,
-            author: pull.author,
-            repo: pull.repo,
-            mergedAt: pull.mergedAt,
-            mergeSha: pull.mergeCommitSha ?? `${pull.repo}#${pull.number}`,
-          }));
+        return mapMergedPullsToReleaseSummaries(
+          merged.filter((pull) => !Number.isFinite(cutoffMs) || Date.parse(pull.mergedAt) <= cutoffMs),
+        );
       },
       findReleaseByTag: async (octokit, repo, tagName) => {
         const releases = await listReleasesForRepo(octokit, repo);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -30,6 +30,7 @@ import {
   createGitHubRelease,
   fetchPullSummary,
   formatRepoSlug,
+  getDefaultBranchForRepo,
   getLatestSemverTagForRepo,
   GitHubIntegrationError,
   installCodeReviewWorkflow,
@@ -84,6 +85,7 @@ export type AppRuntime = {
   addRepo(repoInput: string): Promise<{ repo: string }>;
   updateRepoSettings(repoInput: string, updates: Partial<Omit<WatchedRepo, "repo">>): Promise<WatchedRepo>;
   syncRepos(): Promise<{ ok: true }>;
+  createManualRelease(repoInput: string): Promise<ReleaseRun>;
   listPRs(view?: "active" | "archived"): Promise<PR[]>;
   getPR(id: string): Promise<PR | null>;
   addPR(url: string): Promise<PR>;
@@ -144,8 +146,24 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   const releaseManager = dependencies.releaseManager ?? new ReleaseManager(storage, {
     github: {
       buildOctokit,
+      getDefaultBranch: getDefaultBranchForRepo,
       findLatestSemverReleaseTag: getLatestSemverTagForRepo,
       bumpReleaseTag: resolveNextSemverTag,
+      listUnreleasedMergedPulls: async (octokit, repo, options) => {
+        const merged = await listUnreleasedMergedPulls(octokit, repo, {
+          baseRef: options.baseBranch,
+        });
+
+        return merged.map((pull) => ({
+          number: pull.number,
+          title: pull.title,
+          url: pull.url,
+          author: pull.author,
+          repo: pull.repo,
+          mergedAt: pull.mergedAt,
+          mergeSha: pull.mergeCommitSha ?? `${pull.repo}#${pull.number}`,
+        }));
+      },
       listMergedPullsForReleaseCandidate: async (octokit, repo, options) => {
         const merged = await listUnreleasedMergedPulls(octokit, repo, {
           baseRef: options.baseBranch,
@@ -420,6 +438,22 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       await watcherScheduler.runAndReportErrors();
       notifyChange();
       return { ok: true as const };
+    },
+
+    async createManualRelease(repoInput) {
+      const parsedRepo = parseRepoSlug(repoInput);
+      if (!parsedRepo) {
+        throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+      }
+
+      const canonical = formatRepoSlug(parsedRepo);
+      const release = await releaseManager.enqueueManualRepoRelease(canonical);
+      if (!release) {
+        throw new AppRuntimeError(409, `No unreleased merged pull requests found for ${canonical}`);
+      }
+
+      notifyChange();
+      return release;
     },
 
     async listPRs(view = "active") {

--- a/server/github.ts
+++ b/server/github.ts
@@ -1017,7 +1017,7 @@ function parseDateMs(value: string | null | undefined): number | null {
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
-async function getDefaultBranchForRepo(
+export async function getDefaultBranchForRepo(
   octokit: Octokit,
   repo: ParsedRepoSlug,
 ): Promise<string> {

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -50,6 +50,7 @@ function makeGitHubService(overrides: Partial<ReleaseGitHubService> = {}): Relea
   return {
     buildOctokit: async () => ({}) as Octokit,
     findLatestSemverReleaseTag: async () => "v1.2.3",
+    getDefaultBranch: async () => "main",
     bumpReleaseTag: (latestTag, bump) => {
       if (latestTag !== "v1.2.3") {
         throw new Error(`unexpected latest tag: ${latestTag}`);
@@ -58,6 +59,15 @@ function makeGitHubService(overrides: Partial<ReleaseGitHubService> = {}): Relea
       if (bump === "minor") return "v1.3.0";
       return "v1.2.4";
     },
+    listUnreleasedMergedPulls: async () => [
+      makeMergedSummary({
+        number: 70,
+        title: "Earlier merged change",
+        mergedAt: "2026-03-28T14:00:00.000Z",
+        mergeSha: "def456",
+      }),
+      makeMergedSummary(),
+    ],
     listMergedPullsForReleaseCandidate: async (_octokit, _repo, options) => [
       makeMergedSummary({
         number: 70,
@@ -84,6 +94,7 @@ function makeReleaseRun(overrides: Partial<ReleaseRun> = {}): ReleaseRun {
     triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/74",
     triggerMergeSha: "retry-sha",
     triggerMergedAt: now,
+    source: "automatic",
     status: "error",
     decisionReason: null,
     recommendedBump: null,
@@ -117,6 +128,135 @@ function createQueuedManager(params?: {
 
   return { storage, queue, manager };
 }
+
+test("ReleaseManager enqueues a manual repo release from the latest unreleased merged PR", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  const { manager } = createQueuedManager({
+    storage,
+    github: {
+      listUnreleasedMergedPulls: async () => [
+        makeMergedSummary({
+          number: 70,
+          title: "Earlier merged change",
+          mergedAt: "2026-03-28T14:00:00.000Z",
+          mergeSha: "def456",
+        }),
+        makeMergedSummary({
+          number: 72,
+          title: "Manual release trigger",
+          url: "https://github.com/yungookim/oh-my-pr/pull/72",
+          mergedAt: "2026-03-28T16:00:00.000Z",
+          mergeSha: "manual-sha",
+        }),
+      ],
+    },
+  });
+
+  const created = await manager.enqueueManualRepoRelease("yungookim/oh-my-pr");
+  const jobs = await storage.listBackgroundJobs({
+    kind: "process_release_run",
+    status: "queued",
+  });
+
+  assert.ok(created);
+  assert.equal(created.source, "manual");
+  assert.equal(created.baseBranch, "main");
+  assert.equal(created.triggerPrNumber, 72);
+  assert.equal(created.triggerPrTitle, "Manual release trigger");
+  assert.equal(created.triggerMergeSha, "manual-sha");
+  assert.equal(created.targetSha, "manual-sha");
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].targetId, created.id);
+  assert.equal(jobs[0].dedupeKey, buildBackgroundJobDedupeKey("process_release_run", created.id));
+  assert.equal(await manager.waitForIdle(), true);
+});
+
+test("ReleaseManager publishes manual release runs when auto-release settings are disabled", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig({
+    autoCreateReleases: false,
+    watchedRepos: ["yungookim/oh-my-pr"],
+  }));
+  await storage.updateRepoSettings("yungookim/oh-my-pr", {
+    autoCreateReleases: false,
+  });
+
+  let createCalls = 0;
+  const { manager } = createQueuedManager({
+    storage,
+    github: {
+      createGitHubRelease: async (_octokit, _repo, params) => {
+        createCalls += 1;
+        assert.equal(params.tagName, "v1.2.4");
+        return makePublishedRelease(params.tagName);
+      },
+    },
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: true,
+      reason: "Manual release requested",
+      bump: "patch",
+      title: "Manual patch",
+      notes: "Manual release notes",
+    }),
+  });
+  const manualRun = await storage.createReleaseRun(makeReleaseRun({
+    source: "manual",
+    status: "detected",
+    error: null,
+    completedAt: null,
+  }));
+
+  const processed = await manager.processReleaseRun(manualRun.id);
+
+  assert.ok(processed);
+  assert.equal(processed.status, "published");
+  assert.equal(processed.source, "manual");
+  assert.equal(processed.githubReleaseUrl, "https://github.com/yungookim/oh-my-pr/releases/tag/v1.2.4");
+  assert.equal(createCalls, 1);
+});
+
+test("ReleaseManager publishes a manual patch release when evaluation recommends skipping", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+
+  let releaseBody = "";
+  const { manager } = createQueuedManager({
+    storage,
+    github: {
+      createGitHubRelease: async (_octokit, _repo, params) => {
+        assert.equal(params.tagName, "v1.2.4");
+        assert.equal(params.name, "v1.2.4 - Manual release");
+        releaseBody = params.body;
+        return makePublishedRelease(params.tagName);
+      },
+    },
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: false,
+      reason: "Only internal cleanup",
+      bump: null,
+      title: null,
+      notes: null,
+    }),
+  });
+  const manualRun = await storage.createReleaseRun(makeReleaseRun({
+    source: "manual",
+    status: "detected",
+    error: null,
+    completedAt: null,
+  }));
+
+  const processed = await manager.processReleaseRun(manualRun.id);
+
+  assert.ok(processed);
+  assert.equal(processed.status, "published");
+  assert.equal(processed.decisionReason, "Manual release requested. Evaluator recommendation: Only internal cleanup");
+  assert.equal(processed.recommendedBump, "patch");
+  assert.match(releaseBody, /## Changes/);
+  assert.match(releaseBody, /#70 Earlier merged change/);
+  assert.match(releaseBody, /#74 Retryable release/);
+});
 
 test("ReleaseManager enqueues a durable release job and still executes the release flow", async () => {
   const storage = new MemStorage();

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -25,8 +25,16 @@ type PublishedRelease = {
 
 export type ReleaseGitHubService = {
   buildOctokit(config: Config): Promise<Octokit>;
+  getDefaultBranch(octokit: Octokit, repo: ReleaseRepo): Promise<string>;
   findLatestSemverReleaseTag(octokit: Octokit, repo: ReleaseRepo): Promise<string | null>;
   bumpReleaseTag(latestTag: string | null, bump: ReleaseBump): string;
+  listUnreleasedMergedPulls(
+    octokit: Octokit,
+    repo: ReleaseRepo,
+    options: {
+      baseBranch: string;
+    },
+  ): Promise<ReleaseAgentPullSummary[]>;
   listMergedPullsForReleaseCandidate?(
     octokit: Octokit,
     repo: ReleaseRepo,
@@ -135,6 +143,82 @@ export class ReleaseManager {
     return created;
   }
 
+  async enqueueManualRepoRelease(repoInput: string): Promise<ReleaseRun | null> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new Error(`Invalid repository slug: ${repoInput}`);
+    }
+
+    const repo = `${parsedRepo.owner}/${parsedRepo.repo}`;
+    const config = await this.storage.getConfig();
+    const octokit = await this.github.buildOctokit(config);
+    const baseBranch = await this.github.getDefaultBranch(octokit, parsedRepo);
+    const unreleased = await this.github.listUnreleasedMergedPulls(octokit, parsedRepo, {
+      baseBranch,
+    });
+    const triggerPr = [...unreleased].sort((a, b) => Date.parse(a.mergedAt) - Date.parse(b.mergedAt)).at(-1);
+    if (!triggerPr) {
+      return null;
+    }
+
+    const existing = await this.storage.getReleaseRunByTrigger(
+      repo,
+      triggerPr.number,
+      triggerPr.mergeSha,
+    );
+    if (existing) {
+      const shouldReset = existing.status === "skipped" || existing.status === "error";
+      const updated = await this.storage.updateReleaseRun(existing.id, {
+        source: "manual",
+        ...(shouldReset ? {
+          status: "detected" as const,
+          decisionReason: null,
+          recommendedBump: null,
+          proposedVersion: null,
+          releaseTitle: null,
+          releaseNotes: null,
+          includedPrs: [],
+          targetSha: triggerPr.mergeSha,
+          githubReleaseId: null,
+          githubReleaseUrl: null,
+          error: null,
+          completedAt: null,
+        } : {}),
+      });
+      const next = updated ?? existing;
+      if (!isTerminalReleaseStatus(next.status)) {
+        this.scheduleProcessing(next.id);
+      }
+      return next;
+    }
+
+    const created = await this.storage.createReleaseRun({
+      repo,
+      baseBranch,
+      triggerPrNumber: triggerPr.number,
+      triggerPrTitle: triggerPr.title,
+      triggerPrUrl: triggerPr.url,
+      triggerMergeSha: triggerPr.mergeSha,
+      triggerMergedAt: triggerPr.mergedAt,
+      source: "manual",
+      status: "detected",
+      decisionReason: null,
+      recommendedBump: null,
+      proposedVersion: null,
+      releaseTitle: null,
+      releaseNotes: null,
+      includedPrs: [],
+      targetSha: triggerPr.mergeSha,
+      githubReleaseId: null,
+      githubReleaseUrl: null,
+      error: null,
+      completedAt: null,
+    });
+
+    this.scheduleProcessing(created.id);
+    return created;
+  }
+
   async retryReleaseRun(id: string): Promise<ReleaseRun | undefined> {
     const existing = await this.storage.getReleaseRun(id);
     if (!existing) {
@@ -183,7 +267,8 @@ export class ReleaseManager {
         }
 
         const config = await this.storage.getConfig();
-        if (!config.autoCreateReleases) {
+        const isManualRelease = run.source === "manual";
+        if (!isManualRelease && !config.autoCreateReleases) {
           const skipped = await this.storage.updateReleaseRun(id, {
             status: "skipped",
             decisionReason: "Automatic release creation is disabled in settings",
@@ -193,7 +278,7 @@ export class ReleaseManager {
         }
 
         const repoSettings = await this.storage.getRepoSettings(run.repo);
-        if (repoSettings && !repoSettings.autoCreateReleases) {
+        if (!isManualRelease && repoSettings && !repoSettings.autoCreateReleases) {
           const skipped = await this.storage.updateReleaseRun(id, {
             status: "skipped",
             decisionReason: `Automatic release creation is disabled for ${run.repo}`,
@@ -221,11 +306,14 @@ export class ReleaseManager {
           triggerPr,
           includedPulls: includedPulls,
         });
+        const releaseDecision = decision.shouldRelease || !isManualRelease
+          ? decision
+          : createManualReleaseDecision(decision, includedPulls);
 
-        if (!decision.shouldRelease) {
+        if (!releaseDecision.shouldRelease) {
           const skipped = await this.storage.updateReleaseRun(id, {
             status: "skipped",
-            decisionReason: decision.reason,
+            decisionReason: releaseDecision.reason,
             recommendedBump: null,
             proposedVersion: null,
             releaseTitle: null,
@@ -237,17 +325,17 @@ export class ReleaseManager {
           return skipped ?? undefined;
         }
 
-        if (!decision.bump) {
+        if (!releaseDecision.bump) {
           throw new Error("Release evaluation approved publishing but did not provide a semver bump");
         }
 
-        const proposedVersion = this.github.bumpReleaseTag(latestTag, decision.bump);
-        const releaseTitle = normalizeReleaseTitle(decision, proposedVersion);
-        const releaseNotes = decision.notes ?? `Release ${proposedVersion}`;
+        const proposedVersion = this.github.bumpReleaseTag(latestTag, releaseDecision.bump);
+        const releaseTitle = normalizeReleaseTitle(releaseDecision, proposedVersion);
+        const releaseNotes = releaseDecision.notes ?? `Release ${proposedVersion}`;
         await this.storage.updateReleaseRun(id, {
           status: "proposed",
-          decisionReason: decision.reason,
-          recommendedBump: decision.bump,
+          decisionReason: releaseDecision.reason,
+          recommendedBump: releaseDecision.bump,
           proposedVersion,
           releaseTitle,
           releaseNotes,
@@ -404,6 +492,27 @@ function normalizeReleaseTitle(
   }
 
   return title.startsWith(version) ? title : `${version} - ${title}`;
+}
+
+function createManualReleaseDecision(
+  decision: ReleaseEvaluationDecision,
+  includedPulls: ReleaseAgentPullSummary[],
+): ReleaseEvaluationDecision {
+  return {
+    shouldRelease: true,
+    reason: `Manual release requested. Evaluator recommendation: ${decision.reason}`,
+    bump: "patch",
+    title: "Manual release",
+    notes: buildManualReleaseNotes(includedPulls),
+  };
+}
+
+function buildManualReleaseNotes(includedPulls: ReleaseAgentPullSummary[]): string {
+  const changes = includedPulls.length > 0
+    ? includedPulls.map((pull) => `- #${pull.number} ${pull.title} (@${pull.author})`).join("\n")
+    : "- Manual release requested.";
+
+  return `## Changes\n${changes}`;
 }
 
 function summarizeError(error: unknown): string {

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import test from "node:test";
 import express from "express";
+import type { Octokit } from "@octokit/rest";
 import type { AppUpdateStatus, NewPR } from "@shared/schema";
+import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
+import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 import { MemStorage } from "./memoryStorage";
 import type { RouteDependencies } from "./routes";
 import { registerRoutes } from "./routes";
@@ -65,6 +68,52 @@ async function createHarness(storage = new MemStorage(), dependencies: Partial<R
       });
     },
   };
+}
+
+function makeMergedSummary(overrides: Partial<ReleaseAgentPullSummary> = {}): ReleaseAgentPullSummary {
+  return {
+    number: 42,
+    title: "Manual release",
+    url: "https://github.com/acme/widgets/pull/42",
+    author: "alice",
+    repo: "acme/widgets",
+    mergedAt: "2026-04-24T12:00:00.000Z",
+    mergeSha: "manual-release-sha",
+    ...overrides,
+  };
+}
+
+function makeReleaseManagerForRoutes(
+  storage: MemStorage,
+  overrides: Partial<ReleaseGitHubService> = {},
+): ReleaseManager {
+  const github: ReleaseGitHubService = {
+    buildOctokit: async () => ({}) as Octokit,
+    getDefaultBranch: async () => "main",
+    findLatestSemverReleaseTag: async () => "v1.2.3",
+    bumpReleaseTag: () => "v1.2.4",
+    listUnreleasedMergedPulls: async () => [makeMergedSummary()],
+    listMergedPullsForReleaseCandidate: async () => [makeMergedSummary()],
+    findReleaseByTag: async () => null,
+    createGitHubRelease: async (_octokit, _repo, params) => ({
+      id: 123,
+      url: `https://github.com/acme/widgets/releases/tag/${params.tagName}`,
+      tagName: params.tagName,
+      name: params.name,
+    }),
+    ...overrides,
+  };
+
+  return new ReleaseManager(storage, {
+    github,
+    evaluateRelease: async (): Promise<ReleaseEvaluationDecision> => ({
+      shouldRelease: true,
+      reason: "Manual release requested",
+      bump: "patch",
+      title: "Manual release",
+      notes: "Manual release notes",
+    }),
+  });
 }
 
 test("GET/PATCH /api/config masks and persists ordered github tokens", async () => {
@@ -218,6 +267,62 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
     assert.equal(jobs.length, 1);
     assert.equal(jobs[0].targetId, "runtime:1");
     assert.equal(jobs[0].dedupeKey, "sync_watched_repos");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
+  const storage = new MemStorage();
+  const harness = await createHarness(storage, {
+    releaseManager: makeReleaseManagerForRoutes(storage),
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/repos/release`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ repo: "https://github.com/acme/widgets" }),
+    });
+
+    assert.equal(response.status, 201);
+    const body = await response.json() as {
+      repo: string;
+      source?: string;
+      triggerPrNumber: number;
+      triggerMergeSha: string;
+    };
+    assert.equal(body.repo, "acme/widgets");
+    assert.equal(body.source, "manual");
+    assert.equal(body.triggerPrNumber, 42);
+    assert.equal(body.triggerMergeSha, "manual-release-sha");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("POST /api/repos/release returns 409 when the repo has no unreleased merged PRs", async () => {
+  const storage = new MemStorage();
+  const harness = await createHarness(storage, {
+    releaseManager: makeReleaseManagerForRoutes(storage, {
+      listUnreleasedMergedPulls: async () => [],
+    }),
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/repos/release`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ repo: "acme/widgets" }),
+    });
+
+    assert.equal(response.status, 409);
+    const body = await response.json() as { error: string };
+    assert.match(body.error, /No unreleased merged pull requests found for acme\/widgets/);
   } finally {
     await harness.close();
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -175,6 +175,15 @@ export async function registerRoutes(
     }
   });
 
+  app.post("/api/repos/release", async (req, res) => {
+    try {
+      const { repo } = z.object({ repo: z.string().min(1) }).parse(req.body);
+      res.status(201).json(await runtime.createManualRelease(repo));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.get("/api/prs", async (_req, res) => {
     res.json(await runtime.listPRs("active"));
   });

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -314,6 +314,7 @@ type ReleaseRunRow = {
   trigger_pr_url: string;
   trigger_merge_sha: string;
   trigger_merged_at: string;
+  source: ReleaseRun["source"] | null;
   status: ReleaseRunStatus;
   decision_reason: string | null;
   recommended_bump: "patch" | "minor" | "major" | null;
@@ -717,6 +718,7 @@ export class SqliteStorage implements IStorage {
         trigger_pr_url TEXT NOT NULL,
         trigger_merge_sha TEXT NOT NULL,
         trigger_merged_at TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'automatic',
         status TEXT NOT NULL,
         decision_reason TEXT,
         recommended_bump TEXT,
@@ -800,6 +802,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "deployment_check_poll_interval_ms", "INTEGER NOT NULL DEFAULT 15000");
     this.ensureColumn("watched_repos", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("watched_repos", "own_prs_only", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
 
@@ -2410,6 +2413,7 @@ export class SqliteStorage implements IStorage {
       triggerPrUrl: row.trigger_pr_url,
       triggerMergeSha: row.trigger_merge_sha,
       triggerMergedAt: row.trigger_merged_at,
+      source: row.source === "manual" ? "manual" : "automatic",
       status: row.status,
       decisionReason: row.decision_reason,
       recommendedBump: row.recommended_bump,
@@ -2430,7 +2434,7 @@ export class SqliteStorage implements IStorage {
   async getReleaseRun(id: string): Promise<ReleaseRun | undefined> {
     const row = this.get<ReleaseRunRow>(`
       SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
-             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             trigger_merge_sha, trigger_merged_at, source, status, decision_reason, recommended_bump,
              proposed_version, release_title, release_notes, included_prs_json, target_sha,
              github_release_id, github_release_url, error, created_at, updated_at, completed_at
       FROM release_runs
@@ -2442,7 +2446,7 @@ export class SqliteStorage implements IStorage {
   async getReleaseRunByRepoAndMergeSha(repo: string, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
     const row = this.get<ReleaseRunRow>(`
       SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
-             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             trigger_merge_sha, trigger_merged_at, source, status, decision_reason, recommended_bump,
              proposed_version, release_title, release_notes, included_prs_json, target_sha,
              github_release_id, github_release_url, error, created_at, updated_at, completed_at
       FROM release_runs
@@ -2456,7 +2460,7 @@ export class SqliteStorage implements IStorage {
   async getReleaseRunByTrigger(repo: string, triggerPrNumber: number, triggerMergeSha: string): Promise<ReleaseRun | undefined> {
     const row = this.get<ReleaseRunRow>(`
       SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
-             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             trigger_merge_sha, trigger_merged_at, source, status, decision_reason, recommended_bump,
              proposed_version, release_title, release_notes, included_prs_json, target_sha,
              github_release_id, github_release_url, error, created_at, updated_at, completed_at
       FROM release_runs
@@ -2484,7 +2488,7 @@ export class SqliteStorage implements IStorage {
     const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
     const rows = this.all<ReleaseRunRow>(`
       SELECT id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
-             trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+             trigger_merge_sha, trigger_merged_at, source, status, decision_reason, recommended_bump,
              proposed_version, release_title, release_notes, included_prs_json, target_sha,
              github_release_id, github_release_url, error, created_at, updated_at, completed_at
       FROM release_runs
@@ -2500,10 +2504,10 @@ export class SqliteStorage implements IStorage {
     this.run(`
       INSERT INTO release_runs (
         id, repo, base_branch, trigger_pr_number, trigger_pr_title, trigger_pr_url,
-        trigger_merge_sha, trigger_merged_at, status, decision_reason, recommended_bump,
+        trigger_merge_sha, trigger_merged_at, source, status, decision_reason, recommended_bump,
         proposed_version, release_title, release_notes, included_prs_json, target_sha,
         github_release_id, github_release_url, error, created_at, updated_at, completed_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       entry.id,
       entry.repo,
@@ -2513,6 +2517,7 @@ export class SqliteStorage implements IStorage {
       entry.triggerPrUrl,
       entry.triggerMergeSha,
       entry.triggerMergedAt,
+      entry.source ?? "automatic",
       entry.status,
       entry.decisionReason,
       entry.recommendedBump,
@@ -2539,7 +2544,7 @@ export class SqliteStorage implements IStorage {
     this.run(`
       UPDATE release_runs
       SET repo = ?, base_branch = ?, trigger_pr_number = ?, trigger_pr_title = ?, trigger_pr_url = ?,
-          trigger_merge_sha = ?, trigger_merged_at = ?, status = ?, decision_reason = ?,
+          trigger_merge_sha = ?, trigger_merged_at = ?, source = ?, status = ?, decision_reason = ?,
           recommended_bump = ?, proposed_version = ?, release_title = ?, release_notes = ?,
           included_prs_json = ?, target_sha = ?, github_release_id = ?, github_release_url = ?,
           error = ?, created_at = ?, updated_at = ?, completed_at = ?
@@ -2552,6 +2557,7 @@ export class SqliteStorage implements IStorage {
       next.triggerPrUrl,
       next.triggerMergeSha,
       next.triggerMergedAt,
+      next.source ?? "automatic",
       next.status,
       next.decisionReason,
       next.recommendedBump,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -621,6 +621,7 @@ test("SqliteStorage release run lookup is idempotent and list is newest-first", 
     triggerPrUrl: "https://github.com/owner/repo/pull/2",
     triggerMergeSha: "merge-sha-2",
     triggerMergedAt: "2026-03-28T10:01:00.000Z",
+    source: "manual",
     status: "published",
     decisionReason: "Ship it",
     recommendedBump: "minor",
@@ -637,6 +638,7 @@ test("SqliteStorage release run lookup is idempotent and list is newest-first", 
 
   const byRepoAndSha = await storage.getReleaseRunByRepoAndMergeSha("owner/repo", "merge-sha-1");
   assert.equal(byRepoAndSha?.id, older.id);
+  assert.equal(byRepoAndSha?.source, "automatic");
 
   const byTrigger = await storage.getReleaseRunByTrigger("owner/repo", 1, "merge-sha-1");
   assert.equal(byTrigger?.id, older.id);
@@ -644,6 +646,7 @@ test("SqliteStorage release run lookup is idempotent and list is newest-first", 
   const runs = await storage.listReleaseRuns();
   assert.equal(runs.length, 2);
   assert.equal(runs[0]?.triggerPrNumber, 2);
+  assert.equal(runs[0]?.source, "manual");
   assert.equal(runs[1]?.triggerPrNumber, 1);
   storage.close();
 });

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -216,6 +216,7 @@ export function createReleaseRun(
   const now = new Date().toISOString();
   return releaseRunSchema.parse({
     ...data,
+    source: data.source ?? "automatic",
     id: randomUUID(),
     createdAt: now,
     updatedAt: now,
@@ -229,6 +230,7 @@ export function applyReleaseRunUpdate(
   return releaseRunSchema.parse({
     ...existing,
     ...updates,
+    source: updates.source ?? existing.source ?? "automatic",
     // Immutable fields
     id: existing.id,
     createdAt: existing.createdAt,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -318,6 +318,9 @@ export const releaseRunStatusEnum = z.enum([
 ]);
 export type ReleaseRunStatus = z.infer<typeof releaseRunStatusEnum>;
 
+export const releaseRunSourceEnum = z.enum(["automatic", "manual"]);
+export type ReleaseRunSource = z.infer<typeof releaseRunSourceEnum>;
+
 export const releaseBumpEnum = z.enum(["patch", "minor", "major"]);
 export type ReleaseBump = z.infer<typeof releaseBumpEnum>;
 
@@ -340,6 +343,7 @@ export const releaseRunSchema = z.object({
   triggerPrUrl: z.string(),
   triggerMergeSha: z.string(),
   triggerMergedAt: z.string(),
+  source: releaseRunSourceEnum.optional(),
   status: releaseRunStatusEnum,
   decisionReason: z.string().nullable(),
   recommendedBump: releaseBumpEnum.nullable(),


### PR DESCRIPTION
## Summary
- Add a repo-level manual release trigger endpoint that creates a manual ReleaseRun from the latest unreleased merged PR.
- Mark release runs with a source so manual releases bypass auto-release settings while preserving existing release history and processing.
- Add a compact Release button to each tracked repo card in the dashboard.

## Verification
- node --import tsx --test server/releaseManager.test.ts server/routes.test.ts
- node --import tsx --test server/storage.test.ts server/releaseManager.test.ts server/routes.test.ts
- npm run check
- npm run test
- npm run build
- node --import tsx --test --test-concurrency=1 server/*.test.ts client/src/lib/*.test.ts
- git diff --check
- Branding search for Code Factory/codefactory terms in changed UI/operator-facing files
- Dev server smoke: http://127.0.0.1:5002/ responded with the dashboard shell

## Notes
- npm run test:all was run twice and failed only in server/routes.test.ts with listen EPERM on 127.0.0.1 under concurrent Node test execution in this sandbox. The same full test set passed with --test-concurrency=1, and npm run test passed.
- Required /simplify pre-commit pass could not run because the local Claude CLI returned a 401 authentication error.