### PR TITLE
feat: add drain-mode status and toggle to web Settings

### DIFF
--- a/client/src/lib/runtimeDisplay.test.ts
+++ b/client/src/lib/runtimeDisplay.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RuntimeState } from "@shared/schema";
+import {
+  getDrainActionLabel,
+  getDrainStatusView,
+} from "./runtimeDisplay";
+
+const activeRuntimeState: RuntimeState = {
+  drainMode: false,
+  drainRequestedAt: null,
+  drainReason: null,
+};
+
+test("getDrainStatusView shows loading before runtime state is available", () => {
+  assert.deepEqual(getDrainStatusView(undefined, false), {
+    label: "loading...",
+    className: "text-muted-foreground",
+  });
+});
+
+test("getDrainStatusView shows an error when runtime state fails to load", () => {
+  assert.deepEqual(getDrainStatusView(undefined, true), {
+    label: "unavailable",
+    className: "text-destructive",
+  });
+});
+
+test("getDrainStatusView shows active and paused runtime states", () => {
+  assert.deepEqual(getDrainStatusView(activeRuntimeState, false), {
+    label: "active",
+    className: "text-muted-foreground",
+  });
+  assert.deepEqual(getDrainStatusView({ ...activeRuntimeState, drainMode: true }, false), {
+    label: "paused",
+    className: "text-destructive",
+  });
+});
+
+test("getDrainActionLabel returns capitalized action labels", () => {
+  assert.equal(getDrainActionLabel(undefined), "Pause");
+  assert.equal(getDrainActionLabel(activeRuntimeState), "Pause");
+  assert.equal(getDrainActionLabel({ ...activeRuntimeState, drainMode: true }), "Resume");
+});

