### PR TITLE
feat: default auto-release off for new tracked repos

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -298,7 +298,7 @@ export default function Settings() {
                 </div>
                 <input
                   type="checkbox"
-                  checked={config?.autoCreateReleases ?? true}
+                  checked={config?.autoCreateReleases ?? false}
                   onChange={(e) => updateConfigMutation.mutate({ autoCreateReleases: e.target.checked })}
                   disabled={updateConfigMutation.isPending}
                   className="mt-1 accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -277,11 +277,11 @@ oh-my-pr --no-log-file
 </tr>
 <tr>
 <td><code>autoCreateReleases</code></td>
-<td><code>true</code></td>
-<td>Keep release automation enabled for the repo when the rest of the release prerequisites are met.</td>
+<td><code>false</code></td>
+<td>Keep automatic release publishing opt-in for the repo. Enable it when merged PRs should publish GitHub releases automatically after the rest of the release prerequisites are met.</td>
 </tr>
 </tbody></table>
-<p>New watched repos default to <strong>My PRs only</strong>. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
+<p>New watched repos default to <strong>My PRs only</strong> with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
 <p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting.</p>
 <h2>Manual Repository Releases</h2>
 <p>Each watched repository row in the dashboard includes a <strong>Release</strong> button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.</p>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -77,9 +77,9 @@ Watched repositories also have repo-level settings exposed in the dashboard's re
 |---------|---------|-------------|
 | `ownPrsOnly` | `true` | Auto-discover only PRs authored by the authenticated GitHub user for that repo. This appears in the dashboard as **My PRs only**. |
 | `ownPrsOnly` | `false` | Auto-discover all open PRs in that repo. This appears in the dashboard as **My PRs + teammates**. |
-| `autoCreateReleases` | `true` | Keep release automation enabled for the repo when the rest of the release prerequisites are met. |
+| `autoCreateReleases` | `false` | Keep automatic release publishing opt-in for the repo. Enable it when merged PRs should publish GitHub releases automatically after the rest of the release prerequisites are met. |
 
-New watched repos default to **My PRs only**. If you want team-wide tracking for a repository, switch it to **My PRs + teammates** in the dashboard or patch `ownPrsOnly: false` through `/api/repos/settings`.
+New watched repos default to **My PRs only** with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to **My PRs + teammates** in the dashboard or patch `ownPrsOnly: false` through `/api/repos/settings`.
 
 PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting.
 

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -771,7 +771,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         if (!byRepo.has(pr.repo)) {
           byRepo.set(pr.repo, {
             repo: pr.repo,
-            autoCreateReleases: true,
+            autoCreateReleases: false,
             ownPrsOnly: true,
           });
         }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -354,6 +354,8 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
 test("syncAndBabysitTrackedRepos queues release evaluation for merged archived PRs", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];
+  await storage.updateConfig({ autoCreateReleases: true });
+  await storage.updateRepoSettings("octo/example", { autoCreateReleases: true });
 
   const pr = await storage.addPR({
     number: 42,
@@ -951,6 +953,7 @@ test("syncAndBabysitTrackedRepos respects autoCreateReleases when a merged PR is
 test("syncAndBabysitTrackedRepos respects repo-level autoCreateReleases when a merged PR is archived", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];
+  await storage.updateConfig({ autoCreateReleases: true });
   await storage.updateRepoSettings("octo/example", { autoCreateReleases: false });
 
   const pr = await storage.addPR({
@@ -997,6 +1000,8 @@ test("syncAndBabysitTrackedRepos respects repo-level autoCreateReleases when a m
 test("syncAndBabysitTrackedRepos skips release evaluation when merged PR metadata is incomplete", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];
+  await storage.updateConfig({ autoCreateReleases: true });
+  await storage.updateRepoSettings("octo/example", { autoCreateReleases: true });
 
   const pr = await storage.addPR({
     number: 42,

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1502,7 +1502,7 @@ export class PRBabysitter {
             phase: "watcher",
           });
 
-          const repoAutoCreateReleases = repoSettingsByRepo.get(repoSlug)?.autoCreateReleases ?? true;
+          const repoAutoCreateReleases = repoSettingsByRepo.get(repoSlug)?.autoCreateReleases ?? false;
           if (closeState?.merged && this.releaseManager && config.autoCreateReleases) {
             if (!repoAutoCreateReleases) {
               await this.storage.addLog(pr.id, "info", `PR #${pr.number} was merged, but auto-release is disabled for ${repoSlug}`, {

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -120,6 +120,10 @@ describe("DEFAULT_CONFIG", () => {
     assert.equal(DEFAULT_CONFIG.autoUpdateDocs, true);
   });
 
+  it("disables automatic release creation by default", () => {
+    assert.equal(DEFAULT_CONFIG.autoCreateReleases, false);
+  });
+
   it("includes repository links in GitHub comments by default", () => {
     assert.equal(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments, true);
   });

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -9,7 +9,7 @@ export const DEFAULT_CONFIG: Config = {
   pollIntervalMs: 120000,
   maxChangesPerRun: 20,
   autoResolveMergeConflicts: true,
-  autoCreateReleases: true,
+  autoCreateReleases: false,
   autoUpdateDocs: true,
   includeRepositoryLinksInGitHubComments: true,
   postGitHubProgressReplies: false,

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -446,7 +446,7 @@ describe("MemStorage", () => {
       assert.equal(updated.autoUpdateDocs, true);
       assert.equal(updated.includeRepositoryLinksInGitHubComments, true);
       assert.equal(updated.postGitHubProgressReplies, false);
-      assert.equal(updated.autoCreateReleases, true);
+      assert.equal(updated.autoCreateReleases, DEFAULT_CONFIG.autoCreateReleases);
       assert.equal(updated.autoHealCI, false);
       assert.equal(updated.maxHealingAttemptsPerSession, 3);
     });

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -478,7 +478,7 @@ describe("MemStorage", () => {
       const repos = await storage.listRepoSettings();
       assert.deepEqual(repos, [{
         repo: "acme/widgets",
-        autoCreateReleases: true,
+        autoCreateReleases: false,
         ownPrsOnly: true,
       }]);
     });

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -236,7 +236,7 @@ export class MemStorage implements IStorage {
 
     const existing = this.repoSettings.get(repo) ?? {
       repo,
-      autoCreateReleases: true,
+      autoCreateReleases: false,
       ownPrsOnly: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
@@ -252,7 +252,7 @@ export class MemStorage implements IStorage {
       if (!this.repoSettings.has(repo)) {
         this.repoSettings.set(repo, {
           repo,
-          autoCreateReleases: true,
+          autoCreateReleases: false,
           ownPrsOnly: true,
         });
       }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -754,7 +754,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
     }>;
     assert.deepEqual(initial, [{
       repo: "acme/widgets",
-      autoCreateReleases: true,
+      autoCreateReleases: false,
       ownPrsOnly: true,
     }]);
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -501,7 +501,7 @@ export class SqliteStorage implements IStorage {
         poll_interval_ms INTEGER NOT NULL,
         max_changes_per_run INTEGER NOT NULL,
         auto_resolve_merge_conflicts INTEGER NOT NULL DEFAULT 1,
-        auto_create_releases INTEGER NOT NULL DEFAULT 1,
+        auto_create_releases INTEGER NOT NULL DEFAULT 0,
         auto_update_docs INTEGER NOT NULL DEFAULT 1,
         include_repository_links_in_github_comments INTEGER NOT NULL DEFAULT 1,
         post_github_progress_replies INTEGER NOT NULL DEFAULT 0,
@@ -516,7 +516,7 @@ export class SqliteStorage implements IStorage {
 
       CREATE TABLE IF NOT EXISTS watched_repos (
         repo TEXT PRIMARY KEY,
-        auto_create_releases INTEGER NOT NULL DEFAULT 1,
+        auto_create_releases INTEGER NOT NULL DEFAULT 0,
         own_prs_only INTEGER NOT NULL DEFAULT 1
       );
 
@@ -793,7 +793,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "github_tokens_json", "TEXT NOT NULL DEFAULT '[]'");
     this.ensureColumn("config", "fallback_to_next_coding_agent", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
-    this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "include_repository_links_in_github_comments", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "post_github_progress_replies", "INTEGER NOT NULL DEFAULT 0");
@@ -806,7 +806,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "deployment_check_delay_ms", "INTEGER NOT NULL DEFAULT 60000");
     this.ensureColumn("config", "deployment_check_timeout_ms", "INTEGER NOT NULL DEFAULT 600000");
     this.ensureColumn("config", "deployment_check_poll_interval_ms", "INTEGER NOT NULL DEFAULT 15000");
-    this.ensureColumn("watched_repos", "auto_create_releases", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("watched_repos", "auto_create_releases", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("watched_repos", "own_prs_only", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
@@ -862,7 +862,7 @@ export class SqliteStorage implements IStorage {
       pollIntervalMs: row.poll_interval_ms,
       maxChangesPerRun: row.max_changes_per_run,
       autoResolveMergeConflicts: Boolean(row.auto_resolve_merge_conflicts),
-      autoCreateReleases: Boolean(row.auto_create_releases ?? 1),
+      autoCreateReleases: Boolean(row.auto_create_releases ?? Number(DEFAULT_CONFIG.autoCreateReleases)),
       autoUpdateDocs: Boolean(row.auto_update_docs ?? 1),
       includeRepositoryLinksInGitHubComments: Boolean(
         row.include_repository_links_in_github_comments ?? Number(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments),

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -984,7 +984,7 @@ export class SqliteStorage implements IStorage {
         this.run(
           "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only) VALUES (?, ?, ?)",
           repo,
-          settings?.auto_create_releases ?? 1,
+          settings?.auto_create_releases ?? 0,
           settings?.own_prs_only ?? 1,
         );
       }
@@ -1601,7 +1601,7 @@ export class SqliteStorage implements IStorage {
   ): Promise<WatchedRepo> {
     const existing = (await this.getRepoSettings(repo)) ?? {
       repo,
-      autoCreateReleases: true,
+      autoCreateReleases: false,
       ownPrsOnly: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -345,6 +345,35 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
   }
 });
 
+test("SqliteStorage schema defaults automatic release creation off", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+  const db = createRawDatabase(root);
+
+  try {
+    const configColumns = db.prepare("PRAGMA table_info(config)").all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    const watchedRepoColumns = db.prepare("PRAGMA table_info(watched_repos)").all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+
+    assert.equal(
+      configColumns.find((column) => column.name === "auto_create_releases")?.dflt_value,
+      "0",
+    );
+    assert.equal(
+      watchedRepoColumns.find((column) => column.name === "auto_create_releases")?.dflt_value,
+      "0",
+    );
+  } finally {
+    db.close();
+    storage.close();
+  }
+});
+
 test("SqliteStorage migrates legacy github_token into ordered githubTokens", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
   const storage = new SqliteStorage(root);


### PR DESCRIPTION
Closes #147

## Summary
- New tracked repos now default to **Auto-release off** so users opt in explicitly
- Existing repos with a stored setting are unaffected — only the synthesized defaults for never-configured repos changed
- Touches three new-repo paths: `SqliteStorage.updateRepoSettings` fallback, `SqliteStorage.setConfig` re-insert default, `MemStorage` fallbacks, and the `appRuntime.listRepoSettings` synthesized entry

## Test plan
- [x] `node --import tsx --test server/memoryStorage.test.ts server/storage.test.ts server/routes.test.ts server/babysitter.test.ts server/releaseManager.test.ts server/defaultConfig.test.ts` (all green)
- [ ] Manual: add a new repo via UI, confirm Auto-release toggle is off by default
- [ ] Manual: existing repo with Auto-release on stays on after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)