### PR TITLE
Fix babysitter dependency preflight and hook-safe finalization

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -1318,6 +1318,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("Babysitter run complete")));
   assert.doesNotMatch(receivedPrompt, /commit and push/i);
   assert.doesNotMatch(receivedPrompt, /git push/i);
+  assert.match(receivedPrompt, /If dependencies are missing, install them/i);
   assert.match(receivedPrompt, /GitHub follow-up replies and review-thread resolution will be handled by the babysitter/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.match(receivedPrompt, /FEEDBACK_SUMMARY_START/);
@@ -1474,7 +1475,7 @@ test("babysitPR stages, commits, and pushes agent file edits from the app runtim
   const updated = await storage.getPR(pr.id);
   assert.equal(updated?.status, "watching");
   assert.ok(gitCommands.includes("add -A"));
-  assert.ok(gitCommands.some((command) => command.startsWith("commit -m")));
+  assert.ok(gitCommands.includes("commit --no-verify -m Apply babysitter fixes for PR #42"));
   assert.ok(gitCommands.includes("push origin HEAD:feature/verbose"));
   assert.equal(remoteHeadSha, "appcommit1");
 
@@ -1591,6 +1592,7 @@ test("babysitPR installs locked Node dependencies before remediation when cache 
     remoteHeadSha: "def456",
   });
   const installCommands: string[] = [];
+  const ignoreChecks: string[] = [];
   const runCommand = async (command: string, args: string[], options?: { cwd?: string }) => {
     if (command === "npm") {
       installCommands.push([command, ...args].join(" "));
@@ -1598,6 +1600,13 @@ test("babysitPR installs locked Node dependencies before remediation when cache 
         await mkdir(path.join(options.cwd, "node_modules"), { recursive: true });
       }
       return { code: 0, stdout: "installed\n", stderr: "" };
+    }
+    if (command === "git" && args[0] === "check-ignore") {
+      const checkedPath = args.at(-1) ?? "";
+      ignoreChecks.push(checkedPath);
+      return checkedPath === "node_modules/"
+        ? { code: 0, stdout: ".gitignore:1:node_modules/\tnode_modules/\n", stderr: "" }
+        : { code: 1, stdout: "", stderr: "" };
     }
 
     const result = await gitRun(command, args);
@@ -1645,6 +1654,7 @@ test("babysitPR installs locked Node dependencies before remediation when cache 
 
   const updated = await storage.getPR(pr.id);
   assert.equal(updated?.status, "watching");
+  assert.deepEqual(ignoreChecks, ["node_modules/"]);
   assert.deepEqual(installCommands, ["npm ci"]);
 
   delete process.env.CODEFACTORY_HOME;

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -430,6 +430,7 @@ function buildAgentFixPrompt(params: {
     "Do not wait for user input, confirmation, or approval at any point.",
     "Do not rewrite unrelated files.",
     "Use the available git tooling for inspection and verification only.",
+    "If dependencies are missing, install them using the repository's lockfile/package manager as needed inside this isolated worktree.",
     "Leave file edits uncommitted; the babysitter app will handle Git finalization after your run.",
     "GitHub follow-up replies and review-thread resolution will be handled by the babysitter after your run.",
     "If a task is invalid after inspection, explain it in your final response and include the exact audit token.",
@@ -981,7 +982,7 @@ async function checkDependencyPreflight(params: DependencyPreflightParams): Prom
   }
 
   if (!(await pathExists(path.join(params.cwd, "node_modules")))) {
-    const ignoreCheck = await params.runCommand("git", ["check-ignore", "-q", "node_modules"], {
+    const ignoreCheck = await params.runCommand("git", ["check-ignore", "-q", "node_modules/"], {
       cwd: params.cwd,
       timeoutMs: 5000,
     });
@@ -2960,7 +2961,7 @@ export class PRBabysitter {
               await commitDirtyWorktree({
                 currentPrId: pr.id,
                 cwd: worktreePath,
-                commitArgs: ["commit", "--no-edit"],
+                commitArgs: ["commit", "--no-verify", "--no-edit"],
                 phase: "conflict",
                 context: "merge conflict resolution",
               });
@@ -3076,7 +3077,7 @@ export class PRBabysitter {
           await commitDirtyWorktree({
             currentPrId: pr.id,
             cwd: worktreePath,
-            commitArgs: ["commit", "-m", `Apply babysitter fixes for PR #${pr.number}`],
+            commitArgs: ["commit", "--no-verify", "-m", `Apply babysitter fixes for PR #${pr.number}`],
             phase: "verify.git.status",
             context: "agent run",
           });

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,14 @@
 # Lessons Learned
 
+## 2026-05-01 - Keep babysitter orchestration thin and delegate repo repair
+- Pattern: Babysitter failures around dependency preflight, merge conflicts, and repository git hooks exposed too much repo-specific behavior inside the app, causing repeated app-side failures instead of letting the selected coding agent repair the checked-out PR environment.
+- Rule: In `oh-my-pr`, keep the app responsible for deterministic orchestration boundaries only: queueing, leases, workspace isolation, credentials, logging, and final git/GitHub state transitions. Delegate repository-specific setup and repair decisions to the underlying coding agent wherever a human developer would normally inspect and fix the repo.
+- Prevention checklist:
+  - Before adding new babysitter preflight logic, ask whether the condition is a safety boundary or a repo-specific repair task the agent should own.
+  - Keep app-side checks narrow and deterministic; avoid encoding package-manager, hook, framework, or merge-resolution policy unless needed to protect user data or credentials.
+  - When agents handle repo repair, give them an isolated worktree, clear constraints, and explicit success criteria, then let app-owned finalization verify the resulting git state.
+  - Treat repeated deterministic babysitter failures as orchestration design bugs, not as reasons to add another hardcoded special case.
+
 ## 2026-04-30 - Keep speculative automation acknowledgements local
 - Pattern: The babysitter posted "Accepted" progress replies on GitHub for every accepted review comment, which surprised teammates because triage acknowledgements looked like public conversation from the user before a fix existed.
 - Rule: In `oh-my-pr`, only post GitHub replies when there is a concrete command, result, audit trail, or thread-resolution outcome to expose; keep speculative triage/progress acknowledgements in local logs unless the user explicitly opts into public progress chatter in Settings.


### PR DESCRIPTION
## Summary
- Fix dependency preflight so `node_modules/` is recognized as ignored and locked installs can proceed in fresh worktrees.
- Tell the agent to install missing dependencies inside the isolated worktree instead of blocking the run.
- Make app-owned git commits bypass repo hooks with `--no-verify` so finalization does not fail on target-repo pre-commit scripts.
- Add regression coverage for the ignore check, agent prompt guidance, and hook-free commit path.

## Testing
- `node --test --import tsx server/babysitter.test.ts`
- `node --test --import tsx server/*.test.ts`
- `npm run check`