--- a/client/src/lib/runtimeDisplay.ts
+++ b/client/src/lib/runtimeDisplay.ts
@@ -1,0 +1,29 @@
+import type { RuntimeState } from "@shared/schema";
+
+type DrainStatusView = {
+  label: string;
+  className: string;
+};
+
+export function getDrainStatusView(
+  runtimeState: RuntimeState | undefined,
+  isError: boolean,
+): DrainStatusView {
+  if (runtimeState?.drainMode) {
+    return { label: "paused", className: "text-destructive" };
+  }
+
+  if (runtimeState) {
+    return { label: "active", className: "text-muted-foreground" };
+  }
+
+  if (isError) {
+    return { label: "unavailable", className: "text-destructive" };
+  }
+
+  return { label: "loading...", className: "text-muted-foreground" };
+}
+
+export function getDrainActionLabel(runtimeState: RuntimeState | undefined): string {
+  return runtimeState?.drainMode ? "Resume" : "Pause";
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -5,6 +5,10 @@ import type { Config, RuntimeState } from "@shared/schema";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import { Link } from "wouter";
+import {
+  getDrainActionLabel,
+  getDrainStatusView,
+} from "@/lib/runtimeDisplay";
 
 export default function Settings() {
   const { data: config } = useQuery<Config>({
@@ -31,10 +35,11 @@ export default function Settings() {
     updateGithubTokens(githubTokens.filter((_, i) => i !== index));
   };
 
-  const { data: runtimeState } = useQuery<RuntimeState>({
+  const { data: runtimeState, isError: runtimeStateIsError } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],
     refetchInterval: 5000,
   });
+  const drainStatusView = getDrainStatusView(runtimeState, runtimeStateIsError);
 
   const drainMutation = useMutation({
     mutationFn: async (input: { enabled: boolean; reason?: string }) => {
@@ -320,15 +325,7 @@ export default function Settings() {
                     aria-live="polite"
                     data-testid="text-drain-status"
                   >
-                    {runtimeState ? (
-                      runtimeState.drainMode ? (
-                        <span className="text-destructive">paused</span>
-                      ) : (
-                        <span className="text-muted-foreground">active</span>
-                      )
-                    ) : (
-                      <span className="text-muted-foreground">loading...</span>
-                    )}
+                    <span className={drainStatusView.className}>{drainStatusView.label}</span>
                   </div>
                 </div>
                 <button
@@ -344,7 +341,7 @@ export default function Settings() {
                   data-testid="button-toggle-drain"
                   className="shrink-0 border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                 >
-                  {runtimeState?.drainMode ? "resume" : "pause"}
+                  {getDrainActionLabel(runtimeState)}
                 </button>
               </div>
               {runtimeState?.drainMode && (runtimeState.drainReason || runtimeState.drainRequestedAt) ? (

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
-import type { Config } from "@shared/schema";
+import type { Config, RuntimeState } from "@shared/schema";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import { Link } from "wouter";
@@ -30,6 +30,29 @@ export default function Settings() {
   const removeGithubToken = (index: number) => {
     updateGithubTokens(githubTokens.filter((_, i) => i !== index));
   };
+
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 5000,
+  });
+
+  const drainMutation = useMutation({
+    mutationFn: async (input: { enabled: boolean; reason?: string }) => {
+      const res = await apiRequest("POST", "/api/runtime/drain", input);
+      return res.json();
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/runtime"] });
+      toast({
+        description: variables.enabled
+          ? "Automation paused. New runs are blocked; in-flight runs will finish."
+          : "Automation resumed.",
+      });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Failed to update drain mode: ${error.message}` });
+    },
+  });
 
   const updateConfigMutation = useMutation({
     mutationFn: async (updates: Partial<Config>) => {
@@ -277,6 +300,65 @@ export default function Settings() {
                   data-testid="checkbox-auto-create-releases"
                 />
               </label>
+            </div>
+          </section>
+
+          {/* Runtime */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Runtime
+            </h2>
+            <div className="flex flex-col gap-4 rounded border border-border p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm">Automation</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Drain mode blocks new agent runs. In-flight runs continue until they finish.
+                  </div>
+                  <div
+                    className="mt-2 text-[11px]"
+                    aria-live="polite"
+                    data-testid="text-drain-status"
+                  >
+                    {runtimeState ? (
+                      runtimeState.drainMode ? (
+                        <span className="text-destructive">paused</span>
+                      ) : (
+                        <span className="text-muted-foreground">active</span>
+                      )
+                    ) : (
+                      <span className="text-muted-foreground">loading...</span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    drainMutation.mutate(
+                      runtimeState?.drainMode
+                        ? { enabled: false }
+                        : { enabled: true, reason: "Manually paused via web settings" },
+                    )
+                  }
+                  disabled={!runtimeState || drainMutation.isPending}
+                  data-testid="button-toggle-drain"
+                  className="shrink-0 border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                >
+                  {runtimeState?.drainMode ? "resume" : "pause"}
+                </button>
+              </div>
+              {runtimeState?.drainMode && (runtimeState.drainReason || runtimeState.drainRequestedAt) ? (
+                <div className="border-l-2 border-destructive bg-muted/30 px-3 py-2 text-[11px]">
+                  {runtimeState.drainReason ? (
+                    <div className="text-foreground">{runtimeState.drainReason}</div>
+                  ) : null}
+                  {runtimeState.drainRequestedAt ? (
+                    <div className="mt-1 text-muted-foreground">
+                      since {new Date(runtimeState.drainRequestedAt).toLocaleString()}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           </section>
 

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -223,6 +223,7 @@
 <li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
+<li><strong>Runtime drain mode</strong> — Pause new automation runs from Settings while allowing in-flight runs to finish.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
 <li><strong>CI healing</strong> — Enable autonomous CI repair and tune retry/session limits.</li>
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -45,6 +45,7 @@ The settings page in the dashboard provides a UI for:
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
+- **Runtime drain mode** — Pause new automation runs from Settings while allowing in-flight runs to finish.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.


### PR DESCRIPTION
## Summary

Adds a "Runtime" section to the web Settings page that surfaces drain-mode state and provides a pause/resume toggle. Previously, drain mode was only observable and controllable via REST (`POST /api/runtime/drain`) or MCP (`set_drain_mode`). The babysitter can auto-enable drain mode on agent health-check failure, leaving web-only users with no way to see why automation stopped or resume it.

## Related Issue

Closes #130

## Changes Made

- Import `RuntimeState` from `@shared/schema` alongside the existing `Config` import.
- Add a `useQuery` against `GET /api/runtime` with `refetchInterval: 5000` so server-driven flips (e.g. auto-pause on agent health failure) appear within 5 s without a manual reload.
- Add a `useMutation` against `POST /api/runtime/drain` that invalidates the runtime query on success and shows a success or error toast.
- Render a "Runtime" card in Settings showing current state ("active" / "paused"), a warning callout with `drainReason` and `drainRequestedAt` when paused, and a single toggle button.
- Button is disabled while the query is loading or the mutation is pending.

No server changes. The endpoints (`GET /api/runtime`, `POST /api/runtime/drain`) and the `RuntimeState` type already exist.

## How to Test

1. Start the server locally.
2. Trigger drain mode via curl:
   ```
   curl -X POST http://localhost:5001/api/runtime/drain \
     -H "Content-Type: application/json" \
     -d '{"enabled":true,"reason":"smoke test"}'
   ```
3. Open Settings in the browser — the "Runtime" section should show "paused", the reason "smoke test", and the timestamp within 5 s (without reloading).
4. Click "Resume automation" — state should flip to "active" and a success toast should appear.
5. Click "Pause automation" — state should flip to "paused" with reason "Manually paused via web settings".

## Verification

- `npx tsc --noEmit` passes clean (UI-only change).
- Independent of PR #129 (`feat/editable-ignored-bots`); both can land in any order.

## Checklist

- [x] Follows CONTRIBUTING.md guidelines
- [x] `feat:` commit prefix used
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] No server-side changes; uses existing endpoints and types
- [x] No unrelated files staged
- [x] Branch is up to date with `upstream/main`
- [x] PR is focused and narrow — one feature only