### PR TITLE
Add GitHub progress reply setting

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -409,6 +409,27 @@ export default function Settings() {
                 />
               </div>
 
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm">GitHub progress replies</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Post public Accepted/running/completed status replies while the babysitter works on review comments.
+                  </div>
+                </div>
+                <input
+                  type="checkbox"
+                  aria-label="GitHub progress replies"
+                  checked={config?.postGitHubProgressReplies ?? false}
+                  onChange={(e) =>
+                    updateConfigMutation.mutate({
+                      postGitHubProgressReplies: e.target.checked,
+                    })
+                  }
+                  disabled={updateConfigMutation.isPending}
+                  className="h-4 w-4 accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                />
+              </div>
+
               <div>
                 <div className="text-sm">Trusted reviewers</div>
                 <div className="text-[11px] text-muted-foreground">

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -224,6 +224,7 @@
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
+<li><strong>GitHub progress replies</strong> — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.</li>
 <li><strong>CI healing</strong> — Enable autonomous CI repair and tune retry/session limits.</li>
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>
 <li><strong>Theme</strong> — Toggle between light and dark mode.</li>
@@ -285,8 +286,13 @@ release check fails, the banner stays hidden and the API falls back quietly.</p>
 <td><code>true</code></td>
 <td>When enabled, babysitter comments render the app name as a Markdown link to the oh-my-pr repo and append the <code>Posted by oh-my-pr</code> footer. When disabled, comments reference <code>oh-my-pr</code> as plain text and omit the footer.</td>
 </tr>
+<tr>
+<td><code>GitHub progress replies</code></td>
+<td><code>false</code></td>
+<td>When enabled, the babysitter posts public status replies on accepted review feedback as it moves from queued to running, completed, and resolved. When disabled, it still posts the final follow-up reply without intermediate public progress updates.</td>
+</tr>
 </tbody></table>
-<p>This toggle is available in the dashboard settings page and as <code>includeRepositoryLinksInGitHubComments</code> (boolean) in <code>GET /api/config</code>, <code>PATCH /api/config</code>, and the MCP <code>update_config</code> tool. Turning it off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.</p>
+<p>These toggles are available in the dashboard settings page and as <code>includeRepositoryLinksInGitHubComments</code> plus <code>postGitHubProgressReplies</code> (booleans) in <code>GET /api/config</code>, <code>PATCH /api/config</code>, and the MCP <code>update_config</code> tool. Turning repository links off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.</p>
 <h2>CI Healing Settings</h2>
 <p>oh-my-pr can track failing CI checks as first-class healing sessions and, when enabled, dispatch bounded repair attempts in isolated worktrees.</p>
 <table>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -46,6 +46,7 @@ The settings page in the dashboard provides a UI for:
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
+- **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
 - **Theme** — Toggle between light and dark mode.
@@ -91,8 +92,9 @@ Agent-authored GitHub PR comments posted by the babysitter — follow-up replies
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `Repository links in PR comments` | `true` | When enabled, babysitter comments render the app name as a Markdown link to the oh-my-pr repo and append the `Posted by oh-my-pr` footer. When disabled, comments reference `oh-my-pr` as plain text and omit the footer. |
+| `GitHub progress replies` | `false` | When enabled, the babysitter posts public status replies on accepted review feedback as it moves from queued to running, completed, and resolved. When disabled, it still posts the final follow-up reply without intermediate public progress updates. |
 
-This toggle is available in the dashboard settings page and as `includeRepositoryLinksInGitHubComments` (boolean) in `GET /api/config`, `PATCH /api/config`, and the MCP `update_config` tool. Turning it off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.
+These toggles are available in the dashboard settings page and as `includeRepositoryLinksInGitHubComments` plus `postGitHubProgressReplies` (booleans) in `GET /api/config`, `PATCH /api/config`, and the MCP `update_config` tool. Turning repository links off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.
 
 ## CI Healing Settings
 

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -140,16 +140,19 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
     codingAgent: "codex",
     autoUpdateDocs: false,
     includeRepositoryLinksInGitHubComments: false,
+    postGitHubProgressReplies: true,
   });
 
   assert.equal(updated.codingAgent, "codex");
   assert.equal(updated.autoUpdateDocs, false);
   assert.equal(updated.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(updated.postGitHubProgressReplies, true);
 
   const config = await runtime.getConfig();
   assert.equal(config.codingAgent, "codex");
   assert.equal(config.autoUpdateDocs, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(config.postGitHubProgressReplies, true);
 });
 
 test("runtime release adapter skips merged PRs without a merge commit SHA", () => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -1658,18 +1658,8 @@ test("babysitPR omits repository links in GitHub comments when disabled", async 
 
     await babysitter.babysitPR(pr.id, "codex");
 
-    const expectedAcceptedStatus = "\u23f3 **Accepted** \u2014 this comment requires code changes. Queuing fix...";
-    const expectedFinalStatusBody = [
-      expectedAcceptedStatus,
-      "\ud83e\uddf0 **Agent running** \u2014 `codex` is working on the fix...",
-      "\u2705 **Agent completed** \u2014 verifying changes...",
-      "\ud83c\udf89 **Resolved** \u2014 addressed in commit `def456`.",
-    ].join("\n");
-
-    assert.deepEqual(initialStatusBodies, [
-      { id: existingItem.id, body: expectedAcceptedStatus },
-    ]);
-    assert.equal(statusReplyRefs.get(existingItem.id)?.body, expectedFinalStatusBody);
+    assert.deepEqual(initialStatusBodies, []);
+    assert.equal(statusReplyRefs.has(existingItem.id), false);
     assert.deepEqual(postedFollowUps, [
       {
         id: "gh-review-comment-1",
@@ -1685,7 +1675,7 @@ test("babysitPR omits repository links in GitHub comments when disabled", async 
   }
 });
 
-test("babysitPR centralizes status replies, logs best-effort failures, and updates replies in parallel", async () => {
+test("babysitPR keeps acceptance local and logs best-effort reaction failures", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoUpdateDocs: false });
   const firstItem = makeFeedbackItem();
@@ -1828,6 +1818,125 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
     await babysitter.babysitPR(pr.id, "codex");
 
     const logs = await storage.getLogs(pr.id);
+    assert.deepEqual(initialStatusBodies, []);
+    assert.equal(statusReplyRefs.size, 0);
+    assert.equal(maxConcurrentStatusUpdates, 0);
+    assert.ok(
+      logs.some((log) => {
+        return log.phase === "github.reaction"
+          && log.message.includes("Failed to add reaction for gh-review-comment-1: reaction endpoint unavailable");
+      }),
+    );
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR posts progress replies when GitHub progress replies are enabled", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoUpdateDocs: false,
+    postGitHubProgressReplies: true,
+  });
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    let feedbackFetchCount = 0;
+    const initialStatusBodies: Array<{ id: string; body: string }> = [];
+    const statusReplyRefs = new Map<
+      string,
+      { commentDatabaseId: number; replyKind: FeedbackItem["replyKind"]; body: string }
+    >();
+    const pullSummary = makePullSummary(pr);
+    const followUp = makeFeedbackItem({
+      id: "gh-review-comment-2",
+      author: "code-factory",
+      body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+      bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+      sourceId: "2",
+      sourceNodeId: "PRRC_kwDO_followup",
+      sourceUrl: "https://github.com/octo/example/pull/42#discussion_r2",
+      threadId: existingItem.threadId,
+      threadResolved: true,
+      createdAt: new Date().toISOString(),
+      decision: null,
+      decisionReason: null,
+      action: null,
+    });
+
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => {
+          feedbackFetchCount += 1;
+          return feedbackFetchCount === 1
+            ? [existingItem]
+            : [{ ...existingItem, threadResolved: true }, followUp];
+        },
+        fetchPullSummary: async () => pullSummary,
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postPRComment: async () => undefined,
+        postStatusReplyForFeedbackItem: async (_octokit, _parsed, item, body) => {
+          initialStatusBodies.push({ id: item.id, body });
+          const ref = {
+            commentDatabaseId: Number(item.sourceId),
+            replyKind: item.replyKind,
+            body,
+          };
+          statusReplyRefs.set(item.id, ref);
+          return ref;
+        },
+        updateStatusReply: async (_octokit, _parsed, ref, body) => {
+          ref.body = body;
+        },
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => ({
+          needsFix: true,
+          reason: "Comment requires a code change",
+        }),
+        applyFixesWithAgent: async () => ({
+          code: 0,
+          stdout: "",
+          stderr: "",
+        }),
+        runCommand: makeGitRunCommand({
+          localHeadSha: "def456",
+          remoteHeadSha: "def456",
+        }),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
     const expectedAcceptedLine = "\u23f3 **Accepted** \u2014 this comment requires code changes. Queuing fix...";
     const expectedAcceptedStatus = `${expectedAcceptedLine}\n\n${APP_COMMENT_FOOTER}`;
     const expectedFinalStatusBody = [
@@ -1840,24 +1949,15 @@ test("babysitPR centralizes status replies, logs best-effort failures, and updat
     ].join("\n");
 
     assert.deepEqual(initialStatusBodies, [
-      { id: firstItem.id, body: expectedAcceptedStatus },
-      { id: secondItem.id, body: expectedAcceptedStatus },
+      { id: existingItem.id, body: expectedAcceptedStatus },
     ]);
-    assert.equal(statusReplyRefs.get(firstItem.id)?.body, expectedFinalStatusBody);
-    assert.equal(statusReplyRefs.get(secondItem.id)?.body, expectedFinalStatusBody);
-    assert.ok(maxConcurrentStatusUpdates >= 2);
-    assert.ok(
-      logs.some((log) => {
-        return log.phase === "github.reaction"
-          && log.message.includes("Failed to add reaction for gh-review-comment-1: reaction endpoint unavailable");
-      }),
-    );
+    assert.equal(statusReplyRefs.get(existingItem.id)?.body, expectedFinalStatusBody);
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }
 });
 
