### PR TITLE
fix(build): inject createRequire banner so ESM bundle can load CJS deps

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -78,6 +78,15 @@ async function buildServerEntry(
     minify: true,
     external,
     logLevel: "error",
+    // ESM bundles need a working `require` for any bundled CJS dep that
+    // calls `require("path")` etc. at module init (e.g. postcss). Without
+    // this banner, esbuild's dynamic-require shim throws at runtime.
+    banner:
+      format === "esm"
+        ? {
+            js: "import { createRequire as __esbuildCreateRequire } from 'module'; const require = __esbuildCreateRequire(import.meta.url);",
+          }
+        : undefined,
   });
 }
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -84,7 +84,7 @@ async function buildServerEntry(
     banner:
       format === "esm"
         ? {
-            js: "import { createRequire as __esbuildCreateRequire } from 'module'; const require = __esbuildCreateRequire(import.meta.url);",
+            js: "import { createRequire as __esbuildCreateRequire } from 'node:module'; const require = __esbuildCreateRequire(import.meta.url);\n",
           }
         : undefined,
   });


### PR DESCRIPTION
## Summary

`oh-my-pr` (default TUI mode) currently crashes on startup with:

```
$ oh-my-pr
(node:NN) ExperimentalWarning: SQLite is an experimental feature ...
Dynamic require of "path" is not supported
```

## Root cause

`script/build.ts` emits `dist/tui.mjs` as an ESM bundle (`format: \"esm\"`), but several bundled CJS dependencies (notably `postcss`, via `previous-map.js`) call `require(\"path\")` / `require(\"url\")` at module init. esbuild emits a dynamic-require shim for these:

```js
var An = (t => typeof require < \"u\" ? require : ... )(function (t) {
  if (typeof require < \"u\") return require.apply(this, arguments);
  throw Error('Dynamic require of \"' + t + '\" is not supported');
});
```

In ESM there is no global `require`, so the shim's `typeof require !== \"undefined\"` check fails and every `An(\"path\")` call throws.

Stack trace from `node --input-type=module -e \"import('.../dist/tui.mjs')\"`:

```
Error: Dynamic require of \"path\" is not supported
    at .../dist/tui.mjs:2:383       (the shim)
    at .../dist/tui.mjs:24:40085    (postcss previous-map)
    ...
```

The CJS outputs (`dist/index.cjs`, `dist/mcp.cjs`, `dist/cli.cjs`) are unaffected because real `require` is in scope there.

## Fix

Add an esbuild `banner` to ESM outputs only, prepending:

```js
import { createRequire as __esbuildCreateRequire } from 'module';
const require = __esbuildCreateRequire(import.meta.url);
```

This puts a real Node `require` into lexical scope before the shim's IIFE evaluates, so the `typeof require` check now succeeds and `An` becomes a real `require`. This is the canonical esbuild ESM-output pattern (see https://esbuild.github.io/getting-started/#bundling-for-node — \"Note about ESM\").

## Test plan

- [x] `npm run build` — succeeds
- [x] `node --input-type=module -e \"import('./dist/tui.mjs')\"` — module init no longer throws (now exits with the expected `oh-my-pr tui requires an interactive TTY` message when stdin is piped)
- [x] `oh-my-pr` in a real terminal — TUI launches normally
- [x] CJS outputs are byte-identical to before (banner only applies when `format === \"esm\"`)