### PR TITLE
Add clear failed activity cleanup

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -253,7 +253,15 @@ function ActivitySection({
   );
 }
 
-function ActivityMenu({ activities }: { activities: ActivitySnapshot }) {
+function ActivityMenu({
+  activities,
+  onClearFailed,
+  isClearingFailed,
+}: {
+  activities: ActivitySnapshot;
+  onClearFailed: () => void;
+  isClearingFailed: boolean;
+}) {
   const failedCount = activities.failed.length;
   const inProgressCount = activities.inProgress.length;
   const queuedCount = activities.queued.length;
@@ -272,7 +280,20 @@ function ActivityMenu({ activities }: { activities: ActivitySnapshot }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-80 p-0">
         <div className="border-b border-border px-2 py-2">
-          <div className="text-[12px] font-medium">Activities</div>
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[12px] font-medium">Activities</div>
+            {failedCount > 0 && (
+              <button
+                type="button"
+                onClick={onClearFailed}
+                disabled={isClearingFailed}
+                className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                data-testid="clear-failed-activities"
+              >
+                {isClearingFailed ? "clearing" : "clear failed"}
+              </button>
+            )}
+          </div>
           <div className="text-[11px] text-muted-foreground">
             {failedCount} failed / {inProgressCount} in progress / {queuedCount} queued
           </div>
@@ -1091,6 +1112,20 @@ export default function Dashboard() {
     },
   });
 
+  const clearFailedActivitiesMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("DELETE", "/api/activities/failed");
+      return res.json() as Promise<{ cleared: number }>;
+    },
+    onSuccess: ({ cleared }) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      toast({ description: cleared === 1 ? "Cleared 1 failed activity." : `Cleared ${cleared} failed activities.` });
+    },
+    onError: (error) => {
+      showMutationError("Could not clear failed activities", error);
+    },
+  });
+
   const manualReleaseMutation = useMutation({
     mutationFn: async (repo: string) => {
       const res = await apiRequest("POST", "/api/repos/release", { repo });
@@ -1207,7 +1242,11 @@ export default function Dashboard() {
           >
             settings
           </Link>
-          <ActivityMenu activities={activities} />
+          <ActivityMenu
+            activities={activities}
+            onClearFailed={() => clearFailedActivitiesMutation.mutate()}
+            isClearingFailed={clearFailedActivitiesMutation.isPending}
+          />
         </div>
       </header>
 

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -89,6 +89,7 @@ export type AppRuntime = {
   getRuntimeSnapshot(): Promise<RuntimeSnapshot>;
   setDrainMode(input: DrainModeParams): Promise<RuntimeSnapshot & { drained?: boolean }>;
   listActivities(): Promise<ActivitySnapshot>;
+  clearFailedActivities(): Promise<{ cleared: number }>;
   listRepos(): Promise<string[]>;
   listRepoSettings(): Promise<WatchedRepo[]>;
   addRepo(repoInput: string): Promise<{ repo: string }>;
@@ -690,6 +691,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         warnings,
         generatedAt: new Date().toISOString(),
       };
+    },
+
+    async clearFailedActivities() {
+      const cleared = await storage.clearFailedBackgroundJobs();
+      if (cleared > 0) {
+        notifyChange();
+      }
+      return { cleared };
     },
 
     async setDrainMode(input) {

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -593,6 +593,10 @@ describe("MemStorage", () => {
       assert.equal(failedJobs.length, 1);
       assert.equal(failedJobs[0]?.id, highPriority.id);
 
+      const cleared = await storage.clearFailedBackgroundJobs();
+      assert.equal(cleared, 1);
+      assert.equal((await storage.listBackgroundJobs({ status: "failed" })).length, 0);
+
       const queuedJobs = await storage.listBackgroundJobs({ status: "queued" });
       assert.equal(queuedJobs.length, 1);
       assert.equal(queuedJobs[0]?.id, lowPriority.id);

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -635,6 +635,14 @@ export class MemStorage implements IStorage {
     return expired.length;
   }
 
+  async clearFailedBackgroundJobs(): Promise<number> {
+    const failed = Array.from(this.backgroundJobs.values()).filter((job) => job.status === "failed");
+    for (const job of failed) {
+      this.backgroundJobs.delete(job.id);
+    }
+    return failed.length;
+  }
+
   async getReleaseRun(id: string): Promise<ReleaseRun | undefined> {
     const run = this.releaseRuns.get(id);
     return run ? this.cloneReleaseRun(run) : undefined;

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -509,6 +509,65 @@ test("GET /api/activities warns when a babysitter job fails from agent authentic
   }
 });
 
+test("DELETE /api/activities/failed clears only failed activity jobs", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage, {
+    title: "clear failed activity",
+    repo: "acme/widgets",
+    number: 77,
+    url: "https://github.com/acme/widgets/pull/77",
+  });
+
+  try {
+    const failedJob = await harness.storage.enqueueBackgroundJob({
+      kind: "babysit_pr",
+      targetId: pr.id,
+      dedupeKey: `babysit_pr:${pr.id}`,
+      payload: { preferredAgent: "claude" },
+      availableAt: "2026-04-26T10:00:00.000Z",
+    });
+    await harness.storage.claimNextBackgroundJob({
+      workerId: "worker-1",
+      leaseToken: "lease-1",
+      leaseExpiresAt: "2026-04-26T10:10:00.000Z",
+      now: "2026-04-26T10:01:00.000Z",
+    });
+    await harness.storage.failBackgroundJob(
+      failedJob.id,
+      "lease-1",
+      "agent timed out",
+      "2026-04-26T10:02:00.000Z",
+    );
+
+    const queuedJob = await harness.storage.enqueueBackgroundJob({
+      kind: "sync_watched_repos",
+      targetId: "runtime:1",
+      dedupeKey: "sync_watched_repos",
+      availableAt: "2026-04-26T10:03:00.000Z",
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/activities/failed`, {
+      method: "DELETE",
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cleared: number };
+    assert.equal(body.cleared, 1);
+
+    const activitiesResponse = await fetch(`${harness.baseUrl}/api/activities`);
+    assert.equal(activitiesResponse.status, 200);
+    const activities = await activitiesResponse.json() as {
+      failed: Array<{ id: string }>;
+      queued: Array<{ id: string }>;
+    };
+    assert.equal(activities.failed.length, 0);
+    assert.equal(activities.queued.length, 1);
+    assert.equal(activities.queued[0]?.id, queuedJob.id);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release queues a manual release run for the requested repo", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -117,6 +117,14 @@ export async function registerRoutes(
     res.json(await runtime.listActivities());
   });
 
+  app.delete("/api/activities/failed", async (_req, res) => {
+    try {
+      res.json(await runtime.clearFailedActivities());
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.post("/api/runtime/drain", async (req, res) => {
     try {
       const payload = z.object({

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -2313,6 +2313,14 @@ export class SqliteStorage implements IStorage {
     return Number(result.changes);
   }
 
+  async clearFailedBackgroundJobs(): Promise<number> {
+    const result = this.run(`
+      DELETE FROM background_jobs
+      WHERE status = 'failed'
+    `);
+    return Number(result.changes);
+  }
+
   async getAgentRun(id: string): Promise<AgentRun | undefined> {
     const row = this.get<AgentRunRow>(`
       SELECT id, pr_id, preferred_agent, resolved_agent, status, phase, prompt, initial_head_sha,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -619,6 +619,10 @@ test("SqliteStorage persists background jobs and requeues expired leases", async
       assert.equal(failedJobs.length, 1);
       assert.equal(failedJobs[0]?.id, highPriority.id);
 
+      const cleared = await second.clearFailedBackgroundJobs();
+      assert.equal(cleared, 1);
+      assert.equal((await second.listBackgroundJobs({ status: "failed" })).length, 0);
+
       const queuedJobs = await second.listBackgroundJobs({ status: "queued" });
       assert.equal(queuedJobs.length, 1);
       assert.equal(queuedJobs[0]?.id, lowPriority.id);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -126,6 +126,7 @@ export interface IStorage {
   failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined>;
   cancelBackgroundJob(id: string, leaseToken: string, error: string | null, completedAt: string): Promise<BackgroundJob | undefined>;
   requeueExpiredBackgroundJobs(now: string): Promise<number>;
+  clearFailedBackgroundJobs(): Promise<number>;
 
   // Social media changelogs
   getSocialChangelogs(): Promise<SocialChangelog[]>;


### PR DESCRIPTION
## Summary
- Add a clear-failed action to the Activity menu so failed jobs can be removed in one step
- Wire the action through runtime, routes, and storage for both memory and SQLite backends
- Keep queued and in-progress jobs untouched while refreshing Activity state after cleanup

## Testing
- Added storage coverage for clearing failed background jobs in memory and SQLite
- Added route coverage for `DELETE /api/activities/failed`
- Ran the server test suite, typecheck, and production build locally