-test("babysitPR posts a concise GitHub status reason when the agent fails to address feedback", async () => {
+test("babysitPR marks feedback failed without posting GitHub status when the agent fails", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoUpdateDocs: false });
   const existingItem = makeFeedbackItem();
@@ -1883,7 +1983,7 @@ test("babysitPR posts a concise GitHub status reason when the agent fails to add
 
   try {
     const pullSummary = makePullSummary(pr);
-    let latestStatusReplyBody = "";
+    let postedStatusReplies = 0;
     let postedFollowUps = 0;
 
     const babysitter = new PRBabysitter(
@@ -1901,14 +2001,11 @@ test("babysitPR posts a concise GitHub status reason when the agent fails to add
         resolveReviewThread: async () => undefined,
         resolveGitHubAuthToken: async () => "test-token",
         addReactionToComment: async () => {},
-        postStatusReplyForFeedbackItem: async (_octokit, _parsed, item, body) => {
-          latestStatusReplyBody = body;
-          return { commentDatabaseId: 55, replyKind: item.replyKind, body };
+        postStatusReplyForFeedbackItem: async () => {
+          postedStatusReplies += 1;
+          return null;
         },
-        updateStatusReply: async (_octokit, _parsed, ref, body) => {
-          ref.body = body;
-          latestStatusReplyBody = body;
-        },
+        updateStatusReply: async () => {},
       },
       {
         resolveAgent: async () => "codex",
@@ -1933,8 +2030,7 @@ test("babysitPR posts a concise GitHub status reason when the agent fails to add
 
     assert.equal(failedItem?.status, "failed");
     assert.equal(postedFollowUps, 0);
-    assert.match(latestStatusReplyBody, /\u274c \*\*Agent failed\*\* \u2014 TypeScript check failed\./);
-    assert.doesNotMatch(latestStatusReplyBody, /stack trace line/);
+    assert.equal(postedStatusReplies, 0);
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -2036,6 +2036,94 @@ test("babysitPR marks feedback failed without posting GitHub status when the age
   }
 });
 
+test("babysitPR includes the agent name in failed GitHub progress replies", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoUpdateDocs: false,
+    postGitHubProgressReplies: true,
+  });
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const statusReplyRefs = new Map<
+      string,
+      { commentDatabaseId: number; replyKind: FeedbackItem["replyKind"]; body: string }
+    >();
+    const pullSummary = makePullSummary(pr);
+
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [existingItem],
+        fetchPullSummary: async () => pullSummary,
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async (_octokit, _parsed, item, body) => {
+          const ref = {
+            commentDatabaseId: Number(item.sourceId),
+            replyKind: item.replyKind,
+            body,
+          };
+          statusReplyRefs.set(item.id, ref);
+          return ref;
+        },
+        updateStatusReply: async (_octokit, _parsed, ref, body) => {
+          ref.body = body;
+        },
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => ({
+          needsFix: true,
+          reason: "Comment requires a code change",
+        }),
+        applyFixesWithAgent: async () => ({
+          code: 1,
+          stdout: "",
+          stderr: "TypeScript check failed\nstack trace line that should stay out of the GitHub status reply",
+        }),
+        runCommand: makeGitRunCommand(),
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const body = statusReplyRefs.get(existingItem.id)?.body ?? "";
+    assert.match(
+      body,
+      /\u274c \*\*Agent failed\*\* \u2014 `codex` exited with an error: TypeScript check failed/,
+    );
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
 test("babysitPR marks the run as error when app-owned GitHub follow-up fails", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoUpdateDocs: false });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -2109,9 +2109,9 @@ export class PRBabysitter {
         }
       }
 
-      // Track status reply comments so we can update them with progress.
-      const statusReplies = new Map<string, StatusReplyRef>();
       const includeRepositoryLinksInGitHubComments = config.includeRepositoryLinksInGitHubComments;
+      const postGitHubProgressReplies = config.postGitHubProgressReplies;
+      const statusReplies = new Map<string, StatusReplyRef>();
       const updateItemStatus = async (feedbackId: string, line: string) => {
         const ref = statusReplies.get(feedbackId);
         if (!ref) return;
@@ -2253,25 +2253,27 @@ export class PRBabysitter {
             );
           }
 
-          // Post an initial status reply so the reviewer sees progress.
-          try {
-            const ref = await this.github.postStatusReplyForFeedbackItem(
-              octokit,
-              parsedPr,
-              item,
-              withOptionalAppCommentFooter(STATUS_MESSAGES.accepted, includeRepositoryLinksInGitHubComments),
-            );
-            if (ref) {
-              statusReplies.set(item.id, ref);
+          if (postGitHubProgressReplies) {
+            try {
+              const ref = await this.github.postStatusReplyForFeedbackItem(
+                octokit,
+                parsedPr,
+                item,
+                withOptionalAppCommentFooter(STATUS_MESSAGES.accepted, includeRepositoryLinksInGitHubComments),
+              );
+              if (ref) {
+                statusReplies.set(item.id, ref);
+              }
+            } catch (error) {
+              await logBestEffortFailure(
+                pr.id,
+                "github.status",
+                `Failed to post status reply for ${item.id}: ${summarizeUnknownError(error)}`,
+                { feedbackId: item.id },
+              );
             }
-          } catch (error) {
-            await logBestEffortFailure(
-              pr.id,
-              "github.status",
-              `Failed to post status reply for ${item.id}: ${summarizeUnknownError(error)}`,
-              { feedbackId: item.id },
-            );
           }
+
         } else {
           await queueLog(pr.id, "info", `Rejected feedback ${item.id}: ${evaluation.reason}`, {
             phase: "evaluate.comments",
@@ -2856,9 +2858,10 @@ export class PRBabysitter {
             // Post agent command to GitHub PR as a comment for debugging visibility.
             await postAgentCommandComment(agent, fixPrompt);
 
-            // Update status replies: agent is starting.
-            const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
-            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
+            if (postGitHubProgressReplies) {
+              const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
+              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
+            }
 
             const applyResult = await applyWithCurrentAgent({
               cwd: worktreePath,
@@ -2868,6 +2871,7 @@ export class PRBabysitter {
               onStderrChunk: agentStderr.onChunk,
               phase: "agent",
               onFallback: async (fallbackAgent) => {
+                if (!postGitHubProgressReplies) return;
                 const fallbackStatus = STATUS_MESSAGES.agentRunning(fallbackAgent);
                 await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, fallbackStatus)));
               },
@@ -2876,14 +2880,16 @@ export class PRBabysitter {
             await agentStderr.flush();
 
             if (applyResult.code !== 0) {
-              // Update status replies on failure.
               const failureReason = formatConciseFailureReason(applyResult.stderr || applyResult.stdout);
-              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed(failureReason))));
+              if (postGitHubProgressReplies) {
+                await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed(failureReason))));
+              }
               throw new Error(`${agent} apply failed (${applyResult.code}): ${failureReason}`);
             }
 
-            // Update status replies: agent succeeded.
-            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
+            if (postGitHubProgressReplies) {
+              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
+            }
 
             // Extract per-feedback-item summaries from agent output.
             agentSummaries = extractAgentSummaries(applyResult.stdout);
@@ -3226,8 +3232,9 @@ export class PRBabysitter {
           },
         });
 
