### PR TITLE
feat: in-app log viewer with SSE tail (Logs page)

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -513,6 +513,37 @@ Retrieve activity logs, optionally filtered by PR.
 
 **Response** `200` — array of [LogEntry objects](#logentry)
 
+#### `GET /api/server-logs`
+
+Retrieve recent structured server log records from the in-memory ring buffer
+that backs the dashboard `/logs` page.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `level` | string | Minimum level: `trace`, `debug`, `info`, `warn`, `error`, or `fatal` |
+| `source` | string | Filter to one structured log source |
+| `since` | number | Return records with a sequence number greater than this cursor |
+| `search` | string | Case-insensitive match against the message or structured fields |
+| `limit` | number | Maximum number of records to return; defaults to `500` |
+
+**Response** `200`
+```json
+{
+  "records": [],
+  "sources": ["babysitter", "github"],
+  "latestSeq": 123
+}
+```
+
+#### `GET /api/server-logs/stream`
+
+Tail server logs as Server-Sent Events for the dashboard `/logs` page. Pass
+`since` to replay up to the latest 1000 missed records before live events
+begin. Slow clients may be disconnected rather than allowing unbounded response
+buffering.
+
 ---
 
 ### CI healing sessions

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Watched repositories default to `My PRs only`. You can switch a repo to `My PRs 
 oh-my-pr can be used in a few ways:
 
 - web dashboard: `oh-my-pr`
+- server logs page: `http://localhost:5001/logs`
 - MCP server: `oh-my-pr mcp`
 - local REST API: see [LOCAL_API.md](LOCAL_API.md)
 - optional Tauri desktop shell

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from "@/pages/dashboard";
 import Settings from "@/pages/settings";
 import Changelogs from "@/pages/changelogs";
 import Releases from "@/pages/releases";
+import Logs from "@/pages/logs";
 import NotFound from "@/pages/not-found";
 
 function AppRouter() {
@@ -18,6 +19,7 @@ function AppRouter() {
       <Route path="/settings" component={Settings} />
       <Route path="/changelogs" component={Changelogs} />
       <Route path="/releases" component={Releases} />
+      <Route path="/logs" component={Logs} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1214,6 +1214,12 @@ export default function Dashboard() {
           >
             releases
           </Link>
+          <Link
+            href="/logs"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            logs
+          </Link>
         </div>
         <div className="flex flex-wrap items-center gap-3">
           <span className="text-[11px] text-muted-foreground">

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useSearch } from "wouter";
+import { fetchJson } from "@/lib/queryClient";
+import { UpdateBanner } from "@/components/UpdateBanner";
+
+const LEVELS = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
+type Level = (typeof LEVELS)[number];
+
+type LogRecord = {
+  seq: number;
+  time: number;
+  level: Level;
+  source?: string;
+  msg: string;
+  fields: Record<string, unknown>;
+};
+
+type LogsResponse = {
+  records: LogRecord[];
+  sources: string[];
+  latestSeq: number;
+};
+
+const LEVEL_RANK: Record<Level, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+const LEVEL_COLOR: Record<Level, string> = {
+  trace: "text-muted-foreground",
+  debug: "text-muted-foreground",
+  info: "text-foreground",
+  warn: "text-yellow-500",
+  error: "text-red-500",
+  fatal: "text-red-600 font-medium",
+};
+
+function parseSearchParams(search: string): {
+  level: Level | "";
+  source: string;
+  search: string;
+  follow: boolean;
+} {
+  const params = new URLSearchParams(search);
+  const rawLevel = params.get("level") ?? "";
+  const level = (LEVELS as readonly string[]).includes(rawLevel) ? (rawLevel as Level) : "";
+  return {
+    level,
+    source: params.get("source") ?? "",
+    search: params.get("q") ?? "",
+    follow: params.get("follow") === "1",
+  };
+}
+
+function formatTime(ms: number): string {
+  const d = new Date(ms);
+  return d.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+function recordToText(r: LogRecord): string {
+  const fields = Object.keys(r.fields).length > 0 ? " " + JSON.stringify(r.fields) : "";
+  const source = r.source ? ` [${r.source}]` : "";
+  return `${formatTime(r.time)} ${r.level.toUpperCase().padEnd(5)}${source} ${r.msg}${fields}`;
+}
+
+function recordsToText(records: LogRecord[]): string {
+  return records.map(recordToText).join("\n");
+}
+
+function setUrlParams(updates: { level?: string; source?: string; q?: string; follow?: boolean }) {
+  const hash = window.location.hash || "#/logs";
+  const [path, queryString] = hash.replace(/^#/, "").split("?");
+  const params = new URLSearchParams(queryString ?? "");
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === "" || value === false || value === undefined) {
+      params.delete(key);
+    } else if (value === true) {
+      params.set(key, "1");
+    } else {
+      params.set(key, String(value));
+    }
+  }
+  const next = params.toString();
+  window.location.hash = next ? `${path}?${next}` : path;
+}
+
+export default function Logs() {
+  const search = useSearch();
+  const initial = useMemo(() => parseSearchParams(search), [search]);
+
+  const [level, setLevel] = useState<Level | "">(initial.level);
+  const [source, setSource] = useState<string>(initial.source);
+  const [searchTerm, setSearchTerm] = useState<string>(initial.search);
+  const [follow, setFollow] = useState<boolean>(initial.follow);
+
+  const [records, setRecords] = useState<LogRecord[]>([]);
+  const [sources, setSources] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const recordsRef = useRef<LogRecord[]>([]);
+  recordsRef.current = records;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const followRef = useRef(follow);
+  followRef.current = follow;
+
+  // Initial load
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    const params = new URLSearchParams();
+    if (level) params.set("level", level);
+    if (source) params.set("source", source);
+    if (searchTerm) params.set("search", searchTerm);
+    params.set("limit", "1000");
+
+    fetchJson<LogsResponse>(`/api/server-logs?${params.toString()}`)
+      .then((res) => {
+        if (cancelled) return;
+        setRecords(res.records);
+        setSources(res.sources);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      });
+
+    return () => { cancelled = true; };
+  }, [level, source, searchTerm]);
+
+  // SSE tail when "follow" is on
+  useEffect(() => {
+    if (!follow) return;
+    const lastSeq = recordsRef.current[recordsRef.current.length - 1]?.seq ?? 0;
+    const url = `/api/server-logs/stream?since=${lastSeq}`;
+    const es = new EventSource(url);
+    es.onmessage = (event) => {
+      try {
+        const record = JSON.parse(event.data) as LogRecord;
+        setRecords((prev) => {
+          if (prev.length > 0 && prev[prev.length - 1].seq >= record.seq) return prev;
+          const next = [...prev, record];
+          // Keep the in-memory window bounded
+          return next.length > 5000 ? next.slice(next.length - 5000) : next;
+        });
+      } catch {
+        /* ignore malformed line */
+      }
+    };
+    es.onerror = () => {
+      setError("Lost log stream connection — disable Follow tail and re-enable to retry");
+    };
+    return () => {
+      es.close();
+    };
+  }, [follow]);
+
+  // Auto-scroll while following
+  useEffect(() => {
+    if (!follow) return;
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [records, follow]);
+
+  // URL persistence
+  useEffect(() => { setUrlParams({ level }); }, [level]);
+  useEffect(() => { setUrlParams({ source }); }, [source]);
+  useEffect(() => { setUrlParams({ q: searchTerm }); }, [searchTerm]);
+  useEffect(() => { setUrlParams({ follow }); }, [follow]);
+
+  const filteredRecords = useMemo(() => {
+    let out = records;
+    if (level) {
+      const minRank = LEVEL_RANK[level];
+      out = out.filter((r) => LEVEL_RANK[r.level] >= minRank);
+    }
+    if (source) out = out.filter((r) => r.source === source);
+    if (searchTerm) {
+      const needle = searchTerm.toLowerCase();
+      out = out.filter((r) =>
+        r.msg.toLowerCase().includes(needle)
+        || JSON.stringify(r.fields).toLowerCase().includes(needle),
+      );
+    }
+    return out;
+  }, [records, level, source, searchTerm]);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(recordsToText(filteredRecords));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const onDownload = () => {
+    const blob = new Blob([recordsToText(filteredRecords)], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `oh-my-pr-logs-${new Date().toISOString().replace(/[:.]/g, "-")}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex h-screen flex-col">
+      <UpdateBanner />
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-label="oh-my-pr">
+            <rect x="1" y="1" width="14" height="14" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M4 5h8M4 8h5M4 11h6" stroke="currentColor" strokeWidth="1" />
+          </svg>
+          <span className="text-sm font-medium tracking-tight">oh-my-pr</span>
+          <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+            logs
+          </span>
+        </div>
+        <Link
+          href="/"
+          className="text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        >
+          ← back to dashboard
+        </Link>
+      </header>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-2 text-[11px]">
+        <label htmlFor="logs-level" className="uppercase tracking-wider text-muted-foreground">level</label>
+        <select
+          id="logs-level"
+          value={level}
+          onChange={(e) => setLevel(e.target.value as Level | "")}
+          className="border border-border bg-transparent px-2 py-0.5 focus:border-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <option value="">all</option>
+          {LEVELS.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+
+        <label htmlFor="logs-source" className="uppercase tracking-wider text-muted-foreground">source</label>
+        <select
+          id="logs-source"
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          className="border border-border bg-transparent px-2 py-0.5 focus:border-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <option value="">all</option>
+          {sources.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+
+        <input
+          type="search"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="search…"
+          className="min-w-[180px] flex-1 border border-border bg-transparent px-2 py-0.5 focus:border-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+
+        <label className="flex cursor-pointer items-center gap-1.5 uppercase tracking-wider text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={follow}
+            onChange={(e) => setFollow(e.target.checked)}
+            className="cursor-pointer"
+          />
+          follow tail
+        </label>
+
+        <span className="ml-auto text-muted-foreground">
+          {filteredRecords.length} of {records.length}
+        </span>
+
+        <button
+          type="button"
+          onClick={onCopy}
+          className="border border-border px-2 py-0.5 uppercase tracking-wider text-muted-foreground hover:border-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          copy
+        </button>
+        <button
+          type="button"
+          onClick={onDownload}
+          className="border border-border px-2 py-0.5 uppercase tracking-wider text-muted-foreground hover:border-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          download
+        </button>
+      </div>
+
+      {error && (
+        <div className="shrink-0 border-b border-red-500/40 bg-red-500/10 px-4 py-1 text-[11px] text-red-500">
+          {error}
+        </div>
+      )}
+
+      <div ref={containerRef} className="flex-1 overflow-y-auto p-3 font-mono text-[11px] leading-relaxed">
+        {filteredRecords.length === 0 ? (
+          <div className="text-center text-muted-foreground">No log records match the current filter.</div>
+        ) : (
+          filteredRecords.map((r) => (
+            <div key={r.seq} className="flex gap-2 whitespace-pre-wrap break-all">
+              <span className="shrink-0 text-muted-foreground">{formatTime(r.time)}</span>
+              <span className={`shrink-0 w-12 ${LEVEL_COLOR[r.level]}`}>{r.level}</span>
+              {r.source && <span className="shrink-0 text-muted-foreground">[{r.source}]</span>}
+              <span className="grow">
+                {r.msg}
+                {Object.keys(r.fields).length > 0 && (
+                  <span className="text-muted-foreground"> {JSON.stringify(r.fields)}</span>
+                )}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -54,6 +54,8 @@ oh-my-pr --log-file /tmp/oh-my-pr.log
 oh-my-pr --no-log-file
 ```
 
+The dashboard also exposes a server log viewer at `/logs`. It shows recent structured server logs from the in-memory ring buffer, supports level/source/search filtering, and tails new log records live while the page is open. The live tail uses Server-Sent Events over the local HTTP server, so keep access local and avoid putting the dashboard behind buffering proxies.
+
 ## Dashboard Settings
 
 The settings page in the dashboard provides a UI for:

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -11,7 +11,7 @@ process.env.OH_MY_PR_LOG_FILE = LOG_FILE;
 process.env.LOG_LEVEL = "info";
 process.env.NODE_ENV = "production";
 
-const { logger, sanitizeString, readRingBuffer, _resetRingBufferForTests } = await import("./logger");
+const { logger, sanitizeString, readRingBuffer, _resetRingBufferForTests, _writeRingChunkForTests } = await import("./logger");
 
 function flushAndRead(): Promise<string> {
   return new Promise((resolve) => {
@@ -86,6 +86,19 @@ test("redact paths censor structured token fields", async () => {
   assert.doesNotMatch(content, /ghp_xxxxxxxxxx/);
 });
 
+test("logger handles circular structured fields", async () => {
+  const circular: Record<string, unknown> = {
+    repo: "https://x-access-token:ghs_secret123456789012345@github.com/o/r.git",
+  };
+  circular.self = circular;
+
+  assert.doesNotThrow(() => logger.info(circular, "circular event"));
+
+  const content = await flushAndRead();
+  assert.match(content, /"\[Circular\]"/);
+  assert.doesNotMatch(content, /ghs_secret/);
+});
+
 test("ring buffer captures entries", async () => {
   _resetRingBufferForTests();
   for (let i = 0; i < 5; i += 1) logger.info(`ring-msg-${i}`);
@@ -94,6 +107,24 @@ test("ring buffer captures entries", async () => {
   assert.ok(buf.length >= 5);
   assert.match(buf.join("\n"), /ring-msg-0/);
   assert.match(buf.join("\n"), /ring-msg-4/);
+});
+
+test("ring buffer preserves records split across write chunks", async () => {
+  _resetRingBufferForTests();
+  const line = JSON.stringify({
+    level: 30,
+    time: 1710000000000,
+    source: "split-test",
+    msg: "split chunk event",
+  });
+
+  await _writeRingChunkForTests(line.slice(0, 20));
+  assert.equal(readRingBuffer().length, 0);
+
+  await _writeRingChunkForTests(`${line.slice(20)}   \n`);
+  const buf = readRingBuffer();
+  assert.equal(buf.length, 1);
+  assert.match(buf[0], /split chunk event/);
 });
 
 test.after(() => {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -55,42 +55,170 @@ function sanitizeDeep(value: unknown, seen = new WeakSet<object>()): unknown {
   return value;
 }
 
-// ----- Ring buffer (for in-app log viewer in PR 2) -----
+// ----- Ring buffer & structured records (powers /api/server-logs) -----
+
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+export type LogRecord = {
+  seq: number;
+  time: number;
+  level: LogLevel;
+  source?: string;
+  msg: string;
+  fields: Record<string, unknown>;
+};
 
 const RING_SIZE = 5000;
-const ring: string[] = new Array<string>();
-let ringHead = 0;
-let ringFilled = false;
+const PINO_LEVEL_NAMES: Record<number, LogLevel> = {
+  10: "trace",
+  20: "debug",
+  30: "info",
+  40: "warn",
+  50: "error",
+  60: "fatal",
+};
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
 
-function ringPush(line: string) {
-  if (!ringFilled) {
-    ring.push(line);
-    if (ring.length >= RING_SIZE) {
-      ringFilled = true;
-      ringHead = 0;
+const records: LogRecord[] = [];
+let recordsHead = 0;
+let recordsFilled = false;
+let recordSeq = 0;
+const subscribers = new Set<(record: LogRecord) => void>();
+
+function pushRecord(record: LogRecord) {
+  if (!recordsFilled) {
+    records.push(record);
+    if (records.length >= RING_SIZE) {
+      recordsFilled = true;
+      recordsHead = 0;
     }
     return;
   }
-  ring[ringHead] = line;
-  ringHead = (ringHead + 1) % RING_SIZE;
+  records[recordsHead] = record;
+  recordsHead = (recordsHead + 1) % RING_SIZE;
 }
 
+function readAllRecords(): LogRecord[] {
+  if (!recordsFilled) return records.slice();
+  return [...records.slice(recordsHead), ...records.slice(0, recordsHead)];
+}
+
+// Back-compat: serialized lines for tests / quick assertions.
 export function readRingBuffer(): string[] {
-  if (!ringFilled) return ring.slice();
-  return [...ring.slice(ringHead), ...ring.slice(0, ringHead)];
+  return readAllRecords().map((r) => JSON.stringify({
+    level: LOG_LEVEL_RANK[r.level],
+    time: r.time,
+    source: r.source,
+    msg: r.msg,
+    ...r.fields,
+  }));
 }
 
 export function _resetRingBufferForTests() {
-  ring.length = 0;
-  ringHead = 0;
-  ringFilled = false;
+  records.length = 0;
+  recordsHead = 0;
+  recordsFilled = false;
+  recordSeq = 0;
+  subscribers.clear();
+}
+
+function parseLine(line: string): Omit<LogRecord, "seq"> | null {
+  if (!line.startsWith("{")) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const levelNum = typeof parsed.level === "number" ? parsed.level : 30;
+  const level = PINO_LEVEL_NAMES[levelNum] ?? "info";
+  const time = typeof parsed.time === "string"
+    ? Date.parse(parsed.time)
+    : typeof parsed.time === "number"
+      ? parsed.time
+      : Date.now();
+  const msg = typeof parsed.msg === "string" ? parsed.msg : "";
+  const source = typeof parsed.source === "string" ? parsed.source : undefined;
+  const { level: _l, time: _t, msg: _m, source: _s, ...rest } = parsed;
+  return { time, level, source, msg, fields: rest };
+}
+
+export type ReadLogsOptions = {
+  level?: LogLevel;
+  source?: string;
+  since?: number;
+  search?: string;
+  limit?: number;
+};
+
+export function readLogRecords(opts: ReadLogsOptions = {}): LogRecord[] {
+  let out = readAllRecords();
+
+  if (opts.level) {
+    const minRank = LOG_LEVEL_RANK[opts.level];
+    out = out.filter((r) => LOG_LEVEL_RANK[r.level] >= minRank);
+  }
+  if (opts.source) {
+    out = out.filter((r) => r.source === opts.source);
+  }
+  if (opts.since !== undefined) {
+    const since = opts.since;
+    out = out.filter((r) => r.seq > since);
+  }
+  if (opts.search) {
+    const needle = opts.search.toLowerCase();
+    out = out.filter((r) =>
+      r.msg.toLowerCase().includes(needle)
+      || JSON.stringify(r.fields).toLowerCase().includes(needle),
+    );
+  }
+  if (opts.limit && opts.limit > 0) {
+    out = out.slice(-opts.limit);
+  }
+  return out;
+}
+
+export function getKnownLogSources(): string[] {
+  const seen = new Set<string>();
+  for (const r of readAllRecords()) {
+    if (r.source) seen.add(r.source);
+  }
+  return Array.from(seen).sort();
+}
+
+export function subscribeToLogs(cb: (record: LogRecord) => void): () => void {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
 }
 
 const ringStream = new Writable({
   write(chunk, _enc, cb) {
     const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
     for (const line of text.split("\n")) {
-      if (line.length > 0) ringPush(line);
+      if (line.length === 0) continue;
+      const parsed = parseLine(line);
+      if (!parsed) continue;
+      recordSeq += 1;
+      const record: LogRecord = { seq: recordSeq, ...parsed };
+      pushRecord(record);
+      if (subscribers.size > 0) {
+        subscribers.forEach((sub) => {
+          try {
+            sub(record);
+          } catch {
+            /* ignore subscriber errors */
+          }
+        });
+      }
     }
     cb();
   },

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -28,29 +28,31 @@ export function sanitizeString(s: string): string {
 
 function sanitizeDeep(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === "string") return sanitizeString(value);
-  if (Array.isArray(value)) return value.map((item) => sanitizeDeep(item, seen));
   if (value && typeof value === "object") {
     if (seen.has(value)) return "[Circular]";
     seen.add(value);
-    if (value instanceof Error) {
-      const out: Record<string, unknown> = {
-        name: value.name,
-        message: sanitizeString(value.message),
-      };
-      if (value.stack) out.stack = sanitizeString(value.stack);
-      if ("cause" in value) out.cause = sanitizeDeep(value.cause, seen);
-      for (const [k, v] of Object.entries(value)) {
+    try {
+      if (Array.isArray(value)) return value.map((item) => sanitizeDeep(item, seen));
+      if (value instanceof Error) {
+        const out: Record<string, unknown> = {
+          name: value.name,
+          message: sanitizeString(value.message),
+        };
+        if (value.stack) out.stack = sanitizeString(value.stack);
+        if ("cause" in value) out.cause = sanitizeDeep(value.cause, seen);
+        for (const [k, v] of Object.entries(value)) {
+          out[k] = sanitizeDeep(v, seen);
+        }
+        return out;
+      }
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
         out[k] = sanitizeDeep(v, seen);
       }
-      seen.delete(value);
       return out;
+    } finally {
+      seen.delete(value);
     }
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = sanitizeDeep(v, seen);
-    }
-    seen.delete(value);
-    return out;
   }
   return value;
 }
@@ -90,6 +92,7 @@ const records: LogRecord[] = [];
 let recordsHead = 0;
 let recordsFilled = false;
 let recordSeq = 0;
+let ringStreamBuffer = "";
 const subscribers = new Set<(record: LogRecord) => void>();
 
 function pushRecord(record: LogRecord) {
@@ -126,6 +129,7 @@ export function _resetRingBufferForTests() {
   recordsHead = 0;
   recordsFilled = false;
   recordSeq = 0;
+  ringStreamBuffer = "";
   subscribers.clear();
 }
 
@@ -202,8 +206,11 @@ export function subscribeToLogs(cb: (record: LogRecord) => void): () => void {
 
 const ringStream = new Writable({
   write(chunk, _enc, cb) {
-    const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-    for (const line of text.split("\n")) {
+    ringStreamBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    const lines = ringStreamBuffer.split("\n");
+    ringStreamBuffer = lines.pop() ?? "";
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
       if (line.length === 0) continue;
       const parsed = parseLine(line);
       if (!parsed) continue;
@@ -214,8 +221,8 @@ const ringStream = new Writable({
         subscribers.forEach((sub) => {
           try {
             sub(record);
-          } catch {
-            /* ignore subscriber errors */
+          } catch (err) {
+            console.error("Error in log subscriber:", err);
           }
         });
       }
@@ -223,6 +230,12 @@ const ringStream = new Writable({
     cb();
   },
 });
+
+export function _writeRingChunkForTests(chunk: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ringStream.write(chunk, (err) => err ? reject(err) : resolve());
+  });
+}
 
 // ----- Level / destination resolution -----
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,8 @@ import {
 
 const VALID_LEVELS: LogLevel[] = ["trace", "debug", "info", "warn", "error", "fatal"];
 
+type SseWritable = Pick<Response, "write">;
+
 function parseLevel(value: unknown): LogLevel | undefined {
   if (typeof value !== "string") return undefined;
   return (VALID_LEVELS as string[]).includes(value) ? (value as LogLevel) : undefined;
@@ -86,6 +88,10 @@ function resolveMaskedGithubTokens(currentTokens: string[], requestedTokens: str
       return trimmed;
     })
     .filter(Boolean);
+}
+
+export function writeServerLogSseEvent(res: SseWritable, record: LogRecord): boolean {
+  return res.write(`id: ${record.seq}\ndata: ${JSON.stringify(record)}\n\n`) !== false;
 }
 
 function resolveConfigSecrets(current: Config, updates: Partial<Config>): Partial<Config> {
@@ -158,29 +164,37 @@ export async function registerRoutes(
     res.setHeader("X-Accel-Buffering", "no");
     res.flushHeaders?.();
 
+    let closed = false;
+    let heartbeat: NodeJS.Timeout | undefined;
+    let unsubscribe = () => {};
+
+    const cleanup = () => {
+      if (closed) return;
+      closed = true;
+      if (heartbeat) clearInterval(heartbeat);
+      unsubscribe();
+      if (!res.writableEnded) res.end();
+    };
+
     const send = (record: LogRecord) => {
-      res.write(`id: ${record.seq}\n`);
-      res.write(`data: ${JSON.stringify(record)}\n\n`);
+      if (!writeServerLogSseEvent(res, record)) cleanup();
     };
 
     // Replay any backlog the client missed, if `since` was provided.
     const since = parsePositiveInt(req.query.since);
     if (since !== undefined) {
       const backlog = readLogRecords({ since, limit: 1000 });
-      for (const record of backlog) send(record);
+      for (const record of backlog) {
+        send(record);
+        if (closed) return;
+      }
     }
 
-    const unsubscribe = subscribeToLogs(send);
+    unsubscribe = subscribeToLogs(send);
 
-    const heartbeat = setInterval(() => {
-      res.write(`: heartbeat ${Date.now()}\n\n`);
+    heartbeat = setInterval(() => {
+      if (res.write(`: heartbeat ${Date.now()}\n\n`) === false) cleanup();
     }, 20_000);
-
-    const cleanup = () => {
-      clearInterval(heartbeat);
-      unsubscribe();
-      res.end();
-    };
 
     req.on("close", cleanup);
     req.on("aborted", cleanup);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,6 +11,26 @@ import {
 } from "./appRuntime";
 import { createAppUpdateChecker, type AppUpdateChecker } from "./appUpdate";
 import { GitHubIntegrationError } from "./github";
+import {
+  getKnownLogSources,
+  readLogRecords,
+  subscribeToLogs,
+  type LogLevel,
+  type LogRecord,
+} from "./logger";
+
+const VALID_LEVELS: LogLevel[] = ["trace", "debug", "info", "warn", "error", "fatal"];
+
+function parseLevel(value: unknown): LogLevel | undefined {
+  if (typeof value !== "string") return undefined;
+  return (VALID_LEVELS as string[]).includes(value) ? (value as LogLevel) : undefined;
+}
+
+function parsePositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
 
 const TOKEN_MASK_PREFIX = "***";
 
@@ -111,6 +131,59 @@ export async function registerRoutes(
 
   app.get("/api/runtime", async (_req, res) => {
     res.json(await runtime.getRuntimeSnapshot());
+  });
+
+  app.get("/api/server-logs", (req, res) => {
+    const records = readLogRecords({
+      level: parseLevel(req.query.level),
+      source: typeof req.query.source === "string" ? req.query.source : undefined,
+      since: parsePositiveInt(req.query.since),
+      search: typeof req.query.search === "string" ? req.query.search : undefined,
+      limit: parsePositiveInt(req.query.limit) ?? 500,
+    });
+    res.json({
+      records,
+      sources: getKnownLogSources(),
+      latestSeq: records.length > 0 ? records[records.length - 1].seq : (parsePositiveInt(req.query.since) ?? 0),
+    });
+  });
+
+  app.get("/api/server-logs/stream", (req, res) => {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    // Defeat any compression middleware that may be added later — SSE must not buffer.
+    res.setHeader("Content-Encoding", "identity");
+    res.setHeader("X-Accel-Buffering", "no");
+    res.flushHeaders?.();
+
+    const send = (record: LogRecord) => {
+      res.write(`id: ${record.seq}\n`);
+      res.write(`data: ${JSON.stringify(record)}\n\n`);
+    };
+
+    // Replay any backlog the client missed, if `since` was provided.
+    const since = parsePositiveInt(req.query.since);
+    if (since !== undefined) {
+      const backlog = readLogRecords({ since, limit: 1000 });
+      for (const record of backlog) send(record);
+    }
+
+    const unsubscribe = subscribeToLogs(send);
+
+    const heartbeat = setInterval(() => {
+      res.write(`: heartbeat ${Date.now()}\n\n`);
+    }, 20_000);
+
+    const cleanup = () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+      res.end();
+    };
+
+    req.on("close", cleanup);
+    req.on("aborted", cleanup);
   });
 
   app.get("/api/activities", async (_req, res) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -165,13 +165,15 @@ export async function registerRoutes(
     res.flushHeaders?.();
 
     let closed = false;
-    let heartbeat: NodeJS.Timeout | undefined;
     let unsubscribe = () => {};
+    const heartbeat = setInterval(() => {
+      if (res.write(`: heartbeat ${Date.now()}\n\n`) === false) cleanup();
+    }, 20_000);
 
     const cleanup = () => {
       if (closed) return;
       closed = true;
-      if (heartbeat) clearInterval(heartbeat);
+      clearInterval(heartbeat);
       unsubscribe();
       if (!res.writableEnded) res.end();
     };
@@ -191,10 +193,6 @@ export async function registerRoutes(
     }
 
     unsubscribe = subscribeToLogs(send);
-
-    heartbeat = setInterval(() => {
-      if (res.write(`: heartbeat ${Date.now()}\n\n`) === false) cleanup();
-    }, 20_000);
 
     req.on("close", cleanup);
     req.on("aborted", cleanup);

--- a/server/serverLogsRoutes.test.ts
+++ b/server/serverLogsRoutes.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import test from "node:test";
 import express from "express";
 import { MemStorage } from "./memoryStorage";
-import { registerRoutes } from "./routes";
+import { registerRoutes, writeServerLogSseEvent } from "./routes";
 import { _resetRingBufferForTests, logger } from "./logger";
 
 async function createHarness() {
@@ -205,4 +205,25 @@ test("GET /api/server-logs/stream replays backlog when since is provided", async
   } finally {
     await h.close();
   }
+});
+
+test("writeServerLogSseEvent reports backpressure", () => {
+  const writes: string[] = [];
+  const ok = writeServerLogSseEvent({
+    write(chunk: string) {
+      writes.push(chunk);
+      return false;
+    },
+  }, {
+    seq: 42,
+    time: 1710000000000,
+    level: "info",
+    msg: "slow client event",
+    fields: {},
+  });
+
+  assert.equal(ok, false);
+  assert.equal(writes.length, 1);
+  assert.match(writes[0], /^id: 42\n/);
+  assert.match(writes[0], /data: .*slow client event/);
 });

--- a/server/serverLogsRoutes.test.ts
+++ b/server/serverLogsRoutes.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import express from "express";
+import { MemStorage } from "./memoryStorage";
+import { registerRoutes } from "./routes";
+import { _resetRingBufferForTests, logger } from "./logger";
+
+async function createHarness() {
+  const app = express();
+  app.use(express.json());
+  const server = createServer(app);
+  await registerRoutes(server, app, {
+    storage: new MemStorage(),
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("expected ephemeral address");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => err ? reject(err) : resolve());
+      });
+    },
+  };
+}
+
+async function flushLogs() {
+  await new Promise((r) => setTimeout(r, 30));
+}
+
+test("GET /api/server-logs returns ring buffer records and known sources", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    logger.info({ source: "babysitter" }, "first event");
+    logger.warn({ source: "github" }, "warn event");
+    logger.error({ source: "babysitter" }, "boom");
+    await flushLogs();
+
+    const res = await fetch(`${h.baseUrl}/api/server-logs`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      records: Array<{ msg: string; level: string; source?: string; seq: number }>;
+      sources: string[];
+      latestSeq: number;
+    };
+
+    const msgs = body.records.map((r) => r.msg);
+    assert.ok(msgs.includes("first event"));
+    assert.ok(msgs.includes("warn event"));
+    assert.ok(msgs.includes("boom"));
+    assert.deepEqual(body.sources.sort(), ["babysitter", "github"]);
+    assert.ok(body.latestSeq > 0);
+  } finally {
+    await h.close();
+  }
+});
+
+test("GET /api/server-logs filters by level", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    logger.info("info-msg");
+    logger.warn("warn-msg");
+    logger.error("error-msg");
+    await flushLogs();
+
+    const res = await fetch(`${h.baseUrl}/api/server-logs?level=warn`);
+    const body = (await res.json()) as { records: Array<{ msg: string; level: string }> };
+    const msgs = body.records.map((r) => r.msg);
+    assert.ok(!msgs.includes("info-msg"));
+    assert.ok(msgs.includes("warn-msg"));
+    assert.ok(msgs.includes("error-msg"));
+  } finally {
+    await h.close();
+  }
+});
+
+test("GET /api/server-logs filters by source and search", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    logger.info({ source: "alpha" }, "needle here");
+    logger.info({ source: "beta" }, "no match");
+    logger.info({ source: "alpha" }, "different message");
+    await flushLogs();
+
+    const sourceRes = await fetch(`${h.baseUrl}/api/server-logs?source=alpha`);
+    const sourceBody = (await sourceRes.json()) as { records: Array<{ source?: string }> };
+    assert.equal(sourceBody.records.length, 2);
+    assert.ok(sourceBody.records.every((r) => r.source === "alpha"));
+
+    const searchRes = await fetch(`${h.baseUrl}/api/server-logs?search=needle`);
+    const searchBody = (await searchRes.json()) as { records: Array<{ msg: string }> };
+    assert.equal(searchBody.records.length, 1);
+    assert.match(searchBody.records[0].msg, /needle/);
+  } finally {
+    await h.close();
+  }
+});
+
+test("GET /api/server-logs honors since cursor for pagination", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    logger.info("one");
+    logger.info("two");
+    await flushLogs();
+
+    const first = await (await fetch(`${h.baseUrl}/api/server-logs`)).json() as {
+      records: Array<{ seq: number }>;
+      latestSeq: number;
+    };
+    const cursor = first.latestSeq;
+
+    logger.info("three");
+    logger.info("four");
+    await flushLogs();
+
+    const tail = await (await fetch(`${h.baseUrl}/api/server-logs?since=${cursor}`)).json() as {
+      records: Array<{ msg: string; seq: number }>;
+    };
+    const msgs = tail.records.map((r) => r.msg);
+    assert.deepEqual(msgs, ["three", "four"]);
+    assert.ok(tail.records.every((r) => r.seq > cursor));
+  } finally {
+    await h.close();
+  }
+});
+
+test("GET /api/server-logs/stream emits new records as SSE events", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    const ac = new AbortController();
+    const res = await fetch(`${h.baseUrl}/api/server-logs/stream`, { signal: ac.signal });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/event-stream");
+    assert.equal(res.headers.get("content-encoding"), "identity");
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+
+    const readUntil = async (predicate: (text: string) => boolean, timeoutMs = 1500) => {
+      const start = Date.now();
+      while (!predicate(buffered)) {
+        if (Date.now() - start > timeoutMs) throw new Error(`timed out waiting; buffer: ${buffered}`);
+        const { value, done } = await reader.read();
+        if (done) throw new Error("stream closed early");
+        buffered += decoder.decode(value, { stream: true });
+      }
+    };
+
+    // Allow the SSE handler to register subscriber before logging.
+    await new Promise((r) => setTimeout(r, 30));
+    logger.info({ source: "stream-test" }, "live-event-1");
+    await readUntil((b) => b.includes("live-event-1"));
+
+    logger.warn({ source: "stream-test" }, "live-event-2");
+    await readUntil((b) => b.includes("live-event-2"));
+
+    assert.match(buffered, /id: \d+/);
+    assert.match(buffered, /data: \{.*"msg":"live-event-1"/);
+    assert.match(buffered, /data: \{.*"msg":"live-event-2"/);
+
+    ac.abort();
+  } finally {
+    await h.close();
+  }
+});
+
+test("GET /api/server-logs/stream replays backlog when since is provided", async () => {
+  _resetRingBufferForTests();
+  const h = await createHarness();
+  try {
+    logger.info({ source: "backlog" }, "older-event-1");
+    logger.info({ source: "backlog" }, "older-event-2");
+    await flushLogs();
+
+    const ac = new AbortController();
+    const res = await fetch(`${h.baseUrl}/api/server-logs/stream?since=0`, { signal: ac.signal });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+
+    const start = Date.now();
+    while (!(buffered.includes("older-event-1") && buffered.includes("older-event-2"))) {
+      if (Date.now() - start > 1500) throw new Error(`timed out; buffer: ${buffered}`);
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffered += decoder.decode(value, { stream: true });
+    }
+
+    assert.match(buffered, /older-event-1/);
+    assert.match(buffered, /older-event-2/);
+    ac.abort();
+  } finally {
+    await h.close();
+  }
+});


### PR DESCRIPTION
Closes #138
Depends on #136 (this PR's diff against \`main\` includes #136's commit until it merges; once it does, only the viewer commit will remain).

## Summary

Adds a Logs page to the dashboard so users can see live server output without leaving the UI. Two new endpoints under the existing \`localOnlyMiddleware\` plus a React page wired in at \`/#/logs\` with a link in the dashboard header.

### Backend

\`server/routes.ts\`:

- \`GET /api/server-logs\` — paginated read of the in-memory ring buffer with \`level\`, \`source\`, \`since\`, \`search\`, \`limit\` query params. Returns \`{ records, sources, latestSeq }\` so the client can drive both filtering UI and tail cursors from one response.
- \`GET /api/server-logs/stream\` — Server-Sent Events tail. Headers per peer review: \`text/event-stream\`, \`Cache-Control: no-cache, no-transform\`, \`Connection: keep-alive\`, \`Content-Encoding: identity\` (defeats any future \`compression()\` middleware buffering — Codex flagged this footgun), plus \`X-Accel-Buffering: no\`. 20s heartbeat comments to defeat proxy/browser idle timeouts. Listener cleanup on both \`req.close\` and \`req.aborted\`. Optional \`?since=<seq>\` replays any backlog the client missed before subscribing live.

\`server/logger.ts\` refactor:

- Store parsed \`LogRecord\` objects directly in the ring (not raw JSON lines), so \`seq\` is assigned once at write time and stays stable across reads.
- New exports: \`readLogRecords(opts)\`, \`getKnownLogSources()\`, \`subscribeToLogs(cb)\`, \`LogRecord\`/\`LogLevel\` types.
- \`readRingBuffer()\` kept as a back-compat helper that re-serializes records (used by existing tests).

### Frontend

\`client/src/pages/logs.tsx\`:

- Level dropdown, source dropdown (populated from \`sources\` returned by the API), free-text search
- Follow-tail toggle — when on, opens an EventSource subscribed to live records and auto-scrolls
- Copy / download buttons for the visible filtered set
- All filter state persisted in URL query params via \`useSearch()\` so views survive reloads / are shareable
- Color-coded levels (warn yellow, error/fatal red), monospace layout

Wired into the existing routing (\`App.tsx\`) and the dashboard header (\`pages/dashboard.tsx\`) alongside \`changelogs\` / \`releases\`.

### Why this shape

- **Endpoint name \`/api/server-logs\`** — \`/api/logs\` is already taken (returns PR babysitter logs from storage; different concept).
- **No SSE library** — Express \`res.write\` is enough for one-way send; matches the rest of the codebase, no extra deps.
- **No virtualization** — list capped at 5000 in-memory records (matches ring size); plain DOM is fast enough at this scale on a local dashboard.
- **No re-parsing on read** — record ring is structured, not text. Avoids \`JSON.parse\` per filter call.

## Test plan

- [x] \`npm test\` — 408/409 pass; the 1 failure is the pre-existing \`agentRunner.test.ts\` codex \`@rpath/libnode.141.dylib\` reproducible on \`main\`
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean on all changed files
- [x] 6 new route tests covering: list endpoint, level filter, source/search filters, \`since\` cursor pagination, SSE live emission, SSE backlog replay
- [x] \`npm run build\` produces a working desktop bundle
- [ ] Manual: open dashboard → click Logs → toggle Follow tail → confirm new entries stream in (depends on local activity to verify)

## Out of scope (intentionally)

- Multi-machine / external log sinks (Loki, Datadog, OTLP) — local tool, not needed
- Log retention policy beyond ring buffer + on-disk file
- Auth on log endpoints — already covered by \`localOnlyMiddleware\`