### PR TITLE
fix: hash-router 404 on deep-linked URLs with query strings

### DIFF
--- a/client/src/lib/hashRouteSearch.test.ts
+++ b/client/src/lib/hashRouteSearch.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeHashRouteSearch } from "./hashRouteSearch";
+
+test("normalizeHashRouteSearch merges hash query params with existing search params", () => {
+  assert.equal(
+    normalizeHashRouteSearch("https://example.test/?utm=campaign#/logs?level=info&source=worker"),
+    "https://example.test/?utm=campaign&level=info&source=worker#/logs",
+  );
+});
+
+test("normalizeHashRouteSearch lowercases hash query keys before matching", () => {
+  assert.equal(
+    normalizeHashRouteSearch("https://example.test/?level=warn#/logs?LEVEL=info"),
+    "https://example.test/?level=info#/logs",
+  );
+});
+
+test("normalizeHashRouteSearch leaves hashes without query params unchanged", () => {
+  assert.equal(normalizeHashRouteSearch("https://example.test/#/logs"), null);
+});

--- a/client/src/lib/hashRouteSearch.ts
+++ b/client/src/lib/hashRouteSearch.ts
@@ -1,0 +1,21 @@
+export function normalizeHashRouteSearch(href: string): string | null {
+  const url = new URL(href);
+  const rawHash = url.hash;
+  const qIdx = rawHash.indexOf("?");
+
+  if (qIdx === -1) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams(url.search);
+  const hashParams = new URLSearchParams(rawHash.slice(qIdx));
+
+  hashParams.forEach((value, key) => {
+    searchParams.set(key.toLowerCase(), value);
+  });
+
+  url.hash = rawHash.slice(0, qIdx);
+  url.search = searchParams.toString();
+
+  return url.href;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,19 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
+// wouter's hash router expects the path in location.hash and the query in
+// location.search. Normalize deep links like #/logs?level=info before mount.
+{
+  const rawHash = window.location.hash;
+  const qIdx = rawHash.indexOf("?");
+  if (qIdx !== -1) {
+    const url = new URL(window.location.href);
+    url.hash = rawHash.slice(0, qIdx);
+    url.search = rawHash.slice(qIdx);
+    history.replaceState(history.state, "", url.href);
+  }
+}
+
 if (!window.location.hash) {
   window.location.hash = "#/";
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,17 +1,14 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { normalizeHashRouteSearch } from "./lib/hashRouteSearch";
 import "./index.css";
 
 // wouter's hash router expects the path in location.hash and the query in
 // location.search. Normalize deep links like #/logs?level=info before mount.
 {
-  const rawHash = window.location.hash;
-  const qIdx = rawHash.indexOf("?");
-  if (qIdx !== -1) {
-    const url = new URL(window.location.href);
-    url.hash = rawHash.slice(0, qIdx);
-    url.search = rawHash.slice(qIdx);
-    history.replaceState(history.state, "", url.href);
+  const normalizedHref = normalizeHashRouteSearch(window.location.href);
+  if (normalizedHref) {
+    history.replaceState(history.state, "", normalizedHref);
   }
 }
 

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -77,9 +77,7 @@ function recordsToText(records: LogRecord[]): string {
 }
 
 function setUrlParams(updates: { level?: string; source?: string; q?: string; follow?: boolean }) {
-  const hash = window.location.hash || "#/logs";
-  const [path, queryString] = hash.replace(/^#/, "").split("?");
-  const params = new URLSearchParams(queryString ?? "");
+  const params = new URLSearchParams(window.location.search);
   for (const [key, value] of Object.entries(updates)) {
     if (value === "" || value === false || value === undefined) {
       params.delete(key);
@@ -90,7 +88,11 @@ function setUrlParams(updates: { level?: string; source?: string; q?: string; fo
     }
   }
   const next = params.toString();
-  window.location.hash = next ? `${path}?${next}` : path;
+  const url = new URL(window.location.href);
+  url.search = next ? `?${next}` : "";
+  // wouter monkey-patches replaceState to dispatch a "replaceState" event,
+  // which useSearch listens for, so subscribers re-render.
+  history.replaceState(history.state, "", url.href);
 }
 
 export default function Logs() {


### PR DESCRIPTION
Closes #149

## Summary
- Boot-time normalizer in `main.tsx` moves any `?…` inside `location.hash` to the real `location.search` before React mounts, so deep links like `#/logs?level=info` resolve to `<Route path="/logs">`.
- `logs.tsx` `setUrlParams` now writes `location.search` directly via `history.replaceState` (wouter's monkey-patched `replaceState` dispatches a `replaceState` event that `useSearch` listens for), so filter changes no longer corrupt the hash.

## Why
`wouter@3` `useHashLocation` keeps the **path** in `location.hash` and reads the **query** from `location.search` (default `useBrowserSearch`). Putting `?…` inside the hash makes the location string become `/logs?source=babysitter`, which never matches `path="/logs"` → NotFound. See #149 for full root-cause walk-through.

## Test plan
- [x] `npm run check`
- [ ] Manual: open `http://localhost:5001/#/logs?level=info` — Logs page renders, Level filter pre-set
- [ ] Manual: open `http://localhost:5001/#/logs?source=babysitter` — Logs page renders, Source filter pre-set
- [ ] Manual: change a filter on the Logs page, refresh — same view re-renders
- [ ] Manual: navigate around `#/`, `#/settings`, `#/changelogs`, `#/releases` — no regressions
- [ ] Manual: visit `#/logs?follow=1` — Follow tail enabled on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)