### PR TITLE
Add activity queue menu beside settings

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,11 +2,17 @@ import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
+import { Activity as ActivityIcon } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
-import type { Config, FeedbackItem, HealingSession, LogEntry, PR, PRQuestion, ReleaseRun, WatchedRepo } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, LogEntry, PR, PRQuestion, ReleaseRun, WatchedRepo } from "@shared/schema";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -62,6 +68,12 @@ const WATCH_SCOPE_OPTIONS = [
   { value: "mine", label: "My PRs only" },
   { value: "team", label: "My PRs + teammates" },
 ] as const;
+
+const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
+  inProgress: [],
+  queued: [],
+  generatedAt: "",
+};
 
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
 type RepoSettings = WatchedRepo & {
@@ -161,6 +173,109 @@ function WatchScopeControl({
         );
       })}
     </div>
+  );
+}
+
+function ActivityRow({ activity }: { activity: ActivityItem }) {
+  const timeLabel = activity.status === "in_progress"
+    ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
+    : formatClock(activity.availableAt) ?? formatClock(activity.queuedAt);
+  const content = (
+    <div className="flex min-w-0 items-start gap-2 px-2 py-1.5 text-left">
+      <span
+        className={`mt-1.5 h-1.5 w-1.5 shrink-0 ${
+          activity.status === "in_progress" ? "animate-pulse bg-foreground" : "bg-muted-foreground"
+        }`}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
+        {activity.detail && (
+          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
+        )}
+      </span>
+      {timeLabel && (
+        <span className="shrink-0 text-[10px] leading-4 text-muted-foreground">{timeLabel}</span>
+      )}
+    </div>
+  );
+
+  if (activity.targetUrl) {
+    return (
+      <a
+        href={activity.targetUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="block outline-none hover:bg-muted focus:bg-muted"
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <div>{content}</div>;
+}
+
+function ActivitySection({
+  title,
+  items,
+  emptyLabel,
+}: {
+  title: string;
+  items: ActivityItem[];
+  emptyLabel: string;
+}) {
+  return (
+    <div className="py-1">
+      <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">{title}</div>
+      {items.length > 0 ? (
+        <div className="max-h-52 overflow-y-auto">
+          {items.map((activity) => (
+            <ActivityRow key={activity.id} activity={activity} />
+          ))}
+        </div>
+      ) : (
+        <div className="px-2 pb-2 text-[11px] text-muted-foreground">{emptyLabel}</div>
+      )}
+    </div>
+  );
+}
+
+function ActivityMenu({ activities }: { activities: ActivitySnapshot }) {
+  const inProgressCount = activities.inProgress.length;
+  const queuedCount = activities.queued.length;
+  const totalCount = inProgressCount + queuedCount;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="inline-flex items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus:outline-none"
+        aria-label="Open activity menu"
+        data-testid="activity-menu-trigger"
+      >
+        <ActivityIcon className="h-3 w-3" aria-hidden="true" />
+        <span>activity</span>
+        <span className="text-foreground">{totalCount}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        <div className="border-b border-border px-2 py-2">
+          <div className="text-[12px] font-medium">Activities</div>
+          <div className="text-[11px] text-muted-foreground">
+            {inProgressCount} in progress / {queuedCount} queued
+          </div>
+        </div>
+        <ActivitySection
+          title="In progress"
+          items={activities.inProgress}
+          emptyLabel="No activities running right now."
+        />
+        <div className="border-t border-border" />
+        <ActivitySection
+          title="Queued"
+          items={activities.queued}
+          emptyLabel="Queue is empty."
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -335,6 +450,7 @@ function FeedbackRow({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
       queryClient.invalidateQueries({ queryKey: ["/api/prs", prId] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
     },
     onError: (error) => {
@@ -624,6 +740,7 @@ function QAPanel({ prId }: { prId: string }) {
       apiRequest("POST", `/api/prs/${prId}/questions`, { question }).then((res) => res.json()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs", prId, "questions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       setInput("");
     },
   });
@@ -767,6 +884,11 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
+  const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activities"],
+    refetchInterval: 3000,
+  });
+
   const { data: repos = [] } = useQuery<RepoSettings[]>({
     queryKey: ["/api/repos/settings"],
     refetchInterval: 5000,
@@ -798,6 +920,7 @@ export default function Dashboard() {
     },
     onSuccess: (data: PR) => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
       queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
       setAddUrl("");
@@ -815,6 +938,7 @@ export default function Dashboard() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
     },
     onError: (error) => {
@@ -858,6 +982,7 @@ export default function Dashboard() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
       queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
     },
@@ -873,6 +998,7 @@ export default function Dashboard() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/releases"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       toast({ description: "Release queued." });
     },
     onError: (error) => {
@@ -1010,6 +1136,7 @@ export default function Dashboard() {
           >
             settings
           </Link>
+          <ActivityMenu activities={activities} />
         </div>
       </header>
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -204,7 +204,7 @@ function ActivityRow({ activity }: { activity: ActivityItem }) {
       <a
         href={activity.targetUrl}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         className="block outline-none hover:bg-muted focus:bg-muted"
       >
         {content}

--- a/server/activityPayload.ts
+++ b/server/activityPayload.ts
@@ -1,0 +1,29 @@
+export type ActivityPayloadDescription = {
+  label: string;
+  detail: string | null;
+  targetUrl: string | null;
+};
+
+export function buildActivityPayload(description: ActivityPayloadDescription): Record<string, unknown> {
+  return {
+    activityLabel: description.label,
+    activityDetail: description.detail,
+    activityTargetUrl: description.targetUrl,
+  };
+}
+
+export function readActivityPayload(payload: Record<string, unknown>): ActivityPayloadDescription | null {
+  const label = payload.activityLabel;
+  if (typeof label !== "string" || !label.trim()) {
+    return null;
+  }
+
+  const detail = payload.activityDetail;
+  const targetUrl = payload.activityTargetUrl;
+
+  return {
+    label,
+    detail: typeof detail === "string" ? detail : null,
+    targetUrl: typeof targetUrl === "string" ? targetUrl : null,
+  };
+}

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -69,6 +69,9 @@ test("runtime queueBabysit enqueues a babysit job using the configured agent", a
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0]?.targetId, pr.id);
   assert.equal(jobs[0]?.payload.preferredAgent, "claude");
+  assert.equal(jobs[0]?.payload.activityLabel, "Babysitting PR #42");
+  assert.equal(jobs[0]?.payload.activityDetail, "acme/widgets - feat: add widget");
+  assert.equal(jobs[0]?.payload.activityTargetUrl, pr.url);
 });
 
 test("runtime setWatchEnabled updates the PR and emits a change event", async () => {
@@ -120,6 +123,9 @@ test("runtime askQuestion persists the question and enqueues a durable job", asy
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0]?.targetId, question.id);
   assert.equal(jobs[0]?.payload.prId, pr.id);
+  assert.equal(jobs[0]?.payload.activityLabel, "Answering question for PR #42");
+  assert.equal(jobs[0]?.payload.activityDetail, "acme/widgets - feat: add widget");
+  assert.equal(jobs[0]?.payload.activityTargetUrl, pr.url);
 });
 
 test("runtime updateConfig persists updates and exposes them through getConfig", async () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -24,6 +24,7 @@ import { applyManualFeedbackDecision } from "./manualFeedback";
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
+import { buildActivityPayload, readActivityPayload } from "./activityPayload";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
 import { ReleaseManager } from "./releaseManager";
 import type { ReleaseAgentPullSummary } from "./releaseAgent";
@@ -150,6 +151,20 @@ function fallbackJobLabel(job: BackgroundJob): string {
     case "heal_deployment":
       return "Healing deployment";
   }
+}
+
+type ActivityDescription = Pick<ActivityItem, "label" | "detail" | "targetUrl">;
+
+type ActivityDescriptionContext = {
+  prsById: Map<string, PR>;
+  releaseRunsById: Map<string, ReleaseRun>;
+  socialChangelogsById: Map<string, SocialChangelog>;
+  deploymentHealingSessionsByTarget: Map<string, DeploymentHealingSession>;
+};
+
+function readJobStringPayload(job: BackgroundJob, key: string): string | null {
+  const value = job.payload[key];
+  return typeof value === "string" && value.trim() ? value : null;
 }
 
 export function mapMergedPullsToReleaseSummaries(pulls: MergedPRSummary[]): ReleaseAgentPullSummary[] {
@@ -293,7 +308,61 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     };
   };
 
-  const describeActivityJob = async (job: BackgroundJob): Promise<Pick<ActivityItem, "label" | "detail" | "targetUrl">> => {
+  const buildActivityDescriptionContext = async (jobs: BackgroundJob[]): Promise<ActivityDescriptionContext> => {
+    const prIds = new Set<string>();
+    const releaseRunIds = new Set<string>();
+    const socialChangelogIds = new Set<string>();
+    const deploymentHealingTargets = new Set<string>();
+
+    for (const job of jobs) {
+      if (readActivityPayload(job.payload)) {
+        continue;
+      }
+
+      if (job.kind === "babysit_pr") {
+        prIds.add(job.targetId);
+      } else if (job.kind === "answer_pr_question") {
+        const prId = readJobStringPayload(job, "prId");
+        if (prId) {
+          prIds.add(prId);
+        }
+      } else if (job.kind === "process_release_run") {
+        releaseRunIds.add(job.targetId);
+      } else if (job.kind === "generate_social_changelog") {
+        socialChangelogIds.add(job.targetId);
+      } else if (job.kind === "heal_deployment") {
+        deploymentHealingTargets.add(job.targetId);
+      }
+    }
+
+    const [activePrs, archivedPrs, releaseRuns, socialChangelogs, deploymentHealingSessions] = await Promise.all([
+      prIds.size > 0 ? storage.getPRs() : Promise.resolve([]),
+      prIds.size > 0 ? storage.getArchivedPRs() : Promise.resolve([]),
+      releaseRunIds.size > 0 ? storage.listReleaseRuns() : Promise.resolve([]),
+      socialChangelogIds.size > 0 ? storage.getSocialChangelogs() : Promise.resolve([]),
+      deploymentHealingTargets.size > 0 ? storage.listDeploymentHealingSessions() : Promise.resolve([]),
+    ]);
+
+    const deploymentHealingSessionsByTarget = new Map<string, DeploymentHealingSession>();
+    for (const session of deploymentHealingSessions) {
+      deploymentHealingSessionsByTarget.set(session.id, session);
+      deploymentHealingSessionsByTarget.set(`${session.repo}:${session.mergeSha}`, session);
+    }
+
+    return {
+      prsById: new Map([...activePrs, ...archivedPrs].map((pr) => [pr.id, pr])),
+      releaseRunsById: new Map(releaseRuns.map((run) => [run.id, run])),
+      socialChangelogsById: new Map(socialChangelogs.map((changelog) => [changelog.id, changelog])),
+      deploymentHealingSessionsByTarget,
+    };
+  };
+
+  const describeActivityJob = (job: BackgroundJob, context: ActivityDescriptionContext): ActivityDescription => {
+    const payloadDescription = readActivityPayload(job.payload);
+    if (payloadDescription) {
+      return payloadDescription;
+    }
+
     if (job.kind === "sync_watched_repos") {
       return {
         label: "Sync watched repositories",
@@ -303,7 +372,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "babysit_pr") {
-      const pr = await storage.getPR(job.targetId);
+      const pr = context.prsById.get(job.targetId);
       if (pr) {
         return {
           label: `Babysitting PR #${pr.number}`,
@@ -314,8 +383,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "answer_pr_question") {
-      const prId = typeof job.payload.prId === "string" ? job.payload.prId : null;
-      const pr = prId ? await storage.getPR(prId) : undefined;
+      const prId = readJobStringPayload(job, "prId");
+      const pr = prId ? context.prsById.get(prId) : undefined;
       if (pr) {
         return {
           label: `Answering question for PR #${pr.number}`,
@@ -326,7 +395,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "process_release_run") {
-      const run = await storage.getReleaseRun(job.targetId);
+      const run = context.releaseRunsById.get(job.targetId);
       if (run) {
         return {
           label: `Processing release for ${run.repo}`,
@@ -337,7 +406,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "generate_social_changelog") {
-      const changelog = await storage.getSocialChangelog(job.targetId);
+      const changelog = context.socialChangelogsById.get(job.targetId);
       if (changelog) {
         return {
           label: "Generating social changelog",
@@ -348,7 +417,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "heal_deployment") {
-      const session = await storage.getDeploymentHealingSession(job.targetId);
+      const session = context.deploymentHealingSessionsByTarget.get(job.targetId);
       if (session) {
         return {
           label: `Healing ${session.platform} deployment`,
@@ -365,8 +434,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     };
   };
 
-  const mapActivityJob = async (job: BackgroundJob): Promise<ActivityItem> => {
-    const description = await describeActivityJob(job);
+  const mapActivityJob = (job: BackgroundJob, context: ActivityDescriptionContext): ActivityItem => {
+    const description = describeActivityJob(job, context);
     return {
       id: job.id,
       kind: job.kind,
@@ -412,12 +481,19 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }, interval);
   };
 
-  const queueBabysitWithAgent = async (prId: string, preferredAgent: Config["codingAgent"]) => {
+  const queueBabysitWithAgent = async (pr: PR, preferredAgent: Config["codingAgent"]) => {
     await scheduleBackgroundJob(
       "babysit_pr",
-      prId,
-      buildBackgroundJobDedupeKey("babysit_pr", prId),
-      { preferredAgent },
+      pr.id,
+      buildBackgroundJobDedupeKey("babysit_pr", pr.id),
+      {
+        preferredAgent,
+        ...buildActivityPayload({
+          label: `Babysitting PR #${pr.number}`,
+          detail: `${pr.repo} - ${pr.title}`,
+          targetUrl: pr.url,
+        }),
+      },
     );
   };
 
@@ -464,10 +540,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         storage.listBackgroundJobs({ status: "queued" }),
       ]);
 
-      const [inProgress, queued] = await Promise.all([
-        Promise.all(leasedJobs.map(mapActivityJob)),
-        Promise.all(queuedJobs.map(mapActivityJob)),
-      ]);
+      const descriptionContext = await buildActivityDescriptionContext([...leasedJobs, ...queuedJobs]);
+      const inProgress = leasedJobs.map((job) => mapActivityJob(job, descriptionContext));
+      const queued = queuedJobs.map((job) => mapActivityJob(job, descriptionContext));
 
       return {
         inProgress,
@@ -654,7 +729,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         });
       }
 
-      await queueBabysitWithAgent(pr.id, config.codingAgent);
+      await queueBabysitWithAgent(pr, config.codingAgent);
       notifyChange();
       return pr;
     },
@@ -763,7 +838,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const config = await storage.getConfig();
       await storage.updatePR(pr.id, { status: "processing" });
       await storage.addLog(pr.id, "info", `Launching autonomous babysitter run using ${config.codingAgent}`);
-      await queueBabysitWithAgent(pr.id, config.codingAgent);
+      await queueBabysitWithAgent(pr, config.codingAgent);
 
       const updated = await storage.getPR(pr.id);
       notifyChange();
@@ -779,7 +854,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
       const config = await storage.getConfig();
       await storage.addLog(pr.id, "info", `Manual babysitter trigger using ${config.codingAgent}`);
-      await queueBabysitWithAgent(pr.id, config.codingAgent);
+      await queueBabysitWithAgent(pr, config.codingAgent);
 
       const updated = await storage.getPR(pr.id);
       notifyChange();
@@ -818,7 +893,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
       await storage.addLog(prId, "info", `Feedback item ${feedbackId} queued for retry`);
       const config = await storage.getConfig();
-      await queueBabysitWithAgent(prId, config.codingAgent);
+      await queueBabysitWithAgent(result.updated, config.codingAgent);
       notifyChange();
       return result.updated;
     },
@@ -829,7 +904,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async askQuestion(prId, question) {
-      assertFound(await storage.getPR(prId), "PR not found");
+      const pr = assertFound(await storage.getPR(prId), "PR not found");
       let parsed: { question: string };
       try {
         parsed = askQuestionSchema.parse({ question });
@@ -846,7 +921,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           "answer_pr_question",
           entry.id,
           buildBackgroundJobDedupeKey("answer_pr_question", entry.id),
-          { prId },
+          {
+            prId,
+            ...buildActivityPayload({
+              label: `Answering question for PR #${pr.number}`,
+              detail: `${pr.repo} - ${pr.title}`,
+              targetUrl: pr.url,
+            }),
+          },
         );
       } catch (error) {
         const message = getErrorMessage(error);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
 import type {
+  ActivityItem,
+  ActivitySnapshot,
+  BackgroundJob,
   Config,
   DeploymentHealingSession,
   HealingSession,
@@ -82,6 +85,7 @@ export type AppRuntime = {
   subscribe(listener: () => void): () => void;
   getRuntimeSnapshot(): Promise<RuntimeSnapshot>;
   setDrainMode(input: DrainModeParams): Promise<RuntimeSnapshot & { drained?: boolean }>;
+  listActivities(): Promise<ActivitySnapshot>;
   listRepos(): Promise<string[]>;
   listRepoSettings(): Promise<WatchedRepo[]>;
   addRepo(repoInput: string): Promise<{ repo: string }>;
@@ -129,6 +133,23 @@ function assertFound<T>(value: T | undefined, message: string): T {
   }
 
   return value;
+}
+
+function fallbackJobLabel(job: BackgroundJob): string {
+  switch (job.kind) {
+    case "sync_watched_repos":
+      return "Sync watched repositories";
+    case "babysit_pr":
+      return "Babysitting PR";
+    case "process_release_run":
+      return "Processing release";
+    case "answer_pr_question":
+      return "Answering PR question";
+    case "generate_social_changelog":
+      return "Generating social changelog";
+    case "heal_deployment":
+      return "Healing deployment";
+  }
 }
 
 export function mapMergedPullsToReleaseSummaries(pulls: MergedPRSummary[]): ReleaseAgentPullSummary[] {
@@ -272,6 +293,96 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     };
   };
 
+  const describeActivityJob = async (job: BackgroundJob): Promise<Pick<ActivityItem, "label" | "detail" | "targetUrl">> => {
+    if (job.kind === "sync_watched_repos") {
+      return {
+        label: "Sync watched repositories",
+        detail: null,
+        targetUrl: null,
+      };
+    }
+
+    if (job.kind === "babysit_pr") {
+      const pr = await storage.getPR(job.targetId);
+      if (pr) {
+        return {
+          label: `Babysitting PR #${pr.number}`,
+          detail: `${pr.repo} - ${pr.title}`,
+          targetUrl: pr.url,
+        };
+      }
+    }
+
+    if (job.kind === "answer_pr_question") {
+      const prId = typeof job.payload.prId === "string" ? job.payload.prId : null;
+      const pr = prId ? await storage.getPR(prId) : undefined;
+      if (pr) {
+        return {
+          label: `Answering question for PR #${pr.number}`,
+          detail: `${pr.repo} - ${pr.title}`,
+          targetUrl: pr.url,
+        };
+      }
+    }
+
+    if (job.kind === "process_release_run") {
+      const run = await storage.getReleaseRun(job.targetId);
+      if (run) {
+        return {
+          label: `Processing release for ${run.repo}`,
+          detail: `PR #${run.triggerPrNumber} - ${run.triggerPrTitle}`,
+          targetUrl: run.triggerPrUrl,
+        };
+      }
+    }
+
+    if (job.kind === "generate_social_changelog") {
+      const changelog = await storage.getSocialChangelog(job.targetId);
+      if (changelog) {
+        return {
+          label: "Generating social changelog",
+          detail: `${changelog.date} - ${changelog.triggerCount} merged PRs`,
+          targetUrl: null,
+        };
+      }
+    }
+
+    if (job.kind === "heal_deployment") {
+      const session = await storage.getDeploymentHealingSession(job.targetId);
+      if (session) {
+        return {
+          label: `Healing ${session.platform} deployment`,
+          detail: `${session.repo} PR #${session.triggerPrNumber} - ${session.triggerPrTitle}`,
+          targetUrl: session.triggerPrUrl,
+        };
+      }
+    }
+
+    return {
+      label: fallbackJobLabel(job),
+      detail: job.targetId,
+      targetUrl: null,
+    };
+  };
+
+  const mapActivityJob = async (job: BackgroundJob): Promise<ActivityItem> => {
+    const description = await describeActivityJob(job);
+    return {
+      id: job.id,
+      kind: job.kind,
+      status: job.status === "leased" ? "in_progress" : "queued",
+      label: description.label,
+      detail: description.detail,
+      targetId: job.targetId,
+      targetUrl: description.targetUrl,
+      queuedAt: job.createdAt,
+      availableAt: job.availableAt,
+      startedAt: job.heartbeatAt,
+      updatedAt: job.updatedAt,
+      attemptCount: job.attemptCount,
+    };
+  };
+
   const waitForBackgroundIdle = async (timeoutMs: number): Promise<boolean> => {
     const [dispatcherIdle, babysitterIdle, releaseIdle] = await Promise.all([
       backgroundJobDispatcher.waitForIdle(timeoutMs),
@@ -346,6 +457,24 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     getRuntimeSnapshot,
+
+    async listActivities() {
+      const [leasedJobs, queuedJobs] = await Promise.all([
+        storage.listBackgroundJobs({ status: "leased" }),
+        storage.listBackgroundJobs({ status: "queued" }),
+      ]);
+
+      const [inProgress, queued] = await Promise.all([
+        Promise.all(leasedJobs.map(mapActivityJob)),
+        Promise.all(queuedJobs.map(mapActivityJob)),
+      ]);
+
+      return {
+        inProgress,
+        queued,
+        generatedAt: new Date().toISOString(),
+      };
+    },
 
     async setDrainMode(input) {
       const updated = await storage.updateRuntimeState({

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -458,6 +458,9 @@ test("syncAndBabysitTrackedRepos enqueues social changelog generation as a backg
   });
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0].status, "queued");
+  assert.equal(jobs[0].payload.activityLabel, "Generating social changelog");
+  assert.equal(jobs[0].payload.activityDetail, `${changelogs[0].date} - 5 merged PRs`);
+  assert.equal(jobs[0].payload.activityTargetUrl, null);
 });
 
 test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background scheduler is provided", async () => {
@@ -517,6 +520,9 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
   });
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0].payload.preferredAgent, "claude");
+  assert.equal(jobs[0].payload.activityLabel, "Babysitting PR #42");
+  assert.equal(jobs[0].payload.activityDetail, "octo/example - Example PR");
+  assert.equal(jobs[0].payload.activityTargetUrl, pr.url);
 });
 
 test("syncAndBabysitTrackedRepos repairs missing review-thread metadata on archived PRs", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -44,6 +44,7 @@ import { generateSocialChangelog } from "./socialChangelogAgent";
 import { getCodeFactoryPaths } from "./paths";
 import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
+import { buildActivityPayload } from "./activityPayload";
 import type { DeploymentHealingManager } from "./deploymentHealingManager";
 import { detectDeploymentPlatform } from "./deploymentPlatformDetector";
 import {
@@ -1316,6 +1317,11 @@ export class PRBabysitter {
                       repo: repoSlug, platform: detected.platform, mergeSha: depMergeSha,
                       triggerPrNumber: pr.number, triggerPrTitle: pr.title,
                       triggerPrUrl: pr.url, baseBranch: depBaseBranch,
+                      ...buildActivityPayload({
+                        label: `Healing ${detected.platform} deployment`,
+                        detail: `${repoSlug} PR #${pr.number} - ${pr.title}`,
+                        targetUrl: pr.url,
+                      }),
                     },
                   );
                   await this.storage.addLog(pr.id, "info",
@@ -1383,7 +1389,14 @@ export class PRBabysitter {
             "babysit_pr",
             local.id,
             buildBackgroundJobDedupeKey("babysit_pr", local.id),
-            { preferredAgent: config.codingAgent as CodingAgent },
+            {
+              preferredAgent: config.codingAgent as CodingAgent,
+              ...buildActivityPayload({
+                label: `Babysitting PR #${local.number}`,
+                detail: `${local.repo} - ${local.title}`,
+                targetUrl: local.url,
+              }),
+            },
           );
         } else {
           await this.babysitPR(local.id, config.codingAgent as CodingAgent);
@@ -1462,6 +1475,11 @@ export class PRBabysitter {
           "generate_social_changelog",
           changelog.id,
           buildBackgroundJobDedupeKey("generate_social_changelog", changelog.id),
+          buildActivityPayload({
+            label: "Generating social changelog",
+            detail: `${changelog.date} - ${changelog.triggerCount} merged PRs`,
+            targetUrl: null,
+          }),
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -299,6 +299,9 @@ test("ReleaseManager enqueues a durable release job and still executes the relea
   assert.equal(queuedJobs.length, 1);
   assert.equal(queuedJobs[0].targetId, created.id);
   assert.equal(queuedJobs[0].dedupeKey, buildBackgroundJobDedupeKey("process_release_run", created.id));
+  assert.equal(queuedJobs[0].payload.activityLabel, "Processing release for yungookim/oh-my-pr");
+  assert.equal(queuedJobs[0].payload.activityDetail, "PR #71 - Release automation");
+  assert.equal(queuedJobs[0].payload.activityTargetUrl, "https://github.com/yungookim/oh-my-pr/pull/71");
   assert.equal(await manager.waitForIdle(), true);
 
   const processed = await manager.processReleaseRun(created.id);

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -4,6 +4,7 @@ import type { CodingAgent } from "./agentRunner";
 import { parseRepoSlug } from "./github";
 import type { IStorage } from "./storage";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
+import { buildActivityPayload } from "./activityPayload";
 import {
   evaluateReleaseWorthinessWithAgent,
   type ReleaseAgentPullSummary,
@@ -112,7 +113,7 @@ export class ReleaseManager {
     );
     if (existing) {
       if (!isTerminalReleaseStatus(existing.status)) {
-        this.scheduleProcessing(existing.id);
+        this.scheduleProcessing(existing);
       }
       return existing;
     }
@@ -139,7 +140,7 @@ export class ReleaseManager {
       completedAt: null,
     });
 
-    this.scheduleProcessing(created.id);
+    this.scheduleProcessing(created);
     return created;
   }
 
@@ -187,7 +188,7 @@ export class ReleaseManager {
       });
       const next = updated ?? existing;
       if (!isTerminalReleaseStatus(next.status)) {
-        this.scheduleProcessing(next.id);
+        this.scheduleProcessing(next);
       }
       return next;
     }
@@ -215,7 +216,7 @@ export class ReleaseManager {
       completedAt: null,
     });
 
-    this.scheduleProcessing(created.id);
+    this.scheduleProcessing(created);
     return created;
   }
 
@@ -235,7 +236,7 @@ export class ReleaseManager {
       return undefined;
     }
 
-    this.scheduleProcessing(id);
+    this.scheduleProcessing(reset);
     return reset;
   }
 
@@ -442,13 +443,21 @@ export class ReleaseManager {
     }
   }
 
-  private scheduleProcessing(id: string): void {
+  private scheduleProcessing(run: ReleaseRun): void {
+    const id = run.id;
     if (this.scheduleBackgroundJob) {
       this.scheduleBackgroundJob(
         "process_release_run",
         id,
         buildBackgroundJobDedupeKey("process_release_run", id),
-        { releaseRunId: id },
+        {
+          releaseRunId: id,
+          ...buildActivityPayload({
+            label: `Processing release for ${run.repo}`,
+            detail: `PR #${run.triggerPrNumber} - ${run.triggerPrTitle}`,
+            targetUrl: run.triggerPrUrl,
+          }),
+        },
       ).catch((error) => {
         console.error(`Failed to schedule release run ${id}:`, error);
       });

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -345,6 +345,63 @@ test("GET /api/activities lists in-progress and queued jobs", async () => {
   }
 });
 
+test("GET /api/activities batches PR activity metadata", async () => {
+  const harness = await createHarness();
+  const firstPr = await seedPR(harness.storage, {
+    title: "fix activity menu",
+    repo: "acme/widgets",
+    number: 77,
+    url: "https://github.com/acme/widgets/pull/77",
+  });
+  const secondPr = await seedPR(harness.storage, {
+    title: "answer follow-up",
+    repo: "acme/widgets",
+    number: 78,
+    url: "https://github.com/acme/widgets/pull/78",
+  });
+
+  try {
+    await harness.storage.enqueueBackgroundJob({
+      kind: "babysit_pr",
+      targetId: firstPr.id,
+      dedupeKey: `babysit_pr:${firstPr.id}`,
+      payload: { preferredAgent: "claude" },
+    });
+    await harness.storage.enqueueBackgroundJob({
+      kind: "answer_pr_question",
+      targetId: "question-1",
+      dedupeKey: "answer_pr_question:question-1",
+      payload: { prId: secondPr.id },
+    });
+
+    const getPR = harness.storage.getPR.bind(harness.storage);
+    harness.storage.getPR = async (id: string) => {
+      throw new Error(`unexpected per-job PR lookup for ${id}`);
+    };
+
+    const response = await fetch(`${harness.baseUrl}/api/activities`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      queued: Array<{
+        label: string;
+        detail: string | null;
+        targetUrl: string | null;
+      }>;
+    };
+
+    assert.deepEqual(
+      body.queued.map((item) => [item.label, item.detail, item.targetUrl]),
+      [
+        ["Babysitting PR #77", "acme/widgets - fix activity menu", firstPr.url],
+        ["Answering question for PR #78", "acme/widgets - answer follow-up", secondPr.url],
+      ],
+    );
+    harness.storage.getPR = getPR;
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -272,6 +272,79 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
   }
 });
 
+test("GET /api/activities lists in-progress and queued jobs", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage, {
+    title: "fix activity menu",
+    repo: "acme/widgets",
+    number: 77,
+    url: "https://github.com/acme/widgets/pull/77",
+  });
+
+  try {
+    const runningJob = await harness.storage.enqueueBackgroundJob({
+      kind: "babysit_pr",
+      targetId: pr.id,
+      dedupeKey: `babysit_pr:${pr.id}`,
+      payload: { preferredAgent: "claude" },
+      availableAt: "2026-04-26T10:00:00.000Z",
+    });
+    await harness.storage.claimNextBackgroundJob({
+      workerId: "worker-1",
+      leaseToken: "lease-1",
+      leaseExpiresAt: "2026-04-26T10:10:00.000Z",
+      now: "2026-04-26T10:01:00.000Z",
+    });
+
+    const queuedJob = await harness.storage.enqueueBackgroundJob({
+      kind: "sync_watched_repos",
+      targetId: "runtime:1",
+      dedupeKey: "sync_watched_repos",
+      availableAt: "2026-04-26T10:02:00.000Z",
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/activities`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      inProgress: Array<{
+        id: string;
+        kind: string;
+        status: string;
+        label: string;
+        detail: string | null;
+        targetId: string;
+        targetUrl: string | null;
+      }>;
+      queued: Array<{
+        id: string;
+        kind: string;
+        status: string;
+        label: string;
+        detail: string | null;
+        targetId: string;
+      }>;
+    };
+
+    assert.equal(body.inProgress.length, 1);
+    assert.equal(body.inProgress[0]?.id, runningJob.id);
+    assert.equal(body.inProgress[0]?.kind, "babysit_pr");
+    assert.equal(body.inProgress[0]?.status, "in_progress");
+    assert.equal(body.inProgress[0]?.label, "Babysitting PR #77");
+    assert.equal(body.inProgress[0]?.detail, "acme/widgets - fix activity menu");
+    assert.equal(body.inProgress[0]?.targetId, pr.id);
+    assert.equal(body.inProgress[0]?.targetUrl, pr.url);
+
+    assert.equal(body.queued.length, 1);
+    assert.equal(body.queued[0]?.id, queuedJob.id);
+    assert.equal(body.queued[0]?.kind, "sync_watched_repos");
+    assert.equal(body.queued[0]?.status, "queued");
+    assert.equal(body.queued[0]?.label, "Sync watched repositories");
+    assert.equal(body.queued[0]?.targetId, "runtime:1");
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -113,6 +113,10 @@ export async function registerRoutes(
     res.json(await runtime.getRuntimeSnapshot());
   });
 
+  app.get("/api/activities", async (_req, res) => {
+    res.json(await runtime.listActivities());
+  });
+
   app.post("/api/runtime/drain", async (req, res) => {
     try {
       const payload = z.object({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -166,6 +166,32 @@ export const backgroundJobSchema = z.object({
 });
 export type BackgroundJob = z.infer<typeof backgroundJobSchema>;
 
+export const activityStatusEnum = z.enum(["in_progress", "queued"]);
+export type ActivityStatus = z.infer<typeof activityStatusEnum>;
+
+export const activityItemSchema = z.object({
+  id: z.string(),
+  kind: backgroundJobKindEnum,
+  status: activityStatusEnum,
+  label: z.string(),
+  detail: z.string().nullable(),
+  targetId: z.string(),
+  targetUrl: z.string().nullable(),
+  queuedAt: z.string(),
+  availableAt: z.string(),
+  startedAt: z.string().nullable(),
+  updatedAt: z.string(),
+  attemptCount: z.number().int().nonnegative(),
+});
+export type ActivityItem = z.infer<typeof activityItemSchema>;
+
+export const activitySnapshotSchema = z.object({
+  inProgress: z.array(activityItemSchema),
+  queued: z.array(activityItemSchema),
+  generatedAt: z.string(),
+});
+export type ActivitySnapshot = z.infer<typeof activitySnapshotSchema>;
+
 export const questionStatusEnum = z.enum(["pending", "answering", "answered", "error"]);
 export type QuestionStatus = z.infer<typeof questionStatusEnum>;
 


### PR DESCRIPTION
## Summary
- Add an activity dropdown next to `settings` on the dashboard header.
- Surface live `in progress` and `queued` background jobs from a new `/api/activities` snapshot.
- Keep the menu updated by invalidating activity data after actions that can enqueue work.

## Testing
- Added route coverage for the activity snapshot endpoint.
- Verified the dashboard build and full test suite pass, including the new activity flow.