-        // Final status update on the progress reply.
-        await updateItemStatus(item.id, STATUS_MESSAGES.resolved(headShaForFollowUp));
+        if (postGitHubProgressReplies) {
+          await updateItemStatus(item.id, STATUS_MESSAGES.resolved(headShaForFollowUp));
+        }
       }
 
       pr = await this.syncFeedbackForPR(pr.id, {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -158,9 +158,9 @@ const defaultBabysitterRuntime: BabysitterRuntime = {
 const STATUS_MESSAGES = {
   accepted: "\u23f3 **Accepted** — this comment requires code changes. Queuing fix...",
   agentRunning: (agent: CodingAgent) => `\ud83e\uddf0 **Agent running** — \`${agent}\` is working on the fix...`,
-  agentFailed: (reason?: string) => reason
-    ? `\u274c **Agent failed** — ${reason}`
-    : "\u274c **Agent failed** — the coding agent exited with an error.",
+  agentFailed: (agent: CodingAgent, reason?: string) => reason
+    ? `\u274c **Agent failed** — \`${agent}\` exited with an error: ${reason}`
+    : `\u274c **Agent failed** — \`${agent}\` exited with an error.`,
   agentCompleted: "\u2705 **Agent completed** — verifying changes...",
   resolved: (headSha: string) => {
     const shortSha = headSha.trim().slice(0, 7);
@@ -2111,6 +2111,7 @@ export class PRBabysitter {
 
       const includeRepositoryLinksInGitHubComments = config.includeRepositoryLinksInGitHubComments;
       const postGitHubProgressReplies = config.postGitHubProgressReplies;
+      // Track status reply comments so we can update them with progress.
       const statusReplies = new Map<string, StatusReplyRef>();
       const updateItemStatus = async (feedbackId: string, line: string) => {
         const ref = statusReplies.get(feedbackId);
@@ -2858,10 +2859,8 @@ export class PRBabysitter {
             // Post agent command to GitHub PR as a comment for debugging visibility.
             await postAgentCommandComment(agent, fixPrompt);
 
-            if (postGitHubProgressReplies) {
-              const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
-              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
-            }
+            const agentRunningStatus = STATUS_MESSAGES.agentRunning(agent);
+            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, agentRunningStatus)));
 
             const applyResult = await applyWithCurrentAgent({
               cwd: worktreePath,
@@ -2871,7 +2870,6 @@ export class PRBabysitter {
               onStderrChunk: agentStderr.onChunk,
               phase: "agent",
               onFallback: async (fallbackAgent) => {
-                if (!postGitHubProgressReplies) return;
                 const fallbackStatus = STATUS_MESSAGES.agentRunning(fallbackAgent);
                 await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, fallbackStatus)));
               },
@@ -2881,15 +2879,11 @@ export class PRBabysitter {
 
             if (applyResult.code !== 0) {
               const failureReason = formatConciseFailureReason(applyResult.stderr || applyResult.stdout);
-              if (postGitHubProgressReplies) {
-                await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed(failureReason))));
-              }
+              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentFailed(agent, failureReason))));
               throw new Error(`${agent} apply failed (${applyResult.code}): ${failureReason}`);
             }
 
