### PR TITLE
[codex] configure agent CLI path detection

### DIFF
--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -3,7 +3,7 @@ import { chmod, copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { evaluateFixNecessityWithAgent, resolveAgent, runCommand } from "./agentRunner";
+import { evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
 
 test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
   const result = await runCommand(
@@ -119,6 +119,41 @@ test("resolveAgent uses the next coding agent when fallback is enabled", async (
     assert.equal(await resolveAgent("claude", { allowFallback: true }), "codex");
   } finally {
     process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolveAgent finds an agent available from the login shell when app PATH is narrow", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-login-shell-agent-"));
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.exe" : "codex",
+  );
+  const fakeShellPath = path.join(tempRoot, "fake-shell");
+  const originalPath = process.env.PATH;
+  const originalShell = process.env.SHELL;
+
+  try {
+    await copyFile(process.execPath, fakeCodexPath);
+    await chmod(fakeCodexPath, 0o755);
+    await writeFile(
+      fakeShellPath,
+      `#!/bin/sh\nif [ "$1" = "-lc" ] && [ "$2" = "command -v codex" ]; then echo "${fakeCodexPath}"; exit 0; fi\nexit 1\n`,
+      "utf8",
+    );
+    await chmod(fakeShellPath, 0o755);
+    process.env.PATH = "/usr/bin:/bin";
+    process.env.SHELL = fakeShellPath;
+
+    assert.equal(await resolveAgent("codex"), "codex");
+    assert.equal(await resolveCommandPath("codex"), fakeCodexPath);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalShell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = originalShell;
+    }
     await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -55,11 +55,41 @@ export function isAgentUnavailableError(error: unknown): boolean {
 }
 
 export async function commandExists(command: string): Promise<boolean> {
+  return (await resolveCommandPath(command)) !== null;
+}
+
+export async function resolveCommandPath(command: string): Promise<string | null> {
+  if (!/^[A-Za-z0-9._-]+$/.test(command)) {
+    return null;
+  }
+
   const result = await runCommand("which", [command], {
     timeoutMs: 4000,
   });
 
-  return result.code === 0;
+  const pathFromCurrentEnv = firstOutputLine(result.stdout);
+  if (result.code === 0 && pathFromCurrentEnv) {
+    return pathFromCurrentEnv;
+  }
+
+  const shell = process.env.SHELL || "/bin/zsh";
+  const shellResult = await runCommand(shell, ["-lc", `command -v ${command}`], {
+    timeoutMs: 4000,
+  });
+  const pathFromLoginShell = firstOutputLine(shellResult.stdout);
+  if (shellResult.code === 0 && pathFromLoginShell) {
+    return pathFromLoginShell;
+  }
+
+  return null;
+}
+
+export async function runAgentCommand(
+  agent: CodingAgent,
+  args: string[],
+  options?: Parameters<typeof runCommand>[2],
+): Promise<CommandResult> {
+  return runCommand((await resolveCommandPath(agent)) ?? agent, args, options);
 }
 
 export async function resolveAgent(
@@ -97,7 +127,7 @@ export async function checkAgentHealth(agent: CodingAgent): Promise<AgentHealthR
 
   const prompt = "Respond with exactly: ok";
   const result = agent === "codex"
-    ? await runCommand(
+    ? await runAgentCommand(
         "codex",
         [
           "exec",
@@ -108,7 +138,7 @@ export async function checkAgentHealth(agent: CodingAgent): Promise<AgentHealthR
         ],
         { timeoutMs: 30000 },
       )
-    : await runCommand(
+    : await runAgentCommand(
         "claude",
         [
           "-p",
@@ -145,7 +175,7 @@ export async function evaluateFixNecessityWithAgent(params: {
     const outputFile = path.join(tempDir, "output.txt");
 
     try {
-      const result = await runCommand(
+      const result = await runAgentCommand(
         "codex",
         [
           "exec",
@@ -189,7 +219,7 @@ export async function evaluateFixNecessityWithAgent(params: {
     extractionPrompt,
   ];
 
-  const result = await runCommand(
+  const result = await runAgentCommand(
     "claude",
     claudeArgs,
     { cwd, timeoutMs: 180000 },
@@ -213,7 +243,7 @@ export async function applyFixesWithAgent(params: {
   const { agent, cwd, prompt, env, onStdoutChunk, onStderrChunk } = params;
 
   if (agent === "codex") {
-    const result = await runCommand(
+    const result = await runAgentCommand(
       "codex",
       [
         "exec",
@@ -229,7 +259,7 @@ export async function applyFixesWithAgent(params: {
     return result;
   }
 
-  return runCommand(
+  return runAgentCommand(
     "claude",
     [
       "-p",
@@ -287,6 +317,14 @@ function tryParseJsonFromText(text: string): unknown {
 
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function firstOutputLine(output: string): string | null {
+  const line = output
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .find(Boolean);
+  return line ?? null;
 }
 
 function summarizeHealthFailure(result: CommandResult): string {

--- a/server/prQuestionAgent.ts
+++ b/server/prQuestionAgent.ts
@@ -1,6 +1,6 @@
 import type { IStorage } from "./storage";
 import type { CodingAgent } from "./agentRunner";
-import { resolveAgent, runCommand, summarizeCommandResult } from "./agentRunner";
+import { resolveAgent, runAgentCommand, summarizeCommandResult } from "./agentRunner";
 
 /**
  * Answers a user question about a PR by gathering context (PR state, feedback,
@@ -22,7 +22,7 @@ export async function answerPRQuestion(params: {
     const agent = await resolveAgent(preferredAgent);
     const prompt = buildPrompt(context, question);
 
-    const result = await runCommand(
+    const result = await runAgentCommand(
       agent,
       agent === "claude"
         ? ["-p", "--output-format", "text", prompt]

--- a/server/releaseAgent.ts
+++ b/server/releaseAgent.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { resolveAgent, runCommand, type CodingAgent } from "./agentRunner";
+import { resolveAgent, runAgentCommand, type CodingAgent } from "./agentRunner";
 
 const DEFAULT_RELEASE_AGENT_TIMEOUT_MS = 120_000;
 
@@ -45,7 +45,7 @@ export async function evaluateReleaseWorthinessWithAgent(params: {
     const outputFile = path.join(tempDir, "output.txt");
 
     try {
-      const result = await runCommand(
+      const result = await runAgentCommand(
         "codex",
         [
           "exec",
@@ -70,7 +70,7 @@ export async function evaluateReleaseWorthinessWithAgent(params: {
     }
   }
 
-  const result = await runCommand(
+  const result = await runAgentCommand(
     "claude",
     [
       "-p",


### PR DESCRIPTION
## Summary
- add persisted Codex and Claude absolute path settings and expose them in Settings and onboarding
- prefer configured agent paths before PATH, known install locations, or shell probing
- pass configured paths through babysitter runs, PR questions, releases, CI healing, and deployment healing
- suppress stale agent CLI warnings once a newer babysitter rerun exists for the same PR
- keep best-effort detection for common local installs, including nvm-backed Codex

## Root cause
The app previously treated the server or GUI process PATH as authoritative. That can miss CLIs installed through shell-managed environments such as nvm, and no heuristic can cover every user setup. Failed babysitter jobs also stayed in activity history, so an old Codex CLI failure could keep rendering as an active warning after a rerun was queued.

## User impact
Users can now set exact Codex and Claude executable paths when local environment detection is wrong. The dashboard warning should represent the latest babysitter state for a PR instead of resurfacing an older agent availability failure.

## Verification
- node --import tsx --test server/agentRunner.test.ts server/routes.test.ts
- npm run check
- npm run test
- npm run build