### PR TITLE
docs: document logger CLI flags, file output, and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ Follow the standardized test guidance in `test.md`. Use the red-green-refactor l
 
 Add focused regression coverage for changes to storage, GitHub sync, repo workspace isolation, background jobs, CI/deployment healing, or babysitter flows.
 
+## Logging
+Use the structured logger in `server/logger.ts`, not `console.*`. Create a child logger per module: `const log = childLogger("babysitter")`. Prefer structured calls so fields are queryable: `log.warn({ err: error.message, prId }, "Babysitter failure")` over interpolated strings.
+
+For recoverable conditions, log at `warn` with the message only and emit the stack at `debug` separately. Reserve `error` for genuinely unexpected failures. GitHub tokens are auto-redacted (paths plus a regex sanitizer covering `ghp_/gho_/ghs_/ghu_/ghr_`, `github_pat_`, `x-access-token:…@`, and `Bearer/token` values), but don't add free-text fields that concatenate token-bearing strings without checking the sanitizer covers your case.
+
 ## Agent Defaults
 When agents are used, default to `codingAgent: "claude"` and `model: "opus"`. There is no separate "thinking"/reasoning-effort configuration flag in this app today; agent reasoning behavior follows the selected model/runtime defaults. These defaults are set in `server/defaultConfig.ts` and can be changed at runtime via the dashboard model selector or the `/api/config` endpoint.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ oh-my-pr can be used in a few ways:
 - local REST API: see [LOCAL_API.md](LOCAL_API.md)
 - optional Tauri desktop shell
 
+### Logging
+
+Server output is structured (pino) and goes to two destinations by default:
+
+- stdout (pretty-printed in dev, JSON in production)
+- `~/.oh-my-pr/log/server.log` (or wherever `OH_MY_PR_HOME` points)
+
+Override the file path with `--log-file <path>` or `OH_MY_PR_LOG_FILE`; disable file logging with `--no-log-file` or `OH_MY_PR_NO_LOG_FILE=1`. Set the level with `--log-level <trace|debug|info|warn|error|fatal>` or `LOG_LEVEL`. Defaults: `info` in production, `debug` in development.
+
+GitHub tokens are redacted before any log line is written: `ghp_/gho_/ghs_/ghu_/ghr_` prefixes, `github_pat_…`, `x-access-token:…@` URLs, and `Bearer …` / `token …` authorization values are replaced with `[REDACTED]` automatically.
+
 ### Optional Automation
 
 If you enable them, oh-my-pr can also:
@@ -115,6 +126,18 @@ oh-my-pr              # web dashboard
 oh-my-pr mcp          # MCP server
 oh-my-pr --help       # help
 oh-my-pr --version    # version
+```
+
+Logging flags work with both `web` and `mcp` and can appear before or after the subcommand:
+
+```bash
+oh-my-pr -q                    # errors only
+oh-my-pr --verbose             # debug level
+oh-my-pr --debug               # alias for --verbose
+oh-my-pr --trace               # maximum verbosity
+oh-my-pr --log-level warn      # explicit level
+oh-my-pr --log-file ./out.log  # override file destination
+oh-my-pr --no-log-file         # disable file logging entirely
 ```
 
 Set `PORT` to change the default web server port (`5001`). If an MCP host needs to connect to a non-default server port, set `OH_MY_PR_PORT` for `oh-my-pr mcp`.

--- a/README.md
+++ b/README.md
@@ -102,11 +102,16 @@ oh-my-pr can be used in a few ways:
 Server output is structured (pino) and goes to two destinations by default:
 
 - stdout (pretty-printed in dev, JSON in production)
-- `~/.oh-my-pr/log/server.log` (or wherever `OH_MY_PR_HOME` points)
+- `~/.oh-my-pr/log/server.log` (or under `OH_MY_PR_HOME`)
 
 Override the file path with `--log-file <path>` or `OH_MY_PR_LOG_FILE`; disable file logging with `--no-log-file` or `OH_MY_PR_NO_LOG_FILE=1`. Set the level with `--log-level <trace|debug|info|warn|error|fatal>` or `LOG_LEVEL`. Defaults: `info` in production, `debug` in development.
 
-GitHub tokens are redacted before any log line is written: `ghp_/gho_/ghs_/ghu_/ghr_` prefixes, `github_pat_…`, `x-access-token:…@` URLs, and `Bearer …` / `token …` authorization values are replaced with `[REDACTED]` automatically.
+GitHub tokens are redacted before any log line is written. The sanitizer replaces these values with `[REDACTED]` automatically:
+
+- `ghp_/gho_/ghs_/ghu_/ghr_` prefixes
+- `github_pat_…` tokens
+- `x-access-token:…@` URLs
+- `Bearer …` / `token …` authorization values
 
 ### Optional Automation
 


### PR DESCRIPTION
Closes #142

## Summary

Docs follow-up to #136. Two surgical additions, no code changes.

### \`README.md\`

- \`## Commands\` — adds the new logging flags (\`-q/--quiet\`, \`--verbose\`, \`--debug\`, \`--trace\`, \`--log-level\`, \`--log-file\`, \`--no-log-file\`) with one-line examples
- New \`### Logging\` subsection under \`## Technical Details\` — destinations (stdout + \`~/.oh-my-pr/log/server.log\`), override env vars (\`OH_MY_PR_LOG_FILE\`, \`OH_MY_PR_NO_LOG_FILE\`, \`LOG_LEVEL\`), default level by environment, and the token-redaction guarantee with the exact patterns covered

### \`AGENTS.md\`

- New \`## Logging\` subsection — \`childLogger(\"source\")\` pattern, prefer structured calls (\`log.warn({ err, prId }, \"…\")\`), \`warn\`-with-message-only for recoverable conditions and \`debug\` for stacks, \`error\` reserved for unexpected. Notes that redaction is automatic but contributors should still sanity-check sanitizer coverage when adding free-text fields that mix tokens with surrounding strings.

## Out of scope

- \`/api/server-logs\` and Logs page docs — those land alongside #140 once it merges (separate follow-up Issue)
- Tauri-packaged smoke checklist (Codex review delta 5c) — separate follow-up

## Test plan

- [x] \`README.md\` renders cleanly (manual review)
- [x] \`AGENTS.md\` renders cleanly (manual review)
- [x] No code touched, no tests to run