-            if (postGitHubProgressReplies) {
-              await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
-            }
+            await Promise.all(effectiveCommentTasks.map((task) => updateItemStatus(task.id, STATUS_MESSAGES.agentCompleted)));
 
             // Extract per-feedback-item summaries from agent output.
             agentSummaries = extractAgentSummaries(applyResult.stdout);
@@ -3232,9 +3226,7 @@ export class PRBabysitter {
           },
         });
 
-        if (postGitHubProgressReplies) {
-          await updateItemStatus(item.id, STATUS_MESSAGES.resolved(headShaForFollowUp));
-        }
+        await updateItemStatus(item.id, STATUS_MESSAGES.resolved(headShaForFollowUp));
       }
 
       pr = await this.syncFeedbackForPR(pr.id, {

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -29,6 +29,7 @@ describe("DEFAULT_CONFIG", () => {
       "autoCreateReleases",
       "autoUpdateDocs",
       "includeRepositoryLinksInGitHubComments",
+      "postGitHubProgressReplies",
       "autoHealCI",
       "maxHealingAttemptsPerSession",
       "maxHealingAttemptsPerFingerprint",
@@ -121,6 +122,10 @@ describe("DEFAULT_CONFIG", () => {
 
   it("includes repository links in GitHub comments by default", () => {
     assert.equal(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments, true);
+  });
+
+  it("does not post GitHub progress replies by default", () => {
+    assert.equal(DEFAULT_CONFIG.postGitHubProgressReplies, false);
   });
 
   it("includes deployment-healing defaults", () => {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CONFIG: Config = {
   autoCreateReleases: true,
   autoUpdateDocs: true,
   includeRepositoryLinksInGitHubComments: true,
+  postGitHubProgressReplies: false,
   autoHealCI: false,
   maxHealingAttemptsPerSession: 3,
   maxHealingAttemptsPerFingerprint: 2,

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -41,6 +41,7 @@ const config: Config = {
   autoCreateReleases: true,
   autoUpdateDocs: true,
   includeRepositoryLinksInGitHubComments: true,
+  postGitHubProgressReplies: false,
   autoHealCI: false,
   maxHealingAttemptsPerSession: 3,
   maxHealingAttemptsPerFingerprint: 2,

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -311,7 +311,7 @@ const TOOLS: Tool[] = [
       "Partially update oh-my-pr configuration. All fields are optional; only provided " +
       "fields are changed. Available fields: githubTokens, githubToken (legacy), codingAgent, maxTurns, " +
       "fallbackToNextCodingAgent, batchWindowMs, pollIntervalMs, maxChangesPerRun, autoResolveMergeConflicts, autoUpdateDocs, " +
-      "includeRepositoryLinksInGitHubComments, " +
+      "includeRepositoryLinksInGitHubComments, postGitHubProgressReplies, " +
       "watchedRepos, trustedReviewers, ignoredBots.",
     inputSchema: {
       type: "object",
@@ -327,6 +327,7 @@ const TOOLS: Tool[] = [
         autoResolveMergeConflicts: { type: "boolean" },
         autoUpdateDocs: { type: "boolean" },
         includeRepositoryLinksInGitHubComments: { type: "boolean" },
+        postGitHubProgressReplies: { type: "boolean" },
         watchedRepos: { type: "array", items: { type: "string" } },
         trustedReviewers: { type: "array", items: { type: "string" } },
         ignoredBots: { type: "array", items: { type: "string" } },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -426,6 +426,7 @@ describe("MemStorage", () => {
         config.includeRepositoryLinksInGitHubComments,
         DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments,
       );
+      assert.equal(config.postGitHubProgressReplies, DEFAULT_CONFIG.postGitHubProgressReplies);
       assert.equal(config.autoHealCI, DEFAULT_CONFIG.autoHealCI);
       assert.equal(config.maxHealingAttemptsPerSession, DEFAULT_CONFIG.maxHealingAttemptsPerSession);
       assert.equal(config.maxHealingAttemptsPerFingerprint, DEFAULT_CONFIG.maxHealingAttemptsPerFingerprint);
@@ -444,6 +445,7 @@ describe("MemStorage", () => {
       assert.equal(updated.fallbackToNextCodingAgent, false);
       assert.equal(updated.autoUpdateDocs, true);
       assert.equal(updated.includeRepositoryLinksInGitHubComments, true);
+      assert.equal(updated.postGitHubProgressReplies, false);
       assert.equal(updated.autoCreateReleases, true);
       assert.equal(updated.autoHealCI, false);
       assert.equal(updated.maxHealingAttemptsPerSession, 3);
@@ -453,6 +455,7 @@ describe("MemStorage", () => {
       const updated = await storage.updateConfig({
         githubTokens: ["tok_123", "tok_456"],
         includeRepositoryLinksInGitHubComments: false,
+        postGitHubProgressReplies: true,
         autoHealCI: true,
         maxHealingAttemptsPerSession: 5,
         maxHealingAttemptsPerFingerprint: 4,
@@ -462,6 +465,7 @@ describe("MemStorage", () => {
       const fetched = await storage.getConfig();
       assert.deepEqual(updated, fetched);
       assert.deepEqual(fetched.githubTokens, ["tok_123", "tok_456"]);
+      assert.equal(fetched.postGitHubProgressReplies, true);
     });
   });
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -71,6 +71,7 @@ type ConfigRow = {
   auto_create_releases: number;
   auto_update_docs: number;
   include_repository_links_in_github_comments: number;
+  post_github_progress_replies: number;
   auto_heal_ci: number;
   max_healing_attempts_per_session: number;
   max_healing_attempts_per_fingerprint: number;
@@ -503,6 +504,7 @@ export class SqliteStorage implements IStorage {
         auto_create_releases INTEGER NOT NULL DEFAULT 1,
         auto_update_docs INTEGER NOT NULL DEFAULT 1,
         include_repository_links_in_github_comments INTEGER NOT NULL DEFAULT 1,
+        post_github_progress_replies INTEGER NOT NULL DEFAULT 0,
         auto_heal_ci INTEGER NOT NULL DEFAULT 0,
         max_healing_attempts_per_session INTEGER NOT NULL DEFAULT 3,
         max_healing_attempts_per_fingerprint INTEGER NOT NULL DEFAULT 2,
@@ -794,6 +796,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "include_repository_links_in_github_comments", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "post_github_progress_replies", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_heal_ci", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "max_healing_attempts_per_session", "INTEGER NOT NULL DEFAULT 3");
     this.ensureColumn("config", "max_healing_attempts_per_fingerprint", "INTEGER NOT NULL DEFAULT 2");
@@ -864,6 +867,9 @@ export class SqliteStorage implements IStorage {
       includeRepositoryLinksInGitHubComments: Boolean(
         row.include_repository_links_in_github_comments ?? Number(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments),
       ),
+      postGitHubProgressReplies: Boolean(
+        row.post_github_progress_replies ?? Number(DEFAULT_CONFIG.postGitHubProgressReplies),
+      ),
       autoHealCI: Boolean(row.auto_heal_ci ?? Number(DEFAULT_CONFIG.autoHealCI)),
       maxHealingAttemptsPerSession: row.max_healing_attempts_per_session ?? DEFAULT_CONFIG.maxHealingAttemptsPerSession,
       maxHealingAttemptsPerFingerprint: row.max_healing_attempts_per_fingerprint ?? DEFAULT_CONFIG.maxHealingAttemptsPerFingerprint,
@@ -904,6 +910,7 @@ export class SqliteStorage implements IStorage {
           auto_create_releases,
           auto_update_docs,
           include_repository_links_in_github_comments,
+          post_github_progress_replies,
           auto_heal_ci,
           max_healing_attempts_per_session,
           max_healing_attempts_per_fingerprint,
@@ -915,7 +922,7 @@ export class SqliteStorage implements IStorage {
           deployment_check_poll_interval_ms,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -930,6 +937,7 @@ export class SqliteStorage implements IStorage {
           auto_create_releases = excluded.auto_create_releases,
           auto_update_docs = excluded.auto_update_docs,
           include_repository_links_in_github_comments = excluded.include_repository_links_in_github_comments,
+          post_github_progress_replies = excluded.post_github_progress_replies,
           auto_heal_ci = excluded.auto_heal_ci,
           max_healing_attempts_per_session = excluded.max_healing_attempts_per_session,
           max_healing_attempts_per_fingerprint = excluded.max_healing_attempts_per_fingerprint,
@@ -956,6 +964,7 @@ export class SqliteStorage implements IStorage {
         Number(config.autoCreateReleases),
         Number(config.autoUpdateDocs),
         Number(config.includeRepositoryLinksInGitHubComments),
+        Number(config.postGitHubProgressReplies),
         Number(config.autoHealCI),
         config.maxHealingAttemptsPerSession,
         config.maxHealingAttemptsPerFingerprint,
@@ -1555,7 +1564,8 @@ export class SqliteStorage implements IStorage {
     const row = this.get<ConfigRow>(`
       SELECT github_token, github_tokens_json, coding_agent, fallback_to_next_coding_agent, model, max_turns, batch_window_ms,
              poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
-             auto_update_docs, include_repository_links_in_github_comments, auto_heal_ci, max_healing_attempts_per_session,
+             auto_update_docs, include_repository_links_in_github_comments, post_github_progress_replies,
+             auto_heal_ci, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,
              deployment_check_poll_interval_ms, trusted_reviewers_json, ignored_bots_json

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -80,6 +80,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     autoCreateReleases: false,
     autoUpdateDocs: false,
     includeRepositoryLinksInGitHubComments: false,
+    postGitHubProgressReplies: true,
     autoHealCI: true,
     maxHealingAttemptsPerSession: 5,
     maxHealingAttemptsPerFingerprint: 4,
@@ -211,6 +212,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(config.autoCreateReleases, false);
   assert.equal(config.autoUpdateDocs, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(config.postGitHubProgressReplies, true);
   assert.equal(config.autoHealCI, true);
   assert.equal(config.maxHealingAttemptsPerSession, 5);
   assert.equal(config.maxHealingAttemptsPerFingerprint, 4);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -449,6 +449,7 @@ export const configSchema = z.object({
   autoCreateReleases: z.boolean(),
   autoUpdateDocs: z.boolean(),
   includeRepositoryLinksInGitHubComments: z.boolean(),
+  postGitHubProgressReplies: z.boolean(),
   autoHealCI: z.boolean(),
   maxHealingAttemptsPerSession: z.number(),
   maxHealingAttemptsPerFingerprint: z.number(),

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-04-30 - Keep speculative automation acknowledgements local
+- Pattern: The babysitter posted "Accepted" progress replies on GitHub for every accepted review comment, which surprised teammates because triage acknowledgements looked like public conversation from the user before a fix existed.
+- Rule: In `oh-my-pr`, only post GitHub replies when there is a concrete command, result, audit trail, or thread-resolution outcome to expose; keep speculative triage/progress acknowledgements in local logs unless the user explicitly opts into public progress chatter in Settings.
+- Prevention checklist:
+  - Before adding or preserving automated GitHub comments, classify whether the comment is an audit/result or only a status acknowledgement.
+  - Prefer local logs and dashboard state for noisy intermediate automation progress.
+  - Regression-test both default-off and opt-in enabled behavior for any outward-facing automation comment setting.
+
 ## 2026-04-28 - Make agent recovery opt-in and settings-visible
 - Pattern: A request to surface coding-agent auth failures expanded into fallback behavior, and the user had to specify that fallback should be configurable, settings-visible, and disabled by default.
 - Rule: When adding automatic recovery behavior that can switch execution tools or change operator intent, make it opt-in unless the user explicitly asks for always-on automation.


### PR DESCRIPTION
## Summary
- Add a Settings toggle for public GitHub progress replies during babysitter runs
- Default the setting off so accepted triage stays local unless explicitly enabled
- Thread the config through schema, persistence, MCP updates, and babysitter behavior
- Update tests to cover default-off and opt-in enabled behavior

## Testing
- `node --test --import tsx server/defaultConfig.test.ts server/memoryStorage.test.ts server/storage.test.ts server/babysitter.test.ts server/appRuntime.test.ts`
- `node --test --import tsx server/*.test.ts`
- `npm run check`
- `npm run build`