### PR TITLE
Add persistent design context guidance

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,19 @@
+## Design Context
+
+### Users
+oh-my-pr is for developers and engineering teams who want pull requests to keep moving without manually babysitting review comments, CI failures, merge conflicts, docs follow-ups, and release prep. They are comfortable with GitHub, local CLIs, tokens, logs, branches, and coding agents. They use the app as a local-first operator console to understand what automation is doing, decide where human judgment is needed, and get PRs closer to merge-ready.
+
+### Brand Personality
+The brand personality is autonomous, high-level dashboard, and extreme simplicity. The interface should feel calm, senior, and developer-native: confident enough to run background automation, transparent enough to earn trust, and simple enough that the main state of every PR is obvious at a glance.
+
+### Aesthetic Direction
+Design dark-first only. The product UI should stay dense, monochrome, terminal-adjacent, and operational: bordered panes, compact controls, small metadata labels, JetBrains Mono, low decoration, and restrained status color only where it clarifies state. Linear and Superhuman are the best references: fast, focused, refined, and quiet. Avoid the enterprise-software feel of Jira, Confluence, Microsoft Teams, and ServiceNow: no heavy chrome, cluttered navigation, noisy cards, corporate gradients, or committee-designed settings surfaces.
+
+Accessibility is not a design driver for now beyond preserving the existing baseline of readable contrast and keyboard-usable controls where practical.
+
+### Design Principles
+1. Make automation visible. Show what the agent is doing, why it is doing it, and what state each PR or feedback item is in.
+2. Keep the interface high-level first. Prioritize scan-friendly dashboards, clear lifecycle state, and operator confidence over exhaustive configuration on the main surface.
+3. Practice extreme simplicity. Add the smallest surface that solves the workflow, avoid speculative controls, and remove visual noise before adding polish.
+4. Preserve the local developer-tool feel. Use compact density, mono typography, neutral tokens, sharp or minimal radius, and direct copy.
+5. Use color sparingly for meaning. Reserve green, amber, red, and similar accents for status, warnings, and success signals; keep the rest neutral and dark-first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@ Use `npm install` to install dependencies. `npm run dev` starts the local servic
 ## Coding Style & Naming Conventions
 Use strict TypeScript, 2-space indentation, double quotes, and semicolons to match the existing code. Keep React code under `client/src/`, server modules under `server/`, and shared contracts in `shared/`. Prefer the existing path aliases: `@/` for client imports and `@shared/` for shared modules. Follow established file naming: camelCase for server helpers such as `repoWorkspace.ts`, kebab-case for route files such as `not-found.tsx`, and `*.test.ts` for tests.
 
+## Design Guidance
+Before product UI or UX changes, read `.impeccable.md` and follow its Design Context. Keep the app dark-first, developer-native, dense, transparent about automation, and extremely simple. Avoid enterprise-suite patterns like Jira, Confluence, Microsoft Teams, and ServiceNow.
+
 ## Testing Guidelines
 Follow the standardized test guidance in `test.md`. Use the red-green-refactor loop for every feature, bug fix, refactor, or behavior change. Before completion, run the relevant Node test suite and `npm run check`. Maintain at least 70% coverage of the affected critical path for critical app workflows.
 


### PR DESCRIPTION
## Summary
- Add `.impeccable.md` with the project’s design context, references, and guiding principles.
- Update `AGENTS.md` so future UI and UX work reads `.impeccable.md` first.

## Testing
- Not run (not requested)