### PR TITLE
feat: make ignored bots field editable on Settings page

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -418,17 +418,104 @@ export default function Settings() {
                 </div>
               </div>
 
-              <div>
-                <div className="text-sm">Ignored bots</div>
-                <div className="text-[11px] text-muted-foreground">
-                  {config?.ignoredBots?.length
-                    ? config.ignoredBots.join(", ")
-                    : "none configured"}
-                </div>
-              </div>
+              <StringListRow
+                label="Ignored bots"
+                description="Bot logins whose comments and reviews are ignored."
+                placeholder="dependabot[bot]"
+                values={config?.ignoredBots ?? []}
+                onChange={(next) => updateConfigMutation.mutate({ ignoredBots: next })}
+                disabled={!config || updateConfigMutation.isPending}
+              />
             </div>
           </section>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function StringListRow({
+  label,
+  description,
+  placeholder,
+  values,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  description: string;
+  placeholder: string;
+  values: string[];
+  onChange: (next: string[]) => void;
+  disabled: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const addValue = () => {
+    const trimmed = draft.trim();
+    const lowered = trimmed.toLowerCase();
+    if (!trimmed || values.some((v) => v.toLowerCase() === lowered)) {
+      setDraft("");
+      return;
+    }
+    onChange([...values, trimmed]);
+    setDraft("");
+  };
+
+  const removeValue = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <div className="text-sm">{label}</div>
+        <div className="text-[11px] text-muted-foreground">{description}</div>
+      </div>
+      {values.length ? (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((value, index) => (
+            <span
+              key={`${value}-${index}`}
+              className="inline-flex items-center gap-1.5 border border-border px-2 py-0.5 font-mono text-xs"
+            >
+              {value}
+              <button
+                onClick={() => removeValue(index)}
+                disabled={disabled}
+                aria-label={`Remove ${value}`}
+                className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="text-[11px] text-muted-foreground">none configured</div>
+      )}
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addValue();
+            }
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
+        />
+        <button
+          onClick={addValue}
+          disabled={!draft.trim() || disabled}
+          className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+        >
+          add
+        </button>
       </div>
     </div>
   );

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -450,6 +450,8 @@ function StringListRow({
   disabled: boolean;
 }) {
   const [draft, setDraft] = useState("");
+  const inputId = `setting-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+  const descriptionId = `${inputId}-description`;
 
   const addValue = () => {
     const trimmed = draft.trim();
@@ -468,19 +470,46 @@ function StringListRow({
 
   return (
     <div className="flex flex-col gap-2">
-      <div>
-        <div className="text-sm">{label}</div>
-        <div className="text-[11px] text-muted-foreground">{description}</div>
+      <div className="flex items-end gap-2">
+        <label htmlFor={inputId} className="min-w-0 flex-1 cursor-pointer">
+          <span className="block text-sm">{label}</span>
+          <span id={descriptionId} className="block text-[11px] text-muted-foreground">{description}</span>
+          <input
+            id={inputId}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addValue();
+              }
+            }}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-describedby={descriptionId}
+            className="mt-2 w-full min-w-0 border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={addValue}
+          disabled={!draft.trim() || disabled}
+          className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+        >
+          add
+        </button>
       </div>
       {values.length ? (
         <div className="flex flex-wrap gap-1.5">
           {values.map((value, index) => (
             <span
-              key={`${value}-${index}`}
+              key={value}
               className="inline-flex items-center gap-1.5 border border-border px-2 py-0.5 font-mono text-xs"
             >
               {value}
               <button
+                type="button"
                 onClick={() => removeValue(index)}
                 disabled={disabled}
                 aria-label={`Remove ${value}`}
@@ -494,29 +523,6 @@ function StringListRow({
       ) : (
         <div className="text-[11px] text-muted-foreground">none configured</div>
       )}
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              addValue();
-            }
-          }}
-          placeholder={placeholder}
-          disabled={disabled}
-          className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none disabled:opacity-50"
-        />
-        <button
-          onClick={addValue}
-          disabled={!draft.trim() || disabled}
-          className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
-        >
-          add
-        </button>
-      </div>
     </div>
   );
 }

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -223,6 +223,7 @@
 <li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
+<li><strong>Ignored bots</strong> — Add or remove bot logins whose comments and reviews should be ignored.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
 <li><strong>CI healing</strong> — Enable autonomous CI repair and tune retry/session limits.</li>
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -45,6 +45,7 @@ The settings page in the dashboard provides a UI for:
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
+- **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.


### PR DESCRIPTION
## Summary

Replaces the read-only comma-joined display of **Ignored bots** on the Settings page with an interactive chip list. Users can now remove existing bot entries and add new ones inline, without touching the REST API or MCP tool directly.

## Related Issue

Closes #128

## Changes Made

- Added `StringListRow` component (inline in `settings.tsx`) that renders each entry as a chip with a × remove button and an "add" input field that commits on Enter or button click.
- Wired add/remove actions to the existing `PATCH /api/config` endpoint via the `useMutation` already present on the page — no server changes required.
- Duplicate entries blocked case-insensitively (matches server-side normalization in `server/github.ts`).
- Field disabled while config is loading or a mutation is in flight, preventing an empty array from being PATCHed before initial fetch resolves.
- `ignoredBots` in `shared/schema.ts` already accepts `z.array(z.string())`; `shared/models.ts` already merges partial updates. Zero schema or route changes needed.
- **Trusted reviewers** intentionally remains read-only — the value is stored but no server consumer currently acts on it. This avoids giving false confidence the setting has an effect. Follow-up planned once a consumer exists.

## How to Test

1. Start the app (`npm run dev` or the packaged build).
2. Navigate to **Settings**.
3. Confirm existing ignored bot entries appear as removable chips.
4. Click × on a chip — verify it disappears and the change persists on reload.
5. Type a new bot name in the add field and press Enter (or click "Add") — verify it appears as a chip and persists.
6. Type a name that already exists (any case) — verify it is not added twice.
7. Confirm **Trusted reviewers** is still read-only.

## Checklist

- [x] Follows CONTRIBUTING.md guidelines (imperative `feat:` prefix, focused single-purpose PR)
- [x] `npm run check` (TypeScript typecheck) passes clean — UI-only change
- [x] `npm run lint` passes
- [x] No server tests added/changed — no server code modified
- [x] No unrelated files staged
- [x] Branch is up to date with `yungookim/oh-my-pr:main`