### PR TITLE
feat: structured logger with redaction, file output, and verbosity flags

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   code-review:
     # Skip automated PRs (dependabot, etc.)
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   code-review:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -94,12 +94,16 @@ jobs:
             );
 
             if (!existing) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              } catch (error) {
+                core.warning(`Could not post documentation reminder: ${error.message}`);
+              }
             }
 
       - name: Post docs updated confirmation
@@ -129,10 +133,14 @@ jobs:
             );
 
             if (!existing) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              } catch (error) {
+                core.warning(`Could not post documentation confirmation: ${error.message}`);
+              }
             }

--- a/bin/codefactory.cjs
+++ b/bin/codefactory.cjs
@@ -2,7 +2,7 @@
 "use strict";
 
 const pkg = require("../package.json");
-const { formatCliHelp, parseCliArgs } = require("../dist/cli.cjs");
+const { applyLogEnv, formatCliHelp, parseCliArgs } = require("../dist/cli.cjs");
 const parsed = parseCliArgs(process.argv.slice(2));
 
 if (parsed.mode === "version") {
@@ -15,10 +15,11 @@ if (parsed.mode === "help") {
     console.error(parsed.error);
   }
   console.log(formatCliHelp(pkg.version));
-  process.exit(0);
+  process.exit(parsed.error ? 1 : 0);
 }
 
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
+applyLogEnv(parsed.log);
 if (parsed.mode === "mcp") {
   require("../dist/mcp.cjs");
 } else if (parsed.mode === "web") {

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -204,6 +204,21 @@
 <td>—</td>
 <td>Fallback GitHub token when no dashboard token is configured; <code>gh auth</code> is used after that</td>
 </tr>
+<tr>
+<td><code>LOG_LEVEL</code></td>
+<td><code>debug</code> in development, <code>info</code> in production</td>
+<td>Server log level: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, or <code>fatal</code></td>
+</tr>
+<tr>
+<td><code>OH_MY_PR_LOG_FILE</code></td>
+<td><code>~/.oh-my-pr/log/server.log</code></td>
+<td>Override the structured server log file path</td>
+</tr>
+<tr>
+<td><code>OH_MY_PR_NO_LOG_FILE</code></td>
+<td>—</td>
+<td>Set to <code>1</code> to disable structured server log file output</td>
+</tr>
 </tbody></table>
 <p><code>CODEFACTORY_PORT</code> is still accepted by the MCP server as a legacy fallback, but new MCP configurations should use <code>OH_MY_PR_PORT</code>.</p>
 <h2>Storage</h2>
@@ -217,6 +232,15 @@
 <pre><code>~/.oh-my-pr/log/
 </code></pre>
 <p>These logs mirror the dashboard activity feed and are useful for debugging or auditing agent behavior.</p>
+<p>The server also writes structured runtime logs to <code>~/.oh-my-pr/log/server.log</code> by default. Use <code>LOG_LEVEL</code>, <code>OH_MY_PR_LOG_FILE</code>, or <code>OH_MY_PR_NO_LOG_FILE=1</code> to tune file output.</p>
+<p>CLI flags can override the same logging settings for a single run:</p>
+<pre><code>oh-my-pr --quiet
+oh-my-pr --verbose
+oh-my-pr --log-level warn
+oh-my-pr --log-level=trace
+oh-my-pr --log-file /tmp/oh-my-pr.log
+oh-my-pr --no-log-file
+</code></pre>
 <h2>Dashboard Settings</h2>
 <p>The settings page in the dashboard provides a UI for:</p>
 <ul>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -13,6 +13,9 @@ oh-my-pr is configured through environment variables and the dashboard settings 
 | `CODEFACTORY_PORT` | `5001` | Legacy port the MCP server connects to when `OH_MY_PR_PORT` is not set |
 | `DATABASE_URL` | (SQLite) | PostgreSQL connection string (optional) |
 | `GITHUB_TOKEN` | — | Fallback GitHub token when no dashboard token is configured; `gh auth` is used after that |
+| `LOG_LEVEL` | `debug` in development, `info` in production | Server log level: `trace`, `debug`, `info`, `warn`, `error`, or `fatal` |
+| `OH_MY_PR_LOG_FILE` | `~/.oh-my-pr/log/server.log` | Override the structured server log file path |
+| `OH_MY_PR_NO_LOG_FILE` | — | Set to `1` to disable structured server log file output |
 
 `CODEFACTORY_PORT` is still accepted by the MCP server as a legacy fallback, but new MCP configurations should use `OH_MY_PR_PORT`.
 
@@ -37,6 +40,19 @@ oh-my-pr writes daily activity logs to:
 ```
 
 These logs mirror the dashboard activity feed and are useful for debugging or auditing agent behavior.
+
+The server also writes structured runtime logs to `~/.oh-my-pr/log/server.log` by default. Use `LOG_LEVEL`, `OH_MY_PR_LOG_FILE`, or `OH_MY_PR_NO_LOG_FILE=1` to tune file output.
+
+CLI flags can override the same logging settings for a single run:
+
+```
+oh-my-pr --quiet
+oh-my-pr --verbose
+oh-my-pr --log-level warn
+oh-my-pr --log-level=trace
+oh-my-pr --log-file /tmp/oh-my-pr.log
+oh-my-pr --no-log-file
+```
 
 ## Dashboard Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,8 @@
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "pg": "^8.16.3",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -1904,6 +1906,12 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -5289,6 +5297,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -5606,6 +5623,12 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -5852,6 +5875,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -6248,6 +6280,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -6698,6 +6739,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6753,6 +6800,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -7083,6 +7136,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hono": {
       "version": "4.12.14",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
@@ -7365,6 +7424,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -7932,6 +8000,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -8058,6 +8135,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -8368,6 +8454,67 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -8617,6 +8764,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8652,6 +8815,16 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "license": "ISC"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8696,6 +8869,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/random-bytes": {
@@ -8942,6 +9121,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/recharts": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
@@ -9148,6 +9336,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9176,6 +9373,22 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -9331,6 +9544,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9356,6 +9578,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sucrase": {
@@ -9505,6 +9739,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -9629,7 +9875,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9646,7 +9891,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9663,7 +9907,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9680,7 +9923,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9697,7 +9939,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9714,7 +9955,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9731,7 +9971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9748,7 +9987,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9765,7 +10003,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9782,7 +10019,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9799,7 +10035,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9816,7 +10051,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9833,7 +10067,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9850,7 +10083,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9867,7 +10099,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9884,7 +10115,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9901,7 +10131,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9918,7 +10147,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9935,7 +10163,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9952,7 +10179,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9969,7 +10195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9986,7 +10211,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10003,7 +10227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10020,7 +10243,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10037,7 +10259,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10054,7 +10275,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "pg": "^8.16.3",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/script/build.ts
+++ b/script/build.ts
@@ -26,6 +26,8 @@ const allowlist = [
   "passport",
   "passport-local",
   "pg",
+  "pino",
+  "pino-pretty",
   "postcss",
   "sanitize-html",
   "stripe",

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -23,6 +23,9 @@ import { PRBabysitter } from "./babysitter";
 import { detectAgentUnavailability, type AgentUnavailabilityKind } from "./agentRunner";
 import { applyEvaluationDecision, applyFlagDecision } from "./feedbackLifecycle";
 import { applyManualFeedbackDecision } from "./manualFeedback";
+import { childLogger } from "./logger";
+
+const log = childLogger("runtime");
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
@@ -376,7 +379,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
             attemptCount: job.attemptCount,
           },
         }).catch((error) => {
-          console.error("Failed to log reclaimed background job", error);
+          log.warn(
+            { err: error instanceof Error ? error.message : String(error) },
+            "Failed to log reclaimed background job",
+          );
         });
       }
     },
@@ -393,7 +399,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       );
     },
     (error) => {
-      console.error("Repository babysitter watcher failed", error);
+      log.warn(
+        { err: error instanceof Error ? error.message : String(error) },
+        "Repository babysitter watcher failed",
+      );
     },
   );
   const runWatcher = watcherScheduler.run;

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -43,7 +43,10 @@ import { CIHealingManager, isTerminalHealingState } from "./ciHealingManager";
 import { classifyCIFailures, type ClassifiedCIFailure } from "./ciFailureClassifier";
 import { isFailingCheckSnapshot } from "./ciCheckIngestor";
 import { runCIHealingRepairAttempt } from "./ciHealingAgent";
+import { childLogger } from "./logger";
 import { getCodeFactoryPaths } from "./paths";
+
+const log = childLogger("babysitter");
 import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
 import { buildActivityPayload } from "./activityPayload";
@@ -1317,7 +1320,10 @@ export class PRBabysitter {
       if (!authenticatedLoginPromise) {
         authenticatedLoginPromise = (this.github.getAuthenticatedLogin?.(octokit) ?? Promise.resolve(null))
           .catch((error) => {
-            console.error("Failed to determine authenticated GitHub login for watcher filtering", error);
+            log.warn(
+              { err: error instanceof Error ? error.message : String(error) },
+              "Failed to determine authenticated GitHub login for watcher filtering",
+            );
             return null;
           });
       }
@@ -1336,7 +1342,10 @@ export class PRBabysitter {
       try {
         openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
       } catch (error) {
-        console.error(`Failed to list open PRs for ${repoSlug}`, error);
+        log.warn(
+          { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
+          "Failed to list open PRs",
+        );
         continue;
       }
 
@@ -1687,7 +1696,10 @@ export class PRBabysitter {
 	          });
 	        })
 	        .catch((logError) => {
-	          console.error("Babysitter log write failed", logError);
+	          log.warn(
+	            { err: logError instanceof Error ? logError.message : String(logError) },
+	            "Babysitter log write failed",
+	          );
 	        });
 
       return logQueue;
@@ -3483,7 +3495,11 @@ export class PRBabysitter {
           });
         }
       }
-      console.error("Babysitter failure", error);
+      const failureMsg = error instanceof Error ? error.message : String(error);
+      log.warn({ err: failureMsg, prId }, "Babysitter failure");
+      if (error instanceof Error && error.stack) {
+        log.debug({ stack: error.stack, prId }, "Babysitter failure stack");
+      }
       if (options?.rethrowOnFailure) {
         throw error;
       }

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -2,6 +2,9 @@ import { randomUUID } from "crypto";
 import type { BackgroundJob, BackgroundJobKind } from "@shared/schema";
 import type { IStorage } from "./storage";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
+import { childLogger } from "./logger";
+
+const log = childLogger("jobs");
 
 export type BackgroundJobHandler = (job: BackgroundJob) => Promise<void>;
 
@@ -60,7 +63,10 @@ export class BackgroundJobDispatcher {
     this.retryBackoffMs = Math.max(0, params.retryBackoffMs ?? 30_000);
     this.now = params.now ?? (() => new Date());
     this.onError = params.onError ?? ((error) => {
-      console.error("Background job dispatcher error", error);
+      log.warn(
+        { err: error instanceof Error ? error.message : String(error) },
+        "Background job dispatcher error",
+      );
     });
     this.onReclaimedJobs = params.onReclaimedJobs ?? (() => {});
   }

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatCliHelp, parseCliArgs } from "./cli";
+import { applyLogEnv, formatCliHelp, parseCliArgs } from "./cli";
 
 test("parseCliArgs defaults to web mode when no subcommand is provided", () => {
   assert.deepEqual(parseCliArgs([]), { mode: "web" });
@@ -25,6 +25,85 @@ test("parseCliArgs returns help mode with an error for unknown commands", () => 
   });
 });
 
+test("parseCliArgs accepts logging flags before the subcommand", () => {
+  assert.deepEqual(parseCliArgs(["--quiet", "web"]), {
+    mode: "web",
+    log: { level: "error" },
+  });
+  assert.deepEqual(parseCliArgs(["-q"]), {
+    mode: "web",
+    log: { level: "error" },
+  });
+});
+
+test("parseCliArgs accepts logging flags after the subcommand", () => {
+  assert.deepEqual(parseCliArgs(["web", "--verbose"]), {
+    mode: "web",
+    log: { level: "debug" },
+  });
+  assert.deepEqual(parseCliArgs(["mcp", "--debug"]), {
+    mode: "mcp",
+    log: { level: "debug" },
+  });
+});
+
+test("parseCliArgs --log-file requires a path", () => {
+  assert.deepEqual(parseCliArgs(["--log-file"]), {
+    mode: "help",
+    error: "--log-file requires a path",
+  });
+  assert.deepEqual(parseCliArgs(["--log-file", "/tmp/x.log"]), {
+    mode: "web",
+    log: { logFile: "/tmp/x.log" },
+  });
+  assert.deepEqual(parseCliArgs(["--log-file=/tmp/y.log"]), {
+    mode: "web",
+    log: { logFile: "/tmp/y.log" },
+  });
+});
+
+test("parseCliArgs --no-log-file flag", () => {
+  assert.deepEqual(parseCliArgs(["--no-log-file"]), {
+    mode: "web",
+    log: { noLogFile: true },
+  });
+});
+
+test("parseCliArgs --log-level validates the value", () => {
+  assert.equal(parseCliArgs(["--log-level", "bogus"]).mode, "help");
+  assert.deepEqual(parseCliArgs(["--log-level", "warn"]), {
+    mode: "web",
+    log: { level: "warn" },
+  });
+});
+
+test("applyLogEnv writes the expected environment variables", () => {
+  const prev = {
+    LOG_LEVEL: process.env.LOG_LEVEL,
+    OH_MY_PR_LOG_FILE: process.env.OH_MY_PR_LOG_FILE,
+    OH_MY_PR_NO_LOG_FILE: process.env.OH_MY_PR_NO_LOG_FILE,
+  };
+  delete process.env.LOG_LEVEL;
+  delete process.env.OH_MY_PR_LOG_FILE;
+  delete process.env.OH_MY_PR_NO_LOG_FILE;
+
+  try {
+    applyLogEnv({ level: "warn", logFile: "/tmp/foo.log" });
+    assert.equal(process.env.LOG_LEVEL, "warn");
+    assert.equal(process.env.OH_MY_PR_LOG_FILE, "/tmp/foo.log");
+    assert.equal(process.env.OH_MY_PR_NO_LOG_FILE, undefined);
+
+    applyLogEnv({ noLogFile: true });
+    assert.equal(process.env.OH_MY_PR_NO_LOG_FILE, "1");
+
+    applyLogEnv(undefined);
+  } finally {
+    if (prev.LOG_LEVEL === undefined) delete process.env.LOG_LEVEL; else process.env.LOG_LEVEL = prev.LOG_LEVEL;
+    if (prev.OH_MY_PR_LOG_FILE === undefined) delete process.env.OH_MY_PR_LOG_FILE; else process.env.OH_MY_PR_LOG_FILE = prev.OH_MY_PR_LOG_FILE;
+    if (prev.OH_MY_PR_NO_LOG_FILE === undefined) delete process.env.OH_MY_PR_NO_LOG_FILE; else process.env.OH_MY_PR_NO_LOG_FILE = prev.OH_MY_PR_NO_LOG_FILE;
+  }
+});
+
 test("formatCliHelp reflects the web-first command surface", () => {
   const help = formatCliHelp("1.2.3");
 
@@ -32,4 +111,6 @@ test("formatCliHelp reflects the web-first command surface", () => {
   assert.match(help, /oh-my-pr\s+Start the dashboard server/);
   assert.match(help, /oh-my-pr web\s+Start the dashboard server/);
   assert.match(help, /oh-my-pr mcp\s+Start the MCP server/);
+  assert.match(help, /--quiet/);
+  assert.match(help, /--log-file/);
 });

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -75,6 +75,15 @@ test("parseCliArgs --log-level validates the value", () => {
     mode: "web",
     log: { level: "warn" },
   });
+  assert.deepEqual(parseCliArgs(["--log-level=error"]), {
+    mode: "web",
+    log: { level: "error" },
+  });
+  assert.equal(parseCliArgs(["--log-level=bogus"]).mode, "help");
+  assert.deepEqual(parseCliArgs(["--log-level ", "trace"]), {
+    mode: "web",
+    log: { level: "trace" },
+  });
 });
 
 test("applyLogEnv writes the expected environment variables", () => {

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -23,7 +23,7 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
   let i = 0;
 
   while (i < argv.length) {
-    const tok = argv[i];
+    const tok = argv[i].trimEnd();
 
     if (tok === "--help" || tok === "-h") {
       return { mode: "help" };
@@ -71,14 +71,16 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
       i += 1;
       continue;
     }
-    if (tok === "--log-level") {
-      const next = argv[i + 1];
+    if (tok === "--log-level" || tok.startsWith("--log-level=")) {
+      const next = tok.startsWith("--log-level=")
+        ? tok.slice("--log-level=".length)
+        : argv[i + 1];
       const valid = ["trace", "debug", "info", "warn", "error", "fatal"];
       if (!next || !valid.includes(next)) {
         return { mode: "help", error: `--log-level must be one of ${valid.join(", ")}` };
       }
       log.level = next as CliLogOptions["level"];
-      i += 2;
+      i += tok.startsWith("--log-level=") ? 1 : 2;
       continue;
     }
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -1,37 +1,108 @@
 export type CliMode = "web" | "mcp" | "help" | "version";
 
+export type CliLogOptions = {
+  level?: "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+  logFile?: string;
+  noLogFile?: boolean;
+};
+
 export type ParsedCliArgs = {
   mode: CliMode;
+  log?: CliLogOptions;
   error?: string;
 };
 
+const KNOWN_MODES: Record<string, CliMode> = {
+  web: "web",
+  mcp: "mcp",
+};
+
 export function parseCliArgs(argv: string[]): ParsedCliArgs {
-  const command = argv[0];
+  let mode: CliMode | null = null;
+  const log: CliLogOptions = {};
+  let i = 0;
 
-  if (!command) {
-    return { mode: "web" };
+  while (i < argv.length) {
+    const tok = argv[i];
+
+    if (tok === "--help" || tok === "-h") {
+      return { mode: "help" };
+    }
+    if (tok === "--version" || tok === "-v") {
+      return { mode: "version" };
+    }
+
+    if (tok === "--quiet" || tok === "-q") {
+      log.level = "error";
+      i += 1;
+      continue;
+    }
+    if (tok === "--verbose") {
+      log.level = "debug";
+      i += 1;
+      continue;
+    }
+    if (tok === "--debug") {
+      log.level = "debug";
+      i += 1;
+      continue;
+    }
+    if (tok === "--trace") {
+      log.level = "trace";
+      i += 1;
+      continue;
+    }
+    if (tok === "--no-log-file") {
+      log.noLogFile = true;
+      i += 1;
+      continue;
+    }
+    if (tok === "--log-file") {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        return { mode: "help", error: "--log-file requires a path" };
+      }
+      log.logFile = next;
+      i += 2;
+      continue;
+    }
+    if (tok.startsWith("--log-file=")) {
+      log.logFile = tok.slice("--log-file=".length);
+      i += 1;
+      continue;
+    }
+    if (tok === "--log-level") {
+      const next = argv[i + 1];
+      const valid = ["trace", "debug", "info", "warn", "error", "fatal"];
+      if (!next || !valid.includes(next)) {
+        return { mode: "help", error: `--log-level must be one of ${valid.join(", ")}` };
+      }
+      log.level = next as CliLogOptions["level"];
+      i += 2;
+      continue;
+    }
+
+    if (mode === null && KNOWN_MODES[tok]) {
+      mode = KNOWN_MODES[tok];
+      i += 1;
+      continue;
+    }
+
+    return { mode: "help", error: `Unknown command: ${tok}` };
   }
 
-  if (command === "web") {
-    return { mode: "web" };
+  const result: ParsedCliArgs = { mode: mode ?? "web" };
+  if (log.level || log.logFile || log.noLogFile) {
+    result.log = log;
   }
+  return result;
+}
 
-  if (command === "mcp") {
-    return { mode: "mcp" };
-  }
-
-  if (command === "--help" || command === "-h") {
-    return { mode: "help" };
-  }
-
-  if (command === "--version" || command === "-v") {
-    return { mode: "version" };
-  }
-
-  return {
-    mode: "help",
-    error: `Unknown command: ${command}`,
-  };
+export function applyLogEnv(log: CliLogOptions | undefined): void {
+  if (!log) return;
+  if (log.level) process.env.LOG_LEVEL = log.level;
+  if (log.noLogFile) process.env.OH_MY_PR_NO_LOG_FILE = "1";
+  if (log.logFile) process.env.OH_MY_PR_LOG_FILE = log.logFile;
 }
 
 export function formatCliHelp(version: string): string {
@@ -48,10 +119,19 @@ export function formatCliHelp(version: string): string {
     oh-my-pr --help       Show this help message
     oh-my-pr --version    Print the version
 
+  Logging options:
+    -q, --quiet           Errors only
+    --verbose, --debug    Verbose output (debug level)
+    --trace               Maximum verbosity
+    --log-level <level>   trace | debug | info | warn | error | fatal
+    --log-file <path>     Override log file location
+    --no-log-file         Disable file logging
+
   Environment variables:
     PORT                  Server port (default: 5001)
     GITHUB_TOKEN          GitHub personal access token
     OH_MY_PR_HOME         Override config/state directory (~/.oh-my-pr)
+    LOG_LEVEL             Same as --log-level
 
   https://github.com/yungookim/oh-my-pr
 `;

--- a/server/github.ts
+++ b/server/github.ts
@@ -3,7 +3,20 @@ import type { CheckSnapshot, Config, FeedbackItem } from "@shared/schema";
 import { z } from "zod";
 import { runCommand } from "./agentRunner";
 import { normalizeCheckSnapshotsFromRef } from "./ciCheckIngestor";
+import { childLogger } from "./logger";
 import { renderGitHubMarkdown } from "./markdown";
+
+const octokitLog = childLogger("octokit");
+
+const octokitLogger = {
+  debug: (msg: string, ...args: unknown[]) => octokitLog.debug({ args }, msg),
+  info: (msg: string, ...args: unknown[]) => octokitLog.info({ args }, msg),
+  warn: (msg: string, ...args: unknown[]) => {
+    if (typeof msg === "string" && /is deprecated/i.test(msg)) return;
+    octokitLog.warn({ args }, msg);
+  },
+  error: (msg: string, ...args: unknown[]) => octokitLog.error({ args }, msg),
+};
 
 export type ParsedPRUrl = {
   owner: string;
@@ -697,6 +710,7 @@ export async function buildOctokit(
   const configuredToken = resolveConfiguredGitHubToken(config);
   const buildClient = (authToken?: string) => new Octokit({
     auth: authToken,
+    log: octokitLogger,
     request: {
       ...(deps.requestFetch ? { fetch: deps.requestFetch } : {}),
       headers: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,9 @@ import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
 import { localOnlyMiddleware } from "./localOnly";
 import { createServer } from "http";
+import { childLogger, logger } from "./logger";
+
+const serverLog = childLogger("server");
 
 const app = express();
 const httpServer = createServer(app);
@@ -28,13 +31,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use("/api", localOnlyMiddleware);
 
 export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-  console.log(`${formattedTime} [${source}] ${message}`);
+  logger.info({ source }, message);
 }
 
 async function openDashboard(url: string) {
@@ -53,7 +50,10 @@ async function openDashboard(url: string) {
     const status = error.status || error.statusCode || 500;
     const message = error.message || "Internal Server Error";
 
-    console.error("Internal Server Error:", err);
+    serverLog.error(
+      { err: err instanceof Error ? err.message : String(err), status },
+      "Internal Server Error",
+    );
 
     if (res.headersSent) {
       return next(err);

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+// Configure logger destination BEFORE first import.
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "ompr-log-"));
+const LOG_FILE = path.join(TMP_DIR, "server.log");
+process.env.OH_MY_PR_LOG_FILE = LOG_FILE;
+process.env.LOG_LEVEL = "info";
+process.env.NODE_ENV = "production";
+
+const { logger, sanitizeString, readRingBuffer, _resetRingBufferForTests } = await import("./logger");
+
+function flushAndRead(): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(fs.readFileSync(LOG_FILE, "utf8")), 50);
+  });
+}
+
+test("sanitizeString redacts ghp_/gho_/ghs_ tokens", () => {
+  const out = sanitizeString("auth=ghp_abcdefghijklmnopqrstuvwxyz0123456789");
+  assert.match(out, /ghp_\[REDACTED\]/);
+  assert.doesNotMatch(out, /abcdefghijkl/);
+});
+
+test("sanitizeString redacts github_pat_ tokens", () => {
+  const out = sanitizeString("token: github_pat_ABCDEF1234567890_abcdef1234567890");
+  assert.match(out, /github_pat_\[REDACTED\]/);
+});
+
+test("sanitizeString redacts x-access-token URLs", () => {
+  const url = "https://x-access-token:ghs_secret123456789012345@github.com/owner/repo.git";
+  const out = sanitizeString(url);
+  assert.match(out, /x-access-token:\[REDACTED\]/);
+  assert.doesNotMatch(out, /ghs_secret/);
+});
+
+test("sanitizeString redacts Bearer / token authorization values", () => {
+  assert.match(sanitizeString("Authorization: Bearer abcdef0123456789xyzfoo"), /Bearer \[REDACTED\]/);
+  assert.match(sanitizeString("token abcdef0123456789xyzfoo"), /token \[REDACTED\]/i);
+});
+
+test("sanitizeString leaves benign strings untouched", () => {
+  assert.equal(sanitizeString("hello world"), "hello world");
+  assert.equal(sanitizeString("status=ok count=12"), "status=ok count=12");
+});
+
+test("logger writes file and redacts tokens in serialized output", async () => {
+  logger.info(
+    { repo: "https://x-access-token:ghs_secret123456789012345@github.com/o/r.git" },
+    "cloning",
+  );
+  logger.warn("Authorization: Bearer abcdef0123456789xyzfoo");
+
+  const content = await flushAndRead();
+  assert.match(content, /\[REDACTED\]/);
+  assert.doesNotMatch(content, /ghs_secret/);
+  assert.doesNotMatch(content, /abcdef0123456789xyzfoo/);
+});
+
+test("redact paths censor structured token fields", async () => {
+  logger.info({ headers: { authorization: "Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" } }, "request");
+  const content = await flushAndRead();
+  // Either redact paths or sanitizeDeep should win — token must not appear.
+  assert.doesNotMatch(content, /ghp_xxxxxxxxxx/);
+});
+
+test("ring buffer captures entries", async () => {
+  _resetRingBufferForTests();
+  for (let i = 0; i < 5; i += 1) logger.info(`ring-msg-${i}`);
+  await new Promise((r) => setTimeout(r, 30));
+  const buf = readRingBuffer();
+  assert.ok(buf.length >= 5);
+  assert.match(buf.join("\n"), /ring-msg-0/);
+  assert.match(buf.join("\n"), /ring-msg-4/);
+});
+
+test.after(() => {
+  try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -60,6 +60,25 @@ test("logger writes file and redacts tokens in serialized output", async () => {
   assert.doesNotMatch(content, /abcdef0123456789xyzfoo/);
 });
 
+test("logger preserves Error details and handles circular records", async () => {
+  const circular: Record<string, unknown> = { label: "cycle" };
+  circular.self = circular;
+  logger.error({ err: new Error("failed with ghp_abcdefghijklmnopqrstuvwxyz0123456789"), circular }, "boom");
+
+  const content = await flushAndRead();
+  assert.match(content, /failed with ghp_\[REDACTED\]/);
+  assert.match(content, /"self":"\[Circular\]"/);
+  assert.doesNotMatch(content, /abcdefghijklmnopqrstuvwxyz0123456789/);
+});
+
+test("logger redacts printf-style interpolation arguments", async () => {
+  logger.info("token is %s", "ghs_secret12345678901234567890");
+
+  const content = await flushAndRead();
+  assert.match(content, /ghs_\[REDACTED\]/);
+  assert.doesNotMatch(content, /secret12345678901234567890/);
+});
+
 test("redact paths censor structured token fields", async () => {
   logger.info({ headers: { authorization: "Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" } }, "request");
   const content = await flushAndRead();

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -26,14 +26,30 @@ export function sanitizeString(s: string): string {
   return out;
 }
 
-function sanitizeDeep(value: unknown): unknown {
+function sanitizeDeep(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === "string") return sanitizeString(value);
-  if (Array.isArray(value)) return value.map(sanitizeDeep);
+  if (Array.isArray(value)) return value.map((item) => sanitizeDeep(item, seen));
   if (value && typeof value === "object") {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    if (value instanceof Error) {
+      const out: Record<string, unknown> = {
+        name: value.name,
+        message: sanitizeString(value.message),
+      };
+      if (value.stack) out.stack = sanitizeString(value.stack);
+      if ("cause" in value) out.cause = sanitizeDeep(value.cause, seen);
+      for (const [k, v] of Object.entries(value)) {
+        out[k] = sanitizeDeep(v, seen);
+      }
+      seen.delete(value);
+      return out;
+    }
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = sanitizeDeep(v);
+      out[k] = sanitizeDeep(v, seen);
     }
+    seen.delete(value);
     return out;
   }
   return value;
@@ -139,7 +155,7 @@ function buildStreams(): StreamEntry[] {
   const logFile = resolveLogFilePath();
   if (logFile) {
     streams.push({
-      stream: fs.createWriteStream(logFile, { flags: "a" }),
+      stream: pino.destination(logFile),
     });
   }
 
@@ -161,11 +177,10 @@ export const logger: Logger = pino(
     },
     hooks: {
       logMethod(args, method) {
-        // pino call shapes: (msg), (mergeObj, msg), (mergeObj, msg, ...interp)
-        if (typeof args[0] === "string") {
-          args[0] = sanitizeString(args[0]);
-        } else if (args.length >= 2 && typeof args[1] === "string") {
-          args[1] = sanitizeString(args[1] as string);
+        for (let i = 0; i < args.length; i += 1) {
+          if (typeof args[i] === "string") {
+            args[i] = sanitizeString(args[i] as string);
+          }
         }
         return method.apply(this, args as Parameters<typeof method>);
       },

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,179 @@
+import fs from "fs";
+import path from "path";
+import { Writable } from "stream";
+import pino, { type Level, type Logger, type StreamEntry } from "pino";
+import pretty from "pino-pretty";
+import { getCodeFactoryPaths } from "./paths";
+
+// ----- Token sanitization -----
+
+const TOKEN_PATTERNS: Array<{ re: RegExp; replace: string }> = [
+  // x-access-token:<token>@github.com URLs
+  { re: /(x-access-token:)[^@\s"']+/gi, replace: "$1[REDACTED]" },
+  // GitHub token prefixes
+  { re: /\b(ghp_|gho_|ghs_|ghu_|ghr_)[A-Za-z0-9]{20,}/g, replace: "$1[REDACTED]" },
+  { re: /\bgithub_pat_[A-Za-z0-9_]{20,}/g, replace: "github_pat_[REDACTED]" },
+  // Bearer / Token authorization headers in free text
+  { re: /\b(Bearer\s+)[A-Za-z0-9._-]{16,}/gi, replace: "$1[REDACTED]" },
+  { re: /\b(token\s+)[A-Za-z0-9._-]{16,}/gi, replace: "$1[REDACTED]" },
+];
+
+export function sanitizeString(s: string): string {
+  let out = s;
+  for (const { re, replace } of TOKEN_PATTERNS) {
+    out = out.replace(re, replace);
+  }
+  return out;
+}
+
+function sanitizeDeep(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeString(value);
+  if (Array.isArray(value)) return value.map(sanitizeDeep);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeDeep(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+// ----- Ring buffer (for in-app log viewer in PR 2) -----
+
+const RING_SIZE = 5000;
+const ring: string[] = new Array<string>();
+let ringHead = 0;
+let ringFilled = false;
+
+function ringPush(line: string) {
+  if (!ringFilled) {
+    ring.push(line);
+    if (ring.length >= RING_SIZE) {
+      ringFilled = true;
+      ringHead = 0;
+    }
+    return;
+  }
+  ring[ringHead] = line;
+  ringHead = (ringHead + 1) % RING_SIZE;
+}
+
+export function readRingBuffer(): string[] {
+  if (!ringFilled) return ring.slice();
+  return [...ring.slice(ringHead), ...ring.slice(0, ringHead)];
+}
+
+export function _resetRingBufferForTests() {
+  ring.length = 0;
+  ringHead = 0;
+  ringFilled = false;
+}
+
+const ringStream = new Writable({
+  write(chunk, _enc, cb) {
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    for (const line of text.split("\n")) {
+      if (line.length > 0) ringPush(line);
+    }
+    cb();
+  },
+});
+
+// ----- Level / destination resolution -----
+
+const VALID_LEVELS: Level[] = ["trace", "debug", "info", "warn", "error", "fatal"];
+
+function resolveLevel(): Level {
+  const env = (process.env.LOG_LEVEL || "").toLowerCase();
+  if ((VALID_LEVELS as string[]).includes(env)) return env as Level;
+  return process.env.NODE_ENV === "production" ? "info" : "debug";
+}
+
+function resolveLogFilePath(): string | null {
+  if (process.env.OH_MY_PR_NO_LOG_FILE === "1") return null;
+  const override = process.env.OH_MY_PR_LOG_FILE;
+  if (override) return override;
+  const dir = getCodeFactoryPaths().logRootDir;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    return path.join(dir, "server.log");
+  } catch (err) {
+    process.stderr.write(
+      `logger: could not create log dir ${dir}: ${(err as Error).message}\n`,
+    );
+    return null;
+  }
+}
+
+// ----- Pino setup -----
+
+const REDACT_PATHS = [
+  "authorization",
+  "headers.authorization",
+  "*.authorization",
+  "config.githubToken",
+  "config.GITHUB_TOKEN",
+  "GITHUB_TOKEN",
+  "token",
+  "auth",
+];
+
+function buildStreams(): StreamEntry[] {
+  const streams: StreamEntry[] = [];
+
+  const isDev = process.env.NODE_ENV !== "production";
+  if (isDev && process.stdout.isTTY) {
+    const prettyStream = pretty({
+      colorize: true,
+      translateTime: "SYS:HH:MM:ss",
+      ignore: "pid,hostname",
+      messageFormat: "{msg}",
+    });
+    prettyStream.pipe(process.stdout);
+    streams.push({ stream: prettyStream });
+  } else {
+    streams.push({ stream: process.stdout });
+  }
+
+  const logFile = resolveLogFilePath();
+  if (logFile) {
+    streams.push({
+      stream: fs.createWriteStream(logFile, { flags: "a" }),
+    });
+  }
+
+  streams.push({ stream: ringStream });
+
+  return streams;
+}
+
+export const logger: Logger = pino(
+  {
+    level: resolveLevel(),
+    base: undefined,
+    timestamp: pino.stdTimeFunctions.isoTime,
+    redact: { paths: REDACT_PATHS, censor: "[REDACTED]" },
+    formatters: {
+      log(record) {
+        return sanitizeDeep(record) as Record<string, unknown>;
+      },
+    },
+    hooks: {
+      logMethod(args, method) {
+        // pino call shapes: (msg), (mergeObj, msg), (mergeObj, msg, ...interp)
+        if (typeof args[0] === "string") {
+          args[0] = sanitizeString(args[0]);
+        } else if (args.length >= 2 && typeof args[1] === "string") {
+          args[1] = sanitizeString(args[1] as string);
+        }
+        return method.apply(this, args as Parameters<typeof method>);
+      },
+    },
+  },
+  pino.multistream(buildStreams()),
+);
+
+export function childLogger(source: string): Logger {
+  return logger.child({ source });
+}

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -6,6 +6,7 @@ import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./relea
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
 import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
+import { _resetRingBufferForTests, readRingBuffer } from "./logger";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -445,29 +446,23 @@ test("ReleaseManager logs release job scheduling failures", async () => {
     },
   });
 
-  const originalConsoleError = console.error;
-  const logged: unknown[][] = [];
-  console.error = (...args: unknown[]) => {
-    logged.push(args);
-  };
+  _resetRingBufferForTests();
 
-  try {
-    const created = await manager.enqueueMergedPullReleaseEvaluation({
-      repo: "yungookim/oh-my-pr",
-      baseBranch: "main",
-      triggerPrNumber: 75,
-      triggerPrTitle: "Queue failure logging",
-      triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/75",
-      triggerMergeSha: "queue-failure-sha",
-      triggerMergedAt: "2026-03-28T19:00:00.000Z",
-    });
+  const created = await manager.enqueueMergedPullReleaseEvaluation({
+    repo: "yungookim/oh-my-pr",
+    baseBranch: "main",
+    triggerPrNumber: 75,
+    triggerPrTitle: "Queue failure logging",
+    triggerPrUrl: "https://github.com/yungookim/oh-my-pr/pull/75",
+    triggerMergeSha: "queue-failure-sha",
+    triggerMergedAt: "2026-03-28T19:00:00.000Z",
+  });
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setTimeout(resolve, 30));
 
-    assert.equal(logged.length, 1);
-    assert.equal(logged[0][0], `Failed to schedule release run ${created.id}:`);
-    assert.equal(logged[0][1], schedulingError);
-  } finally {
-    console.error = originalConsoleError;
-  }
+  const ring = readRingBuffer().join("\n");
+  assert.match(ring, /Failed to schedule release run/);
+  assert.match(ring, new RegExp(created.id));
+  assert.match(ring, /queue unavailable/);
 });

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -5,6 +5,9 @@ import { parseRepoSlug } from "./github";
 import type { IStorage } from "./storage";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
 import { buildActivityPayload } from "./activityPayload";
+import { childLogger } from "./logger";
+
+const log = childLogger("release");
 import {
   evaluateReleaseWorthinessWithAgent,
   type ReleaseAgentPullSummary,
@@ -459,7 +462,10 @@ export class ReleaseManager {
           }),
         },
       ).catch((error) => {
-        console.error(`Failed to schedule release run ${id}:`, error);
+        log.warn(
+          { err: error instanceof Error ? error.message : String(error), runId: id },
+          "Failed to schedule release run",
+        );
       });
       return;
     }


### PR DESCRIPTION
Closes #137

## Summary

Replaces raw `console.*` writes in `server/` with a pino-based logger and adds the foundation for the upcoming in-app log viewer. Cuts the two main sources of terminal noise that `oh-my-pr web` users see today.

### What changed

**New `server/logger.ts`** — pino singleton with three streams:
- stdout (pino-pretty in dev TTY, JSON in prod)
- file at `getCodeFactoryPaths().logRootDir/server.log` (overridable via `--log-file` / `OH_MY_PR_LOG_FILE`, disable with `--no-log-file`)
- in-memory ring buffer (5000 records) for the upcoming `/api/logs` endpoint

**Token redaction** (covers Q5a from peer review):
- pino `redact` paths: `authorization`, `headers.authorization`, `*.authorization`, `config.githubToken`, `GITHUB_TOKEN`, `token`, `auth`
- regex sanitizer scrubs `ghp_/gho_/ghs_/ghu_/ghr_`, `github_pat_`, `x-access-token:…@` URLs, and `Bearer …` / `token …` headers from any string in any record (msg, structured fields, nested objects)

**Octokit noise** — `buildOctokit()` now passes a `log` option that drops `is deprecated` warnings (kills the spam from `@octokit/request` on every GitHub REST call).

**Babysitter recoverable failures** — `console.error("Babysitter failure", error)` with full stack → `log.warn({err, prId}, ...)` with message only; stack dumps move to `debug` level. Same treatment for `getAuthenticatedLogin`, `list open PRs`, and log queue write failures.

**CLI flags** (`server/cli.ts`, `bin/codefactory.cjs`):
- `-q / --quiet` (errors only), `--verbose`, `--debug`, `--trace`
- `--log-level <trace|debug|info|warn|error|fatal>`
- `--log-file <path>`, `--no-log-file`
- Flags can appear before or after the subcommand
- `applyLogEnv()` writes env vars before the logger module loads

**Build** — `pino` + `pino-pretty` added to the build allowlist so the bundled `dist/index.cjs` stays self-contained for Tauri (`packagedBundle.test.ts` continues to pass).

### Migrations

`console.{log,error}` replaced with logger calls in `appRuntime.ts`, `backgroundJobDispatcher.ts`, `releaseManager.ts`, `babysitter.ts`, `index.ts`, `github.ts`. The intentional production startup banner in `index.ts` is left as `console.log` (user-facing UX, not log noise). `index.ts log()` kept as a thin alias so existing callers don't churn.

`releaseManager.test.ts` ported from `console.error` monkey-patch to ring-buffer assertion.

### Why this shape

This was peer-reviewed via Codex CLI before implementation. Notable deltas applied:
- Skipped `pino-roll` — `pino.destination()` to a plain file is enough; rotation can land later if log growth becomes a problem
- Octokit filter via `log` option, not a request hook (avoids hiding response headers from downstream code)
- Log dir routed through existing `getCodeFactoryPaths().logRootDir`, not hardcoded `~/.oh-my-pr`
- Token redaction is non-negotiable — landed in this PR, tested

### Follow-up (PR 2)

In-app log viewer: `GET /api/logs` (paginated ring buffer read) + `GET /api/logs/stream` (SSE tail) + a "Logs" tab in the dashboard.

## Test plan

- [x] `npm test` — 402/403 pass; the 1 failure (`agentRunner.test.ts` codex `@rpath/libnode.141.dylib`) reproduces on `main` with this branch stashed (pre-existing, unrelated)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds; `packagedBundle.test.ts` passes (pino bundled)
- [x] `node bin/codefactory.cjs --help` shows new flags
- [x] `node bin/codefactory.cjs web --quiet --no-log-file` produces only the startup banner
- [x] `node bin/codefactory.cjs web --debug` writes structured JSON to `OH_MY_PR_LOG_FILE`
- [x] New tests: 8 logger tests (sanitizer, file output, structured-field redact, ring buffer), 11 CLI tests (flag parsing, env application)
