### PR TITLE
Add PATH repair guidance for agent CLI warnings

### DIFF
--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -177,6 +177,17 @@ type AgentAvailabilityFailure = {
   fixSteps: string[];
 };
 
+function buildCliMissingFixSteps(agentLabel: AgentLabel, command: "claude" | "codex"): string[] {
+  return [
+    `Install the ${agentLabel === "Claude" ? "Claude Code" : "Codex"} CLI on this machine.`,
+    `If ${agentLabel} is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then \`$SHELL -lc "command -v ${command}"\`.`,
+    "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
+    `Verify with \`command -v ${command}\` and \`$SHELL -lc "command -v ${command}"\`.`,
+    "Restart oh-my-pr after installing.",
+    "Rerun the babysitter for this PR.",
+  ];
+}
+
 const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string[]>> = {
   Claude: {
     auth: [
@@ -184,11 +195,7 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
       "Restart oh-my-pr if it was launched before you refreshed credentials.",
       "Rerun the babysitter for this PR.",
     ],
-    cli_missing: [
-      "Install the Claude Code CLI on this machine.",
-      "Restart oh-my-pr after installing.",
-      "Rerun the babysitter for this PR.",
-    ],
+    cli_missing: buildCliMissingFixSteps("Claude", "claude"),
   },
   Codex: {
     auth: [
@@ -196,14 +203,7 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
       "Restart oh-my-pr if it was launched before you refreshed credentials.",
       "Rerun the babysitter for this PR.",
     ],
-    cli_missing: [
-      "Install the Codex CLI on this machine.",
-      "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
-      "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
-      "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
-      "Restart oh-my-pr after installing.",
-      "Rerun the babysitter for this PR.",
-    ],
+    cli_missing: buildCliMissingFixSteps("Codex", "codex"),
   },
 };
 

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -198,6 +198,9 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
     ],
     cli_missing: [
       "Install the Codex CLI on this machine.",
+      "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
+      "For nvm installs, add the active Node bin directory to a login-shell startup file such as `~/.zprofile`; for example: `export PATH=\"$HOME/.nvm/versions/node/v24.12.0/bin:$PATH\"`.",
+      "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
       "Restart oh-my-pr after installing.",
       "Rerun the babysitter for this PR.",
     ],

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -199,7 +199,7 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
     cli_missing: [
       "Install the Codex CLI on this machine.",
       "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
-      "For nvm installs, add the active Node bin directory to a login-shell startup file such as `~/.zprofile`; for example: `export PATH=\"$HOME/.nvm/versions/node/v24.12.0/bin:$PATH\"`.",
+      "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
       "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
       "Restart oh-my-pr after installing.",
       "Rerun the babysitter for this PR.",

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -556,7 +556,7 @@ test("GET /api/activities explains PATH repair when Codex CLI is missing", async
     assert.deepEqual(body.warnings?.[0]?.fixSteps, [
       "Install the Codex CLI on this machine.",
       "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
-      "For nvm installs, add the active Node bin directory to a login-shell startup file such as `~/.zprofile`; for example: `export PATH=\"$HOME/.nvm/versions/node/v24.12.0/bin:$PATH\"`.",
+      "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
       "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
       "Restart oh-my-pr after installing.",
       "Rerun the babysitter for this PR.",

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -509,62 +509,67 @@ test("GET /api/activities warns when a babysitter job fails from agent authentic
   }
 });
 
-test("GET /api/activities explains PATH repair when Codex CLI is missing", async () => {
-  const harness = await createHarness();
-  const pr = await seedPR(harness.storage, {
-    title: "fix codex warning",
-    repo: "acme/widgets",
-    number: 78,
-    url: "https://github.com/acme/widgets/pull/78",
+for (const agent of [
+  { preferredAgent: "codex", label: "Codex", installName: "Codex", prNumber: 78 },
+  { preferredAgent: "claude", label: "Claude", installName: "Claude Code", prNumber: 79 },
+] as const) {
+  test(`GET /api/activities explains PATH repair when ${agent.label} CLI is missing`, async () => {
+    const harness = await createHarness();
+    const pr = await seedPR(harness.storage, {
+      title: `fix ${agent.preferredAgent} warning`,
+      repo: "acme/widgets",
+      number: agent.prNumber,
+      url: `https://github.com/acme/widgets/pull/${agent.prNumber}`,
+    });
+
+    try {
+      const job = await harness.storage.enqueueBackgroundJob({
+        kind: "babysit_pr",
+        targetId: pr.id,
+        dedupeKey: `babysit_pr:${pr.id}`,
+        payload: { preferredAgent: agent.preferredAgent },
+        availableAt: "2026-04-26T11:00:00.000Z",
+      });
+      await harness.storage.claimNextBackgroundJob({
+        workerId: "worker-1",
+        leaseToken: "lease-1",
+        leaseExpiresAt: "2026-04-26T11:10:00.000Z",
+        now: "2026-04-26T11:01:00.000Z",
+      });
+      await harness.storage.failBackgroundJob(
+        job.id,
+        "lease-1",
+        `Configured coding agent ${agent.preferredAgent} CLI is not installed`,
+        "2026-04-26T11:02:00.000Z",
+      );
+      await harness.storage.updatePR(pr.id, {
+        status: "error",
+        lastChecked: "2026-04-26T11:02:00.000Z",
+      });
+
+      const response = await fetch(`${harness.baseUrl}/api/activities`);
+      assert.equal(response.status, 200);
+      const body = await response.json() as {
+        warnings?: Array<{
+          title: string;
+          fixSteps: string[];
+        }>;
+      };
+
+      assert.equal(body.warnings?.[0]?.title, `${agent.label} CLI not installed`);
+      assert.deepEqual(body.warnings?.[0]?.fixSteps, [
+        `Install the ${agent.installName} CLI on this machine.`,
+        `If ${agent.label} is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then \`$SHELL -lc "command -v ${agent.preferredAgent}"\`.`,
+        "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
+        `Verify with \`command -v ${agent.preferredAgent}\` and \`$SHELL -lc "command -v ${agent.preferredAgent}"\`.`,
+        "Restart oh-my-pr after installing.",
+        "Rerun the babysitter for this PR.",
+      ]);
+    } finally {
+      await harness.close();
+    }
   });
-
-  try {
-    const job = await harness.storage.enqueueBackgroundJob({
-      kind: "babysit_pr",
-      targetId: pr.id,
-      dedupeKey: `babysit_pr:${pr.id}`,
-      payload: { preferredAgent: "codex" },
-      availableAt: "2026-04-26T11:00:00.000Z",
-    });
-    await harness.storage.claimNextBackgroundJob({
-      workerId: "worker-1",
-      leaseToken: "lease-1",
-      leaseExpiresAt: "2026-04-26T11:10:00.000Z",
-      now: "2026-04-26T11:01:00.000Z",
-    });
-    await harness.storage.failBackgroundJob(
-      job.id,
-      "lease-1",
-      "Configured coding agent codex CLI is not installed",
-      "2026-04-26T11:02:00.000Z",
-    );
-    await harness.storage.updatePR(pr.id, {
-      status: "error",
-      lastChecked: "2026-04-26T11:02:00.000Z",
-    });
-
-    const response = await fetch(`${harness.baseUrl}/api/activities`);
-    assert.equal(response.status, 200);
-    const body = await response.json() as {
-      warnings?: Array<{
-        title: string;
-        fixSteps: string[];
-      }>;
-    };
-
-    assert.equal(body.warnings?.[0]?.title, "Codex CLI not installed");
-    assert.deepEqual(body.warnings?.[0]?.fixSteps, [
-      "Install the Codex CLI on this machine.",
-      "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
-      "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
-      "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
-      "Restart oh-my-pr after installing.",
-      "Rerun the babysitter for this PR.",
-    ]);
-  } finally {
-    await harness.close();
-  }
-});
+}
 
 test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
   const storage = new MemStorage();

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -509,6 +509,63 @@ test("GET /api/activities warns when a babysitter job fails from agent authentic
   }
 });
 
+test("GET /api/activities explains PATH repair when Codex CLI is missing", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage, {
+    title: "fix codex warning",
+    repo: "acme/widgets",
+    number: 78,
+    url: "https://github.com/acme/widgets/pull/78",
+  });
+
+  try {
+    const job = await harness.storage.enqueueBackgroundJob({
+      kind: "babysit_pr",
+      targetId: pr.id,
+      dedupeKey: `babysit_pr:${pr.id}`,
+      payload: { preferredAgent: "codex" },
+      availableAt: "2026-04-26T11:00:00.000Z",
+    });
+    await harness.storage.claimNextBackgroundJob({
+      workerId: "worker-1",
+      leaseToken: "lease-1",
+      leaseExpiresAt: "2026-04-26T11:10:00.000Z",
+      now: "2026-04-26T11:01:00.000Z",
+    });
+    await harness.storage.failBackgroundJob(
+      job.id,
+      "lease-1",
+      "Configured coding agent codex CLI is not installed",
+      "2026-04-26T11:02:00.000Z",
+    );
+    await harness.storage.updatePR(pr.id, {
+      status: "error",
+      lastChecked: "2026-04-26T11:02:00.000Z",
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/activities`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      warnings?: Array<{
+        title: string;
+        fixSteps: string[];
+      }>;
+    };
+
+    assert.equal(body.warnings?.[0]?.title, "Codex CLI not installed");
+    assert.deepEqual(body.warnings?.[0]?.fixSteps, [
+      "Install the Codex CLI on this machine.",
+      "If Codex is already installed, make sure oh-my-pr can find it on PATH. The app checks its process PATH, then `$SHELL -lc \"command -v codex\"`.",
+      "For nvm installs, add the active Node bin directory to a login-shell startup file such as `~/.zprofile`; for example: `export PATH=\"$HOME/.nvm/versions/node/v24.12.0/bin:$PATH\"`.",
+      "Verify with `command -v codex` and `$SHELL -lc \"command -v codex\"`.",
+      "Restart oh-my-pr after installing.",
+      "Rerun the babysitter for this PR.",
+    ]);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons Learned
 
+## 2026-05-01 - Include PATH repair steps for local CLI warnings
+- Pattern: The Codex CLI was installed under an nvm-managed Node bin directory, but oh-my-pr still showed a generic "CLI not installed" warning because the app runtime could not discover it on PATH.
+- Rule: When surfacing local CLI missing warnings, include concrete PATH diagnostics and login-shell repair steps, not only install/restart instructions.
+- Prevention checklist:
+  - Explain that oh-my-pr checks the app process PATH and then `$SHELL -lc "command -v <tool>"`.
+  - Include nvm-specific guidance to put the active Node bin directory in a login-shell startup file such as `~/.zprofile`.
+  - Add regression coverage for warning `fixSteps` whenever changing local tool availability messages.
+
 ## 2026-04-30 - Keep speculative automation acknowledgements local
 - Pattern: The babysitter posted "Accepted" progress replies on GitHub for every accepted review comment, which surprised teammates because triage acknowledgements looked like public conversation from the user before a fix existed.
 - Rule: In `oh-my-pr`, only post GitHub replies when there is a concrete command, result, audit trail, or thread-resolution outcome to expose; keep speculative triage/progress acknowledgements in local logs unless the user explicitly opts into public progress chatter in Settings.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,12 +1,12 @@
 # Lessons Learned
 
 ## 2026-05-01 - Include PATH repair steps for local CLI warnings
-- Pattern: The Codex CLI was installed under an nvm-managed Node bin directory, but oh-my-pr still showed a generic "CLI not installed" warning because the app runtime could not discover it on PATH.
-- Rule: When surfacing local CLI missing warnings, include concrete PATH diagnostics and login-shell repair steps, not only install/restart instructions.
+- Pattern: The Codex CLI was installed under an nvm-managed Node bin directory, but oh-my-pr still showed a generic "CLI not installed" warning because the app runtime could not discover it on PATH; the same repair guidance also needed to apply to Claude CLI warnings.
+- Rule: When surfacing local CLI missing warnings for any coding agent, include concrete PATH diagnostics and login-shell repair steps, not only install/restart instructions.
 - Prevention checklist:
   - Explain that oh-my-pr checks the app process PATH and then `$SHELL -lc "command -v <tool>"`.
   - Include nvm-specific guidance to put the active Node bin directory in a login-shell startup file such as `~/.zprofile`.
-  - Add regression coverage for warning `fixSteps` whenever changing local tool availability messages.
+  - Add regression coverage for every affected agent's warning `fixSteps` whenever changing local tool availability messages.
 
 ## 2026-04-30 - Keep speculative automation acknowledgements local
 - Pattern: The babysitter posted "Accepted" progress replies on GitHub for every accepted review comment, which surprised teammates because triage acknowledgements looked like public conversation from the user before a fix existed.


### PR DESCRIPTION
## Summary
- Expand the Codex and Claude CLI missing warnings with PATH checks, nvm-specific guidance, and concrete verification steps
- Add regression tests covering the Codex and Claude missing-CLI warning copy
- Record the lesson so future CLI warnings include PATH repair help for every affected local agent

## Testing
- `node --test --import tsx server/routes.test.ts`
- `npm run check`