### PR TITLE
[codex] Improve agent failure resilience

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -71,6 +71,7 @@ const WATCH_SCOPE_OPTIONS = [
 ] as const;
 
 const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
+  failed: [],
   inProgress: [],
   queued: [],
   generatedAt: "",
@@ -179,20 +180,29 @@ function WatchScopeControl({
 }
 
 function ActivityRow({ activity }: { activity: ActivityItem }) {
-  const timeLabel = activity.status === "in_progress"
+  const timeLabel = activity.status === "failed"
+    ? formatClock(activity.updatedAt)
+    : activity.status === "in_progress"
     ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
     : formatClock(activity.availableAt) ?? formatClock(activity.queuedAt);
   const content = (
     <div className="flex min-w-0 items-start gap-2 px-2 py-1.5 text-left">
       <span
         className={`mt-1.5 h-1.5 w-1.5 shrink-0 ${
-          activity.status === "in_progress" ? "animate-pulse bg-foreground" : "bg-muted-foreground"
+          activity.status === "failed"
+            ? "bg-destructive"
+            : activity.status === "in_progress"
+              ? "animate-pulse bg-foreground"
+              : "bg-muted-foreground"
         }`}
       />
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
         {activity.detail && (
           <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
+        )}
+        {activity.status === "failed" && activity.lastError && (
+          <span className="block truncate text-[11px] leading-4 text-destructive">{activity.lastError}</span>
         )}
       </span>
       {timeLabel && (
@@ -243,9 +253,10 @@ function ActivitySection({
 }
 
 function ActivityMenu({ activities }: { activities: ActivitySnapshot }) {
+  const failedCount = activities.failed.length;
   const inProgressCount = activities.inProgress.length;
   const queuedCount = activities.queued.length;
-  const totalCount = inProgressCount + queuedCount;
+  const totalCount = failedCount + inProgressCount + queuedCount;
 
   return (
     <DropdownMenu>
@@ -262,9 +273,15 @@ function ActivityMenu({ activities }: { activities: ActivitySnapshot }) {
         <div className="border-b border-border px-2 py-2">
           <div className="text-[12px] font-medium">Activities</div>
           <div className="text-[11px] text-muted-foreground">
-            {inProgressCount} in progress / {queuedCount} queued
+            {failedCount} failed / {inProgressCount} in progress / {queuedCount} queued
           </div>
         </div>
+        <ActivitySection
+          title="Failed"
+          items={activities.failed}
+          emptyLabel="No failed activities."
+        />
+        <div className="border-t border-border" />
         <ActivitySection
           title="In progress"
           items={activities.inProgress}

--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -20,6 +20,24 @@ test("runCommand reports a timeout even when the child exits 0 after SIGTERM", a
   assert.match(result.stderr, /timed out after 50ms/i);
 });
 
+test("runCommand escalates timed-out children that ignore SIGTERM", async () => {
+  const startedAt = Date.now();
+  const result = await runCommand(
+    process.execPath,
+    [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+    ],
+    { timeoutMs: 50, killTimeoutMs: 50 },
+  );
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.code, 124);
+  assert.equal(result.timedOut, true);
+  assert.match(result.stderr, /timed out after 50ms/i);
+  assert.ok(elapsedMs < 1500, `expected forced cleanup, took ${elapsedMs}ms`);
+});
+
 test("evaluateFixNecessityWithAgent throws a clear error when codex writes no output file", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-bin-"));
   const fakeCodexPath = path.join(

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -18,6 +18,8 @@ export type CommandResult = {
   timedOut?: boolean;
 };
 
+const COMMAND_RESULT_SUMMARY_MAX_CHARS = 2_000;
+
 const AGENTS: CodingAgent[] = ["codex", "claude"];
 
 export async function commandExists(command: string): Promise<boolean> {
@@ -213,12 +215,14 @@ export async function runCommand(
   options?: {
     cwd?: string;
     timeoutMs?: number;
+    killTimeoutMs?: number;
     env?: NodeJS.ProcessEnv;
     onStdoutChunk?: (chunk: string) => void;
     onStderrChunk?: (chunk: string) => void;
   },
 ): Promise<CommandResult> {
   const timeoutMs = options?.timeoutMs ?? 120000;
+  const killTimeoutMs = options?.killTimeoutMs ?? 5000;
 
   return new Promise((resolve) => {
     const child = spawn(command, args, {
@@ -230,10 +234,22 @@ export async function runCommand(
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let killTimer: NodeJS.Timeout | null = null;
+
+    const clearTimers = () => {
+      clearTimeout(timer);
+      if (killTimer) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+    };
 
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, killTimeoutMs);
     }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => {
@@ -249,7 +265,7 @@ export async function runCommand(
     });
 
     child.on("close", (code, signal) => {
-      clearTimeout(timer);
+      clearTimers();
       const stderrParts = [stderr.trim()];
       if (timedOut) {
         stderrParts.push(`Command timed out after ${timeoutMs}ms`);
@@ -267,7 +283,7 @@ export async function runCommand(
     });
 
     child.on("error", (err) => {
-      clearTimeout(timer);
+      clearTimers();
       resolve({
         stdout,
         stderr: `${stderr}\n${err.message}`.trim(),
@@ -275,4 +291,15 @@ export async function runCommand(
       });
     });
   });
+}
+
+export function summarizeCommandResult(result: CommandResult, fallback: string): string {
+  const details = (result.stderr || result.stdout).trim();
+  const summary = details ? `${fallback}: ${details}` : fallback;
+
+  if (summary.length <= COMMAND_RESULT_SUMMARY_MAX_CHARS) {
+    return summary;
+  }
+
+  return `${summary.slice(0, COMMAND_RESULT_SUMMARY_MAX_CHARS - "... (truncated)".length)}... (truncated)`;
 }

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -18,8 +18,6 @@ export type CommandResult = {
   timedOut?: boolean;
 };
 
-const COMMAND_RESULT_SUMMARY_MAX_CHARS = 2_000;
-
 const AGENTS: CodingAgent[] = ["codex", "claude"];
 
 export async function commandExists(command: string): Promise<boolean> {
@@ -294,12 +292,13 @@ export async function runCommand(
 }
 
 export function summarizeCommandResult(result: CommandResult, fallback: string): string {
+  const MAX_CHARS = 2_000;
   const details = (result.stderr || result.stdout).trim();
   const summary = details ? `${fallback}: ${details}` : fallback;
 
-  if (summary.length <= COMMAND_RESULT_SUMMARY_MAX_CHARS) {
+  if (summary.length <= MAX_CHARS) {
     return summary;
   }
 
-  return `${summary.slice(0, COMMAND_RESULT_SUMMARY_MAX_CHARS - "... (truncated)".length)}... (truncated)`;
+  return `${summary.slice(0, MAX_CHARS - "... (truncated)".length)}... (truncated)`;
 }

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -439,7 +439,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     return {
       id: job.id,
       kind: job.kind,
-      status: job.status === "leased" ? "in_progress" : "queued",
+      status: job.status === "leased" ? "in_progress" : job.status === "failed" ? "failed" : "queued",
       label: description.label,
       detail: description.detail,
       targetId: job.targetId,
@@ -449,6 +449,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       startedAt: job.heartbeatAt,
       updatedAt: job.updatedAt,
       attemptCount: job.attemptCount,
+      lastError: job.lastError,
     };
   };
 
@@ -535,16 +536,19 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     getRuntimeSnapshot,
 
     async listActivities() {
-      const [leasedJobs, queuedJobs] = await Promise.all([
+      const [failedJobs, leasedJobs, queuedJobs] = await Promise.all([
+        storage.listBackgroundJobs({ status: "failed" }),
         storage.listBackgroundJobs({ status: "leased" }),
         storage.listBackgroundJobs({ status: "queued" }),
       ]);
 
-      const descriptionContext = await buildActivityDescriptionContext([...leasedJobs, ...queuedJobs]);
+      const descriptionContext = await buildActivityDescriptionContext([...failedJobs, ...leasedJobs, ...queuedJobs]);
+      const failed = failedJobs.map((job) => mapActivityJob(job, descriptionContext));
       const inProgress = leasedJobs.map((job) => mapActivityJob(job, descriptionContext));
       const queued = queuedJobs.map((job) => mapActivityJob(job, descriptionContext));
 
       return {
+        failed,
         inProgress,
         queued,
         generatedAt: new Date().toISOString(),

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -400,6 +400,62 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
   assert.ok(logs.some((log) => log.message.includes("queued release evaluation")));
 });
 
+test("syncAndBabysitTrackedRepos supersedes active healing sessions when archiving closed PRs", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 43,
+    title: "Closed PR with active healing",
+    repo: "octo/example",
+    branch: "feature/healing",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/43",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "head123",
+    currentHeadSha: "head123",
+    state: "awaiting_repair_slot",
+    endedAt: null,
+    blockedReason: null,
+    escalationReason: null,
+    latestFingerprint: "github-check-run:tests:backend-build-and-test",
+    attemptCount: 0,
+    lastImprovementScore: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService(),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updatedPr = await storage.getPR(pr.id);
+  const updatedSession = await storage.getHealingSession(session.id);
+  assert.equal(updatedPr?.status, "archived");
+  assert.equal(updatedSession?.state, "superseded");
+  assert.match(updatedSession?.escalationReason ?? "", /PR archived/);
+  assert.ok(updatedSession?.endedAt);
+});
+
 test("syncAndBabysitTrackedRepos enqueues social changelog generation as a background job", async () => {
   const storage = new MemStorage();
   const backgroundJobQueue = new BackgroundJobQueue(storage);
@@ -2569,6 +2625,101 @@ test("babysitPR reassesses docs when the head SHA changes", async () => {
   }
 });
 
+test("babysitPR caps verbose diff preview logs during docs assessment", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose docs diff",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const diffPreview = Array.from(
+    { length: 120 },
+    (_, index) => `+changed implementation line ${index + 1}`,
+  ).join("\n");
+  let capturedDocsPrompt = "";
+  const baseRunCommand = makeGitRunCommand({ localHeadSha: "abc123", remoteHeadSha: "abc123" });
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async ({ prompt }) => {
+          capturedDocsPrompt = prompt;
+          return { needsFix: false, reason: "Docs are still accurate" };
+        },
+        applyFixesWithAgent: async () => {
+          throw new Error("Should not run the agent when docs assessment says no fix is needed");
+        },
+        runCommand: async (command, args, options) => {
+          if (command === "git" && args[0] === "diff" && args[1] === "--no-color") {
+            options?.onStdoutChunk?.(`${diffPreview}\n`);
+            return { code: 0, stdout: `${diffPreview}\n`, stderr: "" };
+          }
+
+          if (command === "git" && args[0] === "diff" && args[1] === "--name-only") {
+            const stdout = "src/feature.ts\nREADME.md\n";
+            options?.onStdoutChunk?.(stdout);
+            return { code: 0, stdout, stderr: "" };
+          }
+
+          if (command === "git" && args[0] === "diff" && args[1] === "--stat") {
+            const stdout = "src/feature.ts | 120 +++++++++++++++++++++++++++++++++++++\n";
+            options?.onStdoutChunk?.(stdout);
+            return { code: 0, stdout, stderr: "" };
+          }
+
+          const result = await baseRunCommand(command, args);
+          options?.onStdoutChunk?.(result.stdout);
+          options?.onStderrChunk?.(result.stderr);
+          return result;
+        },
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const logs = await storage.getLogs(pr.id);
+    const previewLogs = logs.filter(
+      (log) => log.phase === "evaluate.docs" && log.message.includes("+changed implementation line"),
+    );
+    assert.equal(previewLogs.length, 20);
+    assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("[stdout] output truncated after 20 line(s)")));
+    assert.match(capturedDocsPrompt, /\+changed implementation line 120/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
 test("babysitPR retries docs assessment for same-SHA failed state", async () => {
   const storage = new MemStorage();
   const pr = await storage.addPR({
@@ -4293,6 +4444,147 @@ test("babysitPR blocks external CI failures without launching the healing agent"
   assert.equal(sessions[0]?.state, "blocked");
   assert.match(sessions[0]?.blockedReason ?? "", /external ci failure/i);
   assert.equal(healingAgentCalled, false);
+});
+
+test("babysitPR does not reopen terminal healing sessions for the same head SHA", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoHealCI: true, autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 46,
+    title: "Already escalated CI",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/escalated-ci",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/46",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "same-head",
+    currentHeadSha: "same-head",
+    state: "escalated",
+    endedAt: "2026-04-29T03:46:32.083Z",
+    blockedReason: null,
+    escalationReason: "agent exited with code 124",
+    latestFingerprint: "github-check-run:tests:playwright-e2e",
+    attemptCount: 1,
+    lastImprovementScore: null,
+  });
+
+  let healingAgentCalled = false;
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "same-head", headRef: pr.branch, branch: pr.branch }),
+      fetchCheckSnapshotsForRef: async (_octokit: unknown, _repo: unknown, prId: string, headSha: string) => [
+        makeCheckSnapshot({ prId, sha: headSha, description: "Playwright E2E failed" }),
+      ],
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCIHealingRepairAttempt: async () => {
+        healingAgentCalled = true;
+        throw new Error("terminal sessions must not launch a healing agent");
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updatedPr = await storage.getPR(pr.id);
+  const updatedSession = await storage.getHealingSession(session.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(updatedPr?.status, "watching");
+  assert.equal(updatedSession?.state, "escalated");
+  assert.equal(healingAgentCalled, false);
+  assert.ok(!logs.some((log) => log.message.includes("Illegal healing session transition")));
+});
+
+test("babysitPR honors CI healing retry budgets before launching the healing agent", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoHealCI: true,
+    autoUpdateDocs: false,
+    maxHealingAttemptsPerSession: 1,
+  });
+  const pr = await storage.addPR({
+    number: 47,
+    title: "Retry budget exhausted",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/retry-budget",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/47",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "budget-head",
+    currentHeadSha: "budget-head",
+    state: "awaiting_repair_slot",
+    endedAt: null,
+    blockedReason: null,
+    escalationReason: null,
+    latestFingerprint: "github-check-run:tests:playwright-e2e",
+    attemptCount: 1,
+    lastImprovementScore: null,
+  });
+
+  let healingAgentCalled = false;
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "budget-head", headRef: pr.branch, branch: pr.branch }),
+      fetchCheckSnapshotsForRef: async (_octokit: unknown, _repo: unknown, prId: string, headSha: string) => [
+        makeCheckSnapshot({ prId, sha: headSha, description: "Playwright E2E failed" }),
+      ],
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCIHealingRepairAttempt: async () => {
+        healingAgentCalled = true;
+        throw new Error("retry budget should prevent the healing agent from launching");
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updatedSession = await storage.getHealingSession(session.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(healingAgentCalled, false);
+  assert.equal(updatedSession?.state, "escalated");
+  assert.match(updatedSession?.escalationReason ?? "", /session retry budget exhausted/);
+  assert.ok(logs.some((log) => log.phase === "healing.retry" && log.message.includes("session retry budget exhausted")));
 });
 
 test("babysitPR marks a healing session healed when the repair push turns CI green", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -36,7 +36,7 @@ import {
   type ParsedRepoSlug,
   type StatusReplyRef,
 } from "./github";
-import { CIHealingManager } from "./ciHealingManager";
+import { CIHealingManager, isTerminalHealingState } from "./ciHealingManager";
 import { classifyCIFailures, type ClassifiedCIFailure } from "./ciFailureClassifier";
 import { isFailingCheckSnapshot } from "./ciCheckIngestor";
 import { runCIHealingRepairAttempt } from "./ciHealingAgent";
@@ -874,6 +874,23 @@ export class PRBabysitter {
     return this.clock();
   }
 
+  private async supersedeActiveHealingSessionsForArchivedPr(prId: string): Promise<void> {
+    const sessions = await this.storage.listHealingSessions({ prId });
+    const endedAt = this.now().toISOString();
+
+    for (const session of sessions) {
+      if (isTerminalHealingState(session.state)) {
+        continue;
+      }
+
+      await this.storage.updateHealingSession(session.id, {
+        state: "superseded",
+        endedAt,
+        escalationReason: "PR archived on GitHub",
+      });
+    }
+  }
+
   getActiveRunCount(): number {
     return this.inProgress.size;
   }
@@ -1228,6 +1245,7 @@ export class PRBabysitter {
           }
 
           await this.storage.updatePR(pr.id, { status: "archived" });
+          await this.supersedeActiveHealingSessionsForArchivedPr(pr.id);
           await this.storage.addLog(pr.id, "info", `PR #${pr.number} is no longer open on GitHub — archived`, {
             phase: "watcher",
           });
@@ -1668,8 +1686,30 @@ export class PRBabysitter {
       phase: string,
       stream: "stdout" | "stderr",
       level: "info" | "warn",
+      maxLines?: number,
     ) => {
       let buffer = "";
+      let loggedLines = 0;
+      let loggedTruncation = false;
+
+      const enqueueLine = (trimmed: string) => {
+        if (maxLines !== undefined && loggedLines >= maxLines) {
+          if (!loggedTruncation) {
+            loggedTruncation = true;
+            return queueLog(currentPrId, level, `[${stream}] output truncated after ${maxLines} line(s)`, {
+              phase,
+              metadata: { stream, truncated: true, maxLines },
+            });
+          }
+          return logQueue;
+        }
+
+        loggedLines += 1;
+        return queueLog(currentPrId, level, `[${stream}] ${trimmed}`, {
+          phase,
+          metadata: { stream },
+        });
+      };
 
       return {
         onChunk: (chunk: string) => {
@@ -1678,20 +1718,17 @@ export class PRBabysitter {
           for (const line of drained.lines) {
             const trimmed = line.trim();
             if (!trimmed) continue;
-            void queueLog(currentPrId, level, `[${stream}] ${trimmed}`, {
-              phase,
-              metadata: { stream },
-            });
+            void enqueueLine(trimmed);
           }
         },
         flush: async () => {
           const trimmed = buffer.trim();
-          if (!trimmed) return;
           buffer = "";
-          await queueLog(currentPrId, level, `[${stream}] ${trimmed}`, {
-            phase,
-            metadata: { stream },
-          });
+          if (trimmed) {
+            await enqueueLine(trimmed);
+            return;
+          }
+          await logQueue;
         },
       };
     };
@@ -1704,15 +1741,16 @@ export class PRBabysitter {
       timeoutMs?: number;
       phase: string;
       successMessage: string;
+      maxOutputLogLines?: number;
     }) => {
-      const { currentPrId, command, args, cwd, timeoutMs, phase, successMessage } = params;
+      const { currentPrId, command, args, cwd, timeoutMs, phase, successMessage, maxOutputLogLines } = params;
 
       await queueLog(currentPrId, "info", `Running ${formatCommand(command, args)}`, {
         phase,
       });
 
-      const stdoutLogger = createChunkLogger(currentPrId, phase, "stdout", "info");
-      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "warn");
+      const stdoutLogger = createChunkLogger(currentPrId, phase, "stdout", "info", maxOutputLogLines);
+      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "warn", maxOutputLogLines);
 
       const result = await this.runtime.runCommand(command, args, {
         cwd,
@@ -1849,7 +1887,16 @@ export class PRBabysitter {
           classifiedHealingFailures,
         );
 
-        if (blockedHealingFailures.length > 0) {
+        if (isTerminalHealingState(healingSession.state)) {
+          await queueLog(pr.id, "info", `CI healing session ${healingSession.id} is already ${healingSession.state}; skipping repair transition`, {
+            phase: "healing.state",
+            metadata: {
+              healingSessionId: healingSession.id,
+              healingState: healingSession.state,
+              headSha: pullSummary.headSha,
+            },
+          });
+        } else if (blockedHealingFailures.length > 0) {
           healingSession = await healingManager.markBlocked(
             healingSession.id,
             blockedHealingFailures[0]?.summary ?? "CI failure classified as blocked_external",
@@ -2122,7 +2169,8 @@ export class PRBabysitter {
         : null;
       let hasDocsTask = Boolean(docsTaskSummary);
       const needsWorktree = hasCommentOrStatusAgentWork || hasConflicts || docsAssessmentNeeded || hasDocsTask;
-      const shouldRunCIHealingAgent = Boolean(
+      let healingRetryBlockedReason: string | null = null;
+      const wouldRunCIHealingAgent = Boolean(
         config.autoHealCI
         && healingSession
         && healingSession.state === "awaiting_repair_slot"
@@ -2131,6 +2179,35 @@ export class PRBabysitter {
         && !hasConflicts
         && !docsAssessmentNeeded
         && !hasDocsTask,
+      );
+
+      if (wouldRunCIHealingAgent && healingSession) {
+        const retryFingerprint = healableHealingFailures[0]?.fingerprint ?? healingSession.latestFingerprint ?? undefined;
+        const retryBudget = await healingManager.canRetry(healingSession.id, retryFingerprint);
+        if (!retryBudget.canRetry) {
+          healingRetryBlockedReason = retryBudget.reason ?? "retry budget rejected the healing attempt";
+          healingSession = await healingManager.markEscalated(healingSession.id, healingRetryBlockedReason, {
+            currentHeadSha: pullSummary.headSha,
+            latestFingerprint: retryFingerprint ?? healingSession.latestFingerprint,
+          });
+          await queueLog(pr.id, "warn", `CI healing retry skipped: ${healingRetryBlockedReason}`, {
+            phase: "healing.retry",
+            metadata: {
+              healingSessionId: healingSession.id,
+              fingerprint: retryFingerprint ?? null,
+              sessionAttempts: retryBudget.sessionAttempts,
+              fingerprintAttempts: retryBudget.fingerprintAttempts,
+              maxSessionAttempts: retryBudget.maxSessionAttempts,
+              maxFingerprintAttempts: retryBudget.maxFingerprintAttempts,
+            },
+          });
+        }
+      }
+
+      const shouldRunCIHealingAgent = Boolean(
+        wouldRunCIHealingAgent
+        && healingSession?.state === "awaiting_repair_slot"
+        && !healingRetryBlockedReason,
       );
 
       if (config.autoUpdateDocs && currentHeadDocsAssessment && !docsAssessmentNeeded) {
@@ -2298,6 +2375,7 @@ export class PRBabysitter {
                 timeoutMs: 10000,
                 phase: "evaluate.docs",
                 successMessage: "Collected diff preview for docs assessment",
+                maxOutputLogLines: 20,
               });
               if (diffPreviewResult.code !== 0) {
                 throw new Error(`Failed to collect diff preview for docs assessment: ${summarizeCommandFailure(diffPreviewResult)}`);

--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -262,3 +262,83 @@ test("BackgroundJobDispatcher cancels jobs when the handler raises a cancel erro
     dispatcher.stop();
   }
 });
+
+test("BackgroundJobDispatcher retries transient handler errors before completing", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    maxAttempts: 2,
+    retryBackoffMs: 0,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("temporary GitHub outage");
+        }
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(() => attempts === 2, 500);
+    assert.equal(await dispatcher.waitForIdle(250), true);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(stored?.status, "completed");
+    assert.equal(stored?.attemptCount, 2);
+    assert.equal(stored?.lastError, null);
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher fails handler errors after retry attempts are exhausted", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    maxAttempts: 2,
+    retryBackoffMs: 0,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        throw new Error("persistent failure");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 500);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(attempts, 2);
+    assert.equal(stored?.status, "failed");
+    assert.equal(stored?.attemptCount, 2);
+    assert.match(stored?.lastError ?? "", /persistent failure/);
+  } finally {
+    dispatcher.stop();
+  }
+});

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -23,6 +23,8 @@ export class BackgroundJobDispatcher {
   private readonly pollIntervalMs: number;
   private readonly leaseMs: number;
   private readonly heartbeatIntervalMs: number;
+  private readonly maxAttempts: number;
+  private readonly retryBackoffMs: number;
   private readonly now: () => Date;
   private readonly onError: (error: unknown) => void;
   private readonly activeJobs = new Map<string, Promise<void>>();
@@ -39,6 +41,8 @@ export class BackgroundJobDispatcher {
     pollIntervalMs?: number;
     leaseMs?: number;
     heartbeatIntervalMs?: number;
+    maxAttempts?: number;
+    retryBackoffMs?: number;
     now?: () => Date;
     onError?: (error: unknown) => void;
   }) {
@@ -50,6 +54,8 @@ export class BackgroundJobDispatcher {
     this.pollIntervalMs = params.pollIntervalMs ?? 1_000;
     this.leaseMs = params.leaseMs ?? 30_000;
     this.heartbeatIntervalMs = params.heartbeatIntervalMs ?? 10_000;
+    this.maxAttempts = Math.max(1, params.maxAttempts ?? 3);
+    this.retryBackoffMs = Math.max(0, params.retryBackoffMs ?? 30_000);
     this.now = params.now ?? (() => new Date());
     this.onError = params.onError ?? ((error) => {
       console.error("Background job dispatcher error", error);
@@ -198,12 +204,24 @@ export class BackgroundJobDispatcher {
               now: this.now(),
             });
           } else {
-            await this.queue.fail({
-              jobId: job.id,
-              leaseToken,
-              error: summarizeError(error),
-              now: this.now(),
-            });
+            const errorSummary = summarizeError(error);
+            const now = this.now();
+            if (job.attemptCount < this.maxAttempts) {
+              await this.queue.retry({
+                jobId: job.id,
+                leaseToken,
+                error: errorSummary,
+                now,
+                availableAt: new Date(now.getTime() + this.retryBackoffMs),
+              });
+            } else {
+              await this.queue.fail({
+                jobId: job.id,
+                leaseToken,
+                error: errorSummary,
+                now,
+              });
+            }
           }
         } catch (finalizeError) {
           this.onError(finalizeError);

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -195,37 +195,7 @@ export class BackgroundJobDispatcher {
           now: this.now(),
         });
       } catch (error) {
-        try {
-          if (error instanceof CancelBackgroundJobError) {
-            await this.queue.cancel({
-              jobId: job.id,
-              leaseToken,
-              error: error.message || null,
-              now: this.now(),
-            });
-          } else {
-            const errorSummary = summarizeError(error);
-            const now = this.now();
-            if (job.attemptCount < this.maxAttempts) {
-              await this.queue.retry({
-                jobId: job.id,
-                leaseToken,
-                error: errorSummary,
-                now,
-                availableAt: new Date(now.getTime() + this.retryBackoffMs),
-              });
-            } else {
-              await this.queue.fail({
-                jobId: job.id,
-                leaseToken,
-                error: errorSummary,
-                now,
-              });
-            }
-          }
-        } catch (finalizeError) {
-          this.onError(finalizeError);
-        }
+        await this.finalizeFailedJob(job, leaseToken, error);
       } finally {
         if (heartbeatTimer) {
           clearInterval(heartbeatTimer);
@@ -241,6 +211,61 @@ export class BackgroundJobDispatcher {
     });
 
     this.activeJobs.set(job.id, jobPromise);
+  }
+
+  private async finalizeFailedJob(
+    job: BackgroundJob,
+    leaseToken: string,
+    error: unknown,
+  ): Promise<void> {
+    const now = this.now();
+    const action = this.resolveFailureAction(job, error);
+
+    try {
+      switch (action) {
+        case "cancel":
+          await this.queue.cancel({
+            jobId: job.id,
+            leaseToken,
+            error: error instanceof CancelBackgroundJobError ? (error.message || null) : null,
+            now,
+          });
+          return;
+        case "retry":
+          await this.queue.retry({
+            jobId: job.id,
+            leaseToken,
+            error: summarizeError(error),
+            now,
+            availableAt: new Date(now.getTime() + this.retryBackoffMs),
+          });
+          return;
+        case "fail":
+          await this.queue.fail({
+            jobId: job.id,
+            leaseToken,
+            error: summarizeError(error),
+            now,
+          });
+          return;
+      }
+    } catch (finalizeError) {
+      this.onError(
+        new Error(
+          `Failed to ${action} background job ${job.id} (kind=${job.kind}, attempt=${job.attemptCount}): ${
+            finalizeError instanceof Error ? finalizeError.message : String(finalizeError)
+          }`,
+          { cause: finalizeError },
+        ),
+      );
+    }
+  }
+
+  private resolveFailureAction(job: BackgroundJob, error: unknown): "cancel" | "retry" | "fail" {
+    if (error instanceof CancelBackgroundJobError) {
+      return "cancel";
+    }
+    return job.attemptCount < this.maxAttempts ? "retry" : "fail";
   }
 }
 

--- a/server/backgroundJobQueue.ts
+++ b/server/backgroundJobQueue.ts
@@ -33,6 +33,11 @@ export type BackgroundJobFailParams = BackgroundJobFinalizeParams & {
   error: string;
 };
 
+export type BackgroundJobRetryParams = BackgroundJobFinalizeParams & {
+  error: string;
+  availableAt?: QueueDateInput;
+};
+
 export type BackgroundJobCancelParams = BackgroundJobFinalizeParams & {
   error?: string | null;
 };
@@ -114,6 +119,17 @@ export class BackgroundJobQueue {
       params.leaseToken,
       params.error,
       this.resolveNow(params.now),
+    );
+  }
+
+  async retry(params: BackgroundJobRetryParams): Promise<BackgroundJob | undefined> {
+    const now = this.resolveNow(params.now);
+    return this.storage.retryBackgroundJob(
+      params.jobId,
+      params.leaseToken,
+      params.error,
+      this.resolveNow(params.availableAt ?? now),
+      now,
     );
   }
 

--- a/server/ciFailureClassifier.test.ts
+++ b/server/ciFailureClassifier.test.ts
@@ -74,6 +74,27 @@ test("classifyCIFailure marks timeouts as flaky or ambiguous", () => {
   assert.match(result.summary, /Flaky or ambiguous/);
 });
 
+test("classifyCIFailure treats AI review check failures as blocked external", () => {
+  const snapshot = createCheckSnapshot({
+    prId: "pr-1",
+    sha: "abc123",
+    provider: "github.check_run",
+    context: "claude-review",
+    status: "completed",
+    conclusion: "failure",
+    description: "Failed steps: Run Claude Code Review",
+    targetUrl: "https://github.com/owner/repo/actions/runs/1",
+    observedAt: "2026-04-01T12:00:00.000Z",
+  });
+
+  const result = classifyCIFailure(snapshot);
+
+  assert.equal(result.classification, "blocked_external");
+  assert.equal(result.category, "ai-review");
+  assert.equal(result.fingerprint, "github-check-run:ai-review:claude-review");
+  assert.match(result.summary, /External CI failure/);
+});
+
 test("classifyCIFailure returns unknown for signals it cannot categorize", () => {
   const snapshot = createCheckSnapshot({
     prId: "pr-1",

--- a/server/ciFailureClassifier.ts
+++ b/server/ciFailureClassifier.ts
@@ -18,6 +18,7 @@ const HEALABLE_KEYWORDS = [
 ];
 
 const BLOCKED_KEYWORDS = [
+  { category: "ai-review", fingerprint: "ai-review", pattern: /\b(ai[- ]?review|claude[- ]?review|claude[- ]?code[- ]?review)\b/i },
   { category: "missing-secret", fingerprint: "missing-secret", pattern: /\b(secret|token|credential|auth|authorization|unauthorized|forbidden|permission|access denied)\b/i },
   { category: "external-outage", fingerprint: "external-outage", pattern: /\b(outage|unavailable|service unavailable|502|503|504|network error|dns|connection refused|rate limit|quota|api error)\b/i },
 ];

--- a/server/ciHealingAgent.test.ts
+++ b/server/ciHealingAgent.test.ts
@@ -236,6 +236,69 @@ test("runCIHealingRepairAttempt rejects when the remote SHA does not move", asyn
   assert.equal(cleanupCalled, true);
 });
 
+test("runCIHealingRepairAttempt preserves stderr when the agent exits non-zero", async () => {
+  const result = await runCIHealingRepairAttempt({
+    prNumber: 42,
+    repoFullName: "acme/widgets",
+    repoCloneUrl: "https://github.com/acme/widgets.git",
+    headRepoFullName: "acme/widgets",
+    headRepoCloneUrl: "https://github.com/acme/widgets.git",
+    headRef: "feature/heal-ci",
+    baseRef: "main",
+    headSha: "old-sha",
+    title: "Fix the compiler",
+    url: "https://github.com/acme/widgets/pull/42",
+    author: "octocat",
+    branch: "feature/heal-ci",
+    agent: "claude",
+    failures: [makeFailure()],
+    runId: "run-nonzero",
+    dependencies: {
+      preparePrWorktree: async () => ({
+        repoCacheDir: "/tmp/repo-cache",
+        worktreePath: "/tmp/worktree",
+        healed: false,
+        remoteName: "origin",
+      }),
+      removePrWorktree: async () => {},
+      applyFixesWithAgent: async () => ({
+        code: 124,
+        stdout: "partial context",
+        stderr: "Command timed out after 900000ms",
+        timedOut: true,
+      }),
+      runCommand: async (command, args) => {
+        if (command !== "git") {
+          return { code: 1, stdout: "", stderr: `unexpected command ${command}` };
+        }
+
+        const signature = args.join(" ");
+        if (signature.includes("-C /tmp/worktree rev-parse HEAD")) {
+          return { code: 0, stdout: "old-sha\n", stderr: "" };
+        }
+
+        if (signature.includes("-C /tmp/worktree status --porcelain")) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+
+        if (signature.includes("-C /tmp/repo-cache fetch origin feature/heal-ci")) {
+          return { code: 0, stdout: "fetched\n", stderr: "" };
+        }
+
+        if (signature.includes("-C /tmp/repo-cache rev-parse FETCH_HEAD")) {
+          return { code: 0, stdout: "old-sha\n", stderr: "" };
+        }
+
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+  });
+
+  assert.equal(result.accepted, false);
+  assert.match(result.rejectionReason ?? "", /agent exited with code 124/);
+  assert.match(result.rejectionReason ?? "", /timed out after 900000ms/);
+});
+
 test("runCIHealingRepairAttempt rejects dirty worktrees before remote verification", async () => {
   const callLog: Array<{ command: string; args: string[] }> = [];
   const result = await runCIHealingRepairAttempt({

--- a/server/ciHealingAgent.ts
+++ b/server/ciHealingAgent.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import type { CodingAgent, CommandResult } from "./agentRunner";
-import { applyFixesWithAgent, runCommand } from "./agentRunner";
+import { applyFixesWithAgent, runCommand, summarizeCommandResult } from "./agentRunner";
 import type { ClassifiedCIFailure } from "./ciFailureClassifier";
 import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 
@@ -300,7 +300,7 @@ export async function runCIHealingRepairAttempt(input: CIHealingWorktreeInput & 
 
     if (!accepted) {
       if (agentResult.code !== 0) {
-        rejectionReason = `agent exited with code ${agentResult.code}`;
+        rejectionReason = summarizeCommandResult(agentResult, `agent exited with code ${agentResult.code}`);
       } else if (worktreeDirty) {
         rejectionReason = `dirty worktree after agent run: ${worktreeStatus[0] ?? "unknown changes"}`;
       } else if (localCommitCreated && !pushedNewSha) {

--- a/server/ciHealingManager.ts
+++ b/server/ciHealingManager.ts
@@ -47,7 +47,7 @@ function nowIso(now: Date): string {
   return now.toISOString();
 }
 
-function isTerminalState(state: HealingSessionState): boolean {
+export function isTerminalHealingState(state: HealingSessionState): boolean {
   return TERMINAL_STATES.includes(state);
 }
 
@@ -82,7 +82,7 @@ export class CIHealingManager {
 
   async getActiveSessionsForPr(prId: string): Promise<HealingSession[]> {
     const sessions = await this.storage.listHealingSessions({ prId });
-    return sessions.filter((session) => !isTerminalState(session.state));
+    return sessions.filter((session) => !isTerminalHealingState(session.state));
   }
 
   async ensureSessionForHead(input: CIHealingSessionInput): Promise<HealingSession> {
@@ -154,7 +154,7 @@ export class CIHealingManager {
       mergedUpdates.attemptCount = session.attemptCount + 1;
     }
 
-    if (isTerminalState(nextState)) {
+    if (isTerminalHealingState(nextState)) {
       mergedUpdates.endedAt = updates.endedAt ?? nowIso(this.now());
     }
 
@@ -248,7 +248,7 @@ export class CIHealingManager {
     let reason: string | null = null;
     let canRetry = true;
 
-    if (isTerminalState(session.state)) {
+    if (isTerminalHealingState(session.state)) {
       canRetry = false;
       reason = `session is ${session.state}`;
     } else if (session.state === "cooldown" && cooldownRemainingMs > 0) {

--- a/server/deploymentHealingAgent.test.ts
+++ b/server/deploymentHealingAgent.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildDeploymentHealingPrompt, extractDeploymentHealingSummary } from "./deploymentHealingAgent";
+import { buildDeploymentHealingPrompt, extractDeploymentHealingSummary, runDeploymentHealingRepair } from "./deploymentHealingAgent";
 
 test("buildDeploymentHealingPrompt includes platform and log", () => {
   const prompt = buildDeploymentHealingPrompt({
@@ -32,4 +32,46 @@ test("extractDeploymentHealingSummary falls back to last line", () => {
 test("extractDeploymentHealingSummary handles empty output", () => {
   const summary = extractDeploymentHealingSummary("");
   assert.equal(summary, "No agent summary provided");
+});
+
+test("runDeploymentHealingRepair rejects non-zero agent exits even when commits exist", async () => {
+  const result = await runDeploymentHealingRepair({
+    repo: "owner/repo",
+    platform: "vercel",
+    mergeSha: "merge123",
+    triggerPrNumber: 42,
+    triggerPrTitle: "Add feature",
+    triggerPrUrl: "https://github.com/owner/repo/pull/42",
+    deploymentLog: "Cannot find module",
+    baseBranch: "main",
+    repoCloneUrl: "https://github.com/owner/repo.git",
+    agent: "claude",
+    githubToken: "ghs_test",
+    dependencies: {
+      ensureRepoCache: async () => ({ repoCacheDir: "/tmp/repo-cache", healed: false }),
+      applyFixesWithAgent: async () => ({
+        code: 2,
+        stdout: "DEPLOYMENT_FIX_SUMMARY: attempted a fix",
+        stderr: "agent crashed",
+      }),
+      runCommand: async (command, args) => {
+        assert.equal(command, "git");
+        const signature = args.join(" ");
+        if (signature.includes("checkout -b")) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        if (signature.includes("log merge123..HEAD --oneline")) {
+          return { code: 0, stdout: "abc123 fix deployment\n", stderr: "" };
+        }
+        if (signature.includes("checkout --detach")) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        throw new Error(`unexpected git command: ${signature}`);
+      },
+    },
+  });
+
+  assert.equal(result.accepted, false);
+  assert.match(result.rejectionReason ?? "", /agent failed \(2\): agent crashed/);
+  assert.equal(result.summary, "attempted a fix");
 });

--- a/server/deploymentHealingAgent.ts
+++ b/server/deploymentHealingAgent.ts
@@ -1,5 +1,5 @@
 import type { CodingAgent, CommandResult } from "./agentRunner";
-import { applyFixesWithAgent, runCommand } from "./agentRunner";
+import { applyFixesWithAgent, runCommand, summarizeCommandResult } from "./agentRunner";
 import { ensureRepoCache } from "./repoWorkspace";
 import type { DeploymentPlatform } from "@shared/schema";
 
@@ -133,6 +133,16 @@ export async function runDeploymentHealingRepair(
       prompt,
       env: input.env,
     });
+
+    if (agentResult.code !== 0) {
+      return {
+        accepted: false,
+        rejectionReason: summarizeCommandResult(agentResult, `agent failed (${agentResult.code})`),
+        summary: extractDeploymentHealingSummary(agentResult.stdout),
+        fixBranch,
+        agentResult,
+      };
+    }
 
     const logResult = await deps.runCommand(
       "git",

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -561,6 +561,33 @@ export class MemStorage implements IStorage {
     return this.cloneBackgroundJob(updated);
   }
 
+  async retryBackgroundJob(
+    id: string,
+    leaseToken: string,
+    error: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    const existing = this.backgroundJobs.get(id);
+    if (!existing || existing.status !== "leased" || existing.leaseToken !== leaseToken) {
+      return undefined;
+    }
+
+    const updated = applyBackgroundJobUpdate(existing, {
+      status: "queued",
+      availableAt,
+      leaseOwner: null,
+      leaseToken: null,
+      leaseExpiresAt: null,
+      heartbeatAt: null,
+      lastError: error,
+      completedAt: null,
+      updatedAt,
+    });
+    this.backgroundJobs.set(id, updated);
+    return this.cloneBackgroundJob(updated);
+  }
+
   async cancelBackgroundJob(
     id: string,
     leaseToken: string,

--- a/server/prQuestionAgent.test.ts
+++ b/server/prQuestionAgent.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { MemStorage } from "./memoryStorage";
 import { answerPRQuestion } from "./prQuestionAgent";
 import type { PRQuestion } from "@shared/schema";
@@ -24,6 +27,35 @@ async function seedPR(storage: MemStorage): Promise<string> {
     lastChecked: null,
   });
   return pr.id;
+}
+
+async function withFakeAgent(
+  output: { stdout?: string; stderr?: string; code?: number },
+  run: () => Promise<void>,
+): Promise<void> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-agent-bin-"));
+  const fakeClaudePath = path.join(tempRoot, "claude");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeClaudePath,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(output.stdout ?? "")});`,
+        `process.stderr.write(${JSON.stringify(output.stderr ?? "")});`,
+        `process.exit(${output.code ?? 0});`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeClaudePath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+    await run();
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 }
 
 describe("answerPRQuestion", () => {
@@ -217,5 +249,27 @@ describe("answerPRQuestion", () => {
     assert.ok(updated);
     assert.equal(updated.status, "error");
     assert.equal(updated.error, "string error without Error wrapper");
+  });
+
+  it("sets status to 'error' when the agent returns an empty successful answer", async () => {
+    await withFakeAgent({ stdout: "   \n", code: 0 }, async () => {
+      const storage = new MemStorage();
+      const prId = await seedPR(storage);
+      const q = await storage.addQuestion(prId, "What changed?");
+
+      await answerPRQuestion({
+        storage,
+        prId,
+        questionId: q.id,
+        question: q.question,
+        preferredAgent: "claude",
+      });
+
+      const updated = (await storage.getQuestions(prId)).find((x) => x.id === q.id);
+      assert.ok(updated);
+      assert.equal(updated.status, "error");
+      assert.match(updated.error ?? "", /empty response/i);
+      assert.equal(updated.answer, null);
+    });
   });
 });

--- a/server/prQuestionAgent.ts
+++ b/server/prQuestionAgent.ts
@@ -1,6 +1,6 @@
 import type { IStorage } from "./storage";
 import type { CodingAgent } from "./agentRunner";
-import { resolveAgent, runCommand } from "./agentRunner";
+import { resolveAgent, runCommand, summarizeCommandResult } from "./agentRunner";
 
 /**
  * Answers a user question about a PR by gathering context (PR state, feedback,
@@ -31,7 +31,7 @@ export async function answerPRQuestion(params: {
     );
 
     if (result.code !== 0) {
-      const errorMsg = result.stderr || result.stdout || `Agent exited with code ${result.code}`;
+      const errorMsg = summarizeCommandResult(result, `Agent exited with code ${result.code}`);
       await storage.updateQuestion(questionId, {
         status: "error",
         error: errorMsg.slice(0, 2000),
@@ -39,7 +39,15 @@ export async function answerPRQuestion(params: {
       return;
     }
 
-    const answer = result.stdout.trim() || "(Agent returned an empty response)";
+    const answer = result.stdout.trim();
+    if (!answer) {
+      await storage.updateQuestion(questionId, {
+        status: "error",
+        error: "Agent returned an empty response",
+        answer: null,
+      });
+      return;
+    }
 
     await storage.updateQuestion(questionId, {
       status: "answered",

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -272,7 +272,7 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
   }
 });
 
-test("GET /api/activities lists in-progress and queued jobs", async () => {
+test("GET /api/activities lists failed, in-progress, and queued jobs", async () => {
   const harness = await createHarness();
   const pr = await seedPR(harness.storage, {
     title: "fix activity menu",
@@ -303,9 +303,40 @@ test("GET /api/activities lists in-progress and queued jobs", async () => {
       availableAt: "2026-04-26T10:02:00.000Z",
     });
 
+    const failedJob = await harness.storage.enqueueBackgroundJob({
+      kind: "answer_pr_question",
+      targetId: "question-1",
+      dedupeKey: "answer_pr_question:question-1",
+      payload: { prId: pr.id },
+      availableAt: "2026-04-26T10:03:00.000Z",
+    });
+    const claimedFailed = await harness.storage.claimNextBackgroundJob({
+      workerId: "worker-2",
+      leaseToken: "lease-2",
+      leaseExpiresAt: "2026-04-26T10:10:00.000Z",
+      now: "2026-04-26T10:03:30.000Z",
+      kinds: ["answer_pr_question"],
+    });
+    assert.equal(claimedFailed?.id, failedJob.id);
+    await harness.storage.failBackgroundJob(
+      failedJob.id,
+      "lease-2",
+      "question agent timed out",
+      "2026-04-26T10:04:00.000Z",
+    );
+
     const response = await fetch(`${harness.baseUrl}/api/activities`);
     assert.equal(response.status, 200);
     const body = await response.json() as {
+      failed: Array<{
+        id: string;
+        kind: string;
+        status: string;
+        label: string;
+        detail: string | null;
+        targetId: string;
+        lastError: string | null;
+      }>;
       inProgress: Array<{
         id: string;
         kind: string;
@@ -324,6 +355,15 @@ test("GET /api/activities lists in-progress and queued jobs", async () => {
         targetId: string;
       }>;
     };
+
+    assert.equal(body.failed.length, 1);
+    assert.equal(body.failed[0]?.id, failedJob.id);
+    assert.equal(body.failed[0]?.kind, "answer_pr_question");
+    assert.equal(body.failed[0]?.status, "failed");
+    assert.equal(body.failed[0]?.label, "Answering question for PR #77");
+    assert.equal(body.failed[0]?.detail, "acme/widgets - fix activity menu");
+    assert.equal(body.failed[0]?.targetId, "question-1");
+    assert.equal(body.failed[0]?.lastError, "question agent timed out");
 
     assert.equal(body.inProgress.length, 1);
     assert.equal(body.inProgress[0]?.id, runningJob.id);

--- a/server/socialChangelogAgent.test.ts
+++ b/server/socialChangelogAgent.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { MemStorage } from "./memoryStorage";
+import { generateSocialChangelog } from "./socialChangelogAgent";
+
+async function withFakeAgent(
+  output: { stdout?: string; stderr?: string; code?: number },
+  run: () => Promise<void>,
+): Promise<void> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-agent-bin-"));
+  const fakeClaudePath = path.join(tempRoot, "claude");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeClaudePath,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(output.stdout ?? "")});`,
+        `process.stderr.write(${JSON.stringify(output.stderr ?? "")});`,
+        `process.exit(${output.code ?? 0});`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeClaudePath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+    await run();
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test("generateSocialChangelog marks empty successful agent output as error", async () => {
+  await withFakeAgent({ stdout: "\n\n", code: 0 }, async () => {
+    const storage = new MemStorage();
+    const changelog = await storage.createSocialChangelog({
+      date: "2026-04-29",
+      triggerCount: 5,
+      prSummaries: [{
+        number: 1,
+        title: "Improve automation",
+        url: "https://github.com/owner/repo/pull/1",
+        author: "octocat",
+        repo: "owner/repo",
+      }],
+      content: null,
+      status: "generating",
+      error: null,
+      completedAt: null,
+    });
+
+    await generateSocialChangelog({
+      storage,
+      changelogId: changelog.id,
+      prSummaries: changelog.prSummaries,
+      date: changelog.date,
+      preferredAgent: "claude",
+    });
+
+    const updated = await storage.getSocialChangelog(changelog.id);
+    assert.equal(updated?.status, "error");
+    assert.equal(updated?.content, null);
+    assert.match(updated?.error ?? "", /empty response/i);
+  });
+});

--- a/server/socialChangelogAgent.ts
+++ b/server/socialChangelogAgent.ts
@@ -1,7 +1,7 @@
 import type { IStorage } from "./storage";
 import type { SocialChangelogPRSummary } from "@shared/schema";
 import type { CodingAgent } from "./agentRunner";
-import { resolveAgent, runCommand } from "./agentRunner";
+import { resolveAgent, runCommand, summarizeCommandResult } from "./agentRunner";
 
 const DEFAULT_SOCIAL_CHANGELOG_TIMEOUT_MS = 120_000;
 const SOCIAL_CHANGELOG_ERROR_SUMMARY_MAX_CHARS = 2_000;
@@ -40,7 +40,7 @@ export async function generateSocialChangelog(params: {
     );
 
     if (result.code !== 0) {
-      const errorMsg = result.stderr || result.stdout || `Agent exited with code ${result.code}`;
+      const errorMsg = summarizeCommandResult(result, `Agent exited with code ${result.code}`);
       console.error(`social-changelog: generation command failed for ${changelogId} (code=${result.code})`, {
         stdout: result.stdout,
         stderr: result.stderr,
@@ -53,7 +53,17 @@ export async function generateSocialChangelog(params: {
       return;
     }
 
-    const content = result.stdout.trim() || "(Agent returned an empty response)";
+    const content = result.stdout.trim();
+    if (!content) {
+      await storage.updateSocialChangelog(changelogId, {
+        status: "error",
+        error: "Agent returned an empty response",
+        content: null,
+        completedAt: new Date().toISOString(),
+      });
+      return;
+    }
+
     await storage.updateSocialChangelog(changelogId, {
       status: "done",
       content,

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1473,16 +1473,24 @@ export class SqliteStorage implements IStorage {
     const rows = prId
       ? this.all<LogRow>(`
           SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-          FROM logs
-          WHERE pr_id = ?
+          FROM (
+            SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
+            FROM logs
+            WHERE pr_id = ?
+            ORDER BY datetime(timestamp) DESC, rowid DESC
+            LIMIT 500
+          )
           ORDER BY datetime(timestamp) ASC
-          LIMIT 500
         `, prId)
       : this.all<LogRow>(`
           SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-          FROM logs
+          FROM (
+            SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
+            FROM logs
+            ORDER BY datetime(timestamp) DESC, rowid DESC
+            LIMIT 500
+          )
           ORDER BY datetime(timestamp) ASC
-          LIMIT 500
         `);
 
     return rows.map((row) => ({
@@ -2212,6 +2220,62 @@ export class SqliteStorage implements IStorage {
 
   async failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined> {
     return this.finalizeBackgroundJob(id, leaseToken, "failed", error, completedAt);
+  }
+
+  async retryBackgroundJob(
+    id: string,
+    leaseToken: string,
+    error: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    return this.withWriteTransaction(() => {
+      const current = this.get<BackgroundJobRow>(`
+        SELECT id, kind, target_id, dedupe_key, status, priority, available_at,
+               lease_owner, lease_token, lease_expires_at, heartbeat_at, attempt_count,
+               last_error, payload_json, created_at, updated_at, completed_at
+        FROM background_jobs
+        WHERE id = ? AND status = 'leased' AND lease_token = ?
+      `, id, leaseToken);
+
+      if (!current) {
+        return undefined;
+      }
+
+      const updated = applyBackgroundJobUpdate(this.parseBackgroundJobRow(current), {
+        status: "queued",
+        availableAt,
+        leaseOwner: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        heartbeatAt: null,
+        lastError: error,
+        completedAt: null,
+        updatedAt,
+      });
+
+      this.run(`
+        UPDATE background_jobs
+        SET status = 'queued',
+            available_at = ?,
+            lease_owner = NULL,
+            lease_token = NULL,
+            lease_expires_at = NULL,
+            heartbeat_at = NULL,
+            last_error = ?,
+            completed_at = NULL,
+            updated_at = ?
+        WHERE id = ? AND status = 'leased' AND lease_token = ?
+      `,
+        updated.availableAt,
+        updated.lastError,
+        updated.updatedAt,
+        id,
+        leaseToken,
+      );
+
+      return updated;
+    });
   }
 
   async cancelBackgroundJob(

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1470,28 +1470,19 @@ export class SqliteStorage implements IStorage {
   }
 
   async getLogs(prId?: string): Promise<LogEntry[]> {
-    const rows = prId
-      ? this.all<LogRow>(`
-          SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-          FROM (
-            SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-            FROM logs
-            WHERE pr_id = ?
-            ORDER BY datetime(timestamp) DESC, rowid DESC
-            LIMIT 500
-          )
-          ORDER BY datetime(timestamp) ASC
-        `, prId)
-      : this.all<LogRow>(`
-          SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-          FROM (
-            SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
-            FROM logs
-            ORDER BY datetime(timestamp) DESC, rowid DESC
-            LIMIT 500
-          )
-          ORDER BY datetime(timestamp) ASC
-        `);
+    const whereClause = prId ? "WHERE pr_id = ?" : "";
+    const sql = `
+      SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
+      FROM (
+        SELECT id, pr_id, run_id, timestamp, level, phase, message, metadata_json
+        FROM logs
+        ${whereClause}
+        ORDER BY datetime(timestamp) DESC, rowid DESC
+        LIMIT 500
+      )
+      ORDER BY datetime(timestamp) ASC
+    `;
+    const rows = prId ? this.all<LogRow>(sql, prId) : this.all<LogRow>(sql);
 
     return rows.map((row) => ({
       id: row.id,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -250,6 +250,50 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   second.close();
 });
 
+test("SqliteStorage getLogs returns the latest 500 entries in chronological order", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+  const db = createRawDatabase(root);
+
+  try {
+    const pr = await storage.addPR({
+      number: 107,
+      title: "Long log stream",
+      repo: "alex-morgan-o/lolodex",
+      branch: "feature/logs",
+      author: "octocat",
+      url: "https://github.com/alex-morgan-o/lolodex/pull/107",
+      status: "watching",
+      feedbackItems: [],
+      accepted: 0,
+      rejected: 0,
+      flagged: 0,
+      testsPassed: null,
+      lintPassed: null,
+      lastChecked: null,
+    });
+
+    const insert = db.prepare(`
+      INSERT INTO logs (id, pr_id, timestamp, level, phase, message, metadata_json)
+      VALUES (?, ?, ?, 'info', 'agent', ?, NULL)
+    `);
+
+    for (let i = 1; i <= 501; i += 1) {
+      const timestamp = new Date(Date.UTC(2026, 3, 1, 12, 0, i)).toISOString();
+      insert.run(`log-${i}`, pr.id, timestamp, `Log ${i}`);
+    }
+
+    const logs = await storage.getLogs(pr.id);
+
+    assert.equal(logs.length, 500);
+    assert.equal(logs[0]?.message, "Log 2");
+    assert.equal(logs[499]?.message, "Log 501");
+  } finally {
+    db.close();
+    storage.close();
+  }
+});
+
 test("SqliteStorage returns defaults when singleton rows are missing", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
   const storage = new SqliteStorage(root);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -122,6 +122,7 @@ export interface IStorage {
   }): Promise<BackgroundJob | undefined>;
   heartbeatBackgroundJob(id: string, leaseToken: string, heartbeatAt: string, leaseExpiresAt: string): Promise<BackgroundJob | undefined>;
   completeBackgroundJob(id: string, leaseToken: string, completedAt: string): Promise<BackgroundJob | undefined>;
+  retryBackgroundJob(id: string, leaseToken: string, error: string, availableAt: string, updatedAt: string): Promise<BackgroundJob | undefined>;
   failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined>;
   cancelBackgroundJob(id: string, leaseToken: string, error: string | null, completedAt: string): Promise<BackgroundJob | undefined>;
   requeueExpiredBackgroundJobs(now: string): Promise<number>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -166,7 +166,7 @@ export const backgroundJobSchema = z.object({
 });
 export type BackgroundJob = z.infer<typeof backgroundJobSchema>;
 
-export const activityStatusEnum = z.enum(["in_progress", "queued"]);
+export const activityStatusEnum = z.enum(["in_progress", "queued", "failed"]);
 export type ActivityStatus = z.infer<typeof activityStatusEnum>;
 
 export const activityItemSchema = z.object({
@@ -182,10 +182,12 @@ export const activityItemSchema = z.object({
   startedAt: z.string().nullable(),
   updatedAt: z.string(),
   attemptCount: z.number().int().nonnegative(),
+  lastError: z.string().nullable(),
 });
 export type ActivityItem = z.infer<typeof activityItemSchema>;
 
 export const activitySnapshotSchema = z.object({
+  failed: z.array(activityItemSchema),
   inProgress: z.array(activityItemSchema),
   queued: z.array(activityItemSchema),
   generatedAt: z.string(),


### PR DESCRIPTION
## Summary

Addresses the agent failure patterns found in the last-24-hour log review:

- Prevents terminal CI healing sessions from reopening and supersedes active healing sessions when PRs are archived.
- Enforces CI healing retry budgets before launching repair agents.
- Adds durable background job retries and surfaces failed jobs in the activity API/dashboard.
- Returns the latest SQLite logs chronologically and caps verbose docs-diff log output.
- Preserves stderr/stdout in agent failure reasons and treats empty successful agent output as an error.
- Classifies `claude-review` failures as blocked external and rejects deployment healing when agents exit non-zero.

## Verification

- `npm run check`
- `npm run test`
- `npm run build`
- `git diff --check`

## Notes

- The repo-required `claude -p "/simplify ..."` pre-commit review was attempted, but the local process produced no output after roughly two minutes and was stopped. The standard typecheck, server test suite, production build, and whitespace check all pass.