### PR TITLE
fix: stop recurring babysitter log failure loops

### DIFF
--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -3,7 +3,7 @@ import { chmod, copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
+import { checkAgentHealth, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
 
 test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
   const result = await runCommand(
@@ -71,6 +71,43 @@ test("evaluateFixNecessityWithAgent throws a clear error when codex writes no ou
     } else {
       process.env.NODE_OPTIONS = originalNodeOptions;
     }
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("checkAgentHealth surfaces actionable codex session permission errors", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-health-bin-"));
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeCodexPath,
+      [
+        "#!/bin/sh",
+        "echo 'Reading additional input from stdin...' >&2",
+        "echo 'ERROR codex_core::session: Failed to create session: Operation not permitted' >&2",
+        "echo 'Error: thread/start: Codex cannot access session files at /Users/dgyk/.codex/sessions (permission denied)' >&2",
+        "exit 1",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeCodexPath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+
+    const result = await checkAgentHealth("codex");
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /cannot access session files/i);
+      assert.doesNotMatch(result.reason, /Reading additional input from stdin/);
+    }
+  } finally {
     process.env.PATH = originalPath;
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -31,6 +31,7 @@ const AGENT_AUTH_PATTERNS = [
   "authentication_error",
   "invalid authentication credentials",
   "api error: 401",
+  "cannot access session files",
 ];
 
 const AGENT_CLI_MISSING_PATTERNS = [
@@ -328,11 +329,15 @@ function firstOutputLine(output: string): string | null {
 }
 
 function summarizeHealthFailure(result: CommandResult): string {
-  const raw = (result.stderr.trim() || result.stdout.trim() || "no output")
+  const lines = (result.stderr.trim() || result.stdout.trim() || "no output")
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find((line) => line.length > 0)
-    ?? "no output";
+    .filter((line) => line.length > 0);
+  const actionable = lines.findLast((line) =>
+    /cannot access session files|permission denied|failed to create session|failed|error:/i.test(line)
+      && !/^reading additional input from stdin/i.test(line)
+  );
+  const raw = actionable ?? lines[0] ?? "no output";
   return raw.length > 220 ? `${raw.slice(0, 217).trimEnd()}...` : raw;
 }
 

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -204,6 +204,7 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
   Codex: {
     auth: [
       "Run `codex login` on this machine.",
+      "Check ownership and permissions for ~/.codex, especially ~/.codex/sessions, so oh-my-pr can access Codex session files.",
       "Restart oh-my-pr if it was launched before you refreshed credentials.",
       "Rerun the babysitter for this PR.",
     ],

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -567,6 +567,89 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
   assert.equal(jobs[0].payload.activityTargetUrl, pr.url);
 });
 
+test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Needs deps",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "error",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+  const now = new Date().toISOString();
+  await storage.upsertAgentRun({
+    id: "failed-preflight-run",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "failed",
+    phase: "run.failed",
+    prompt: null,
+    initialHeadSha: "head-same",
+    metadata: {
+      deterministicFailure: {
+        kind: "dependency_preflight",
+        headSha: "head-same",
+        reason: "node_modules missing",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        count: 1,
+      },
+    },
+    lastError: "Dependency preflight failed: node_modules missing",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Needs deps",
+        branch: "feature/example",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+        headSha: "head-same",
+      }],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should not invoke babysitPR directly when a scheduler is provided");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(jobs.length, 0);
+  assert.ok(logs.some((log) => log.message.includes("Dependency preflight previously failed")));
+});
+
 test("syncAndBabysitTrackedRepos repairs missing review-thread metadata on archived PRs", async () => {
   const storage = new MemStorage();
   const pr = await storage.addPR({
@@ -1550,7 +1633,11 @@ test("babysitPR blocks remediation when dependency preflight fails", async () =>
 
   const updated = await storage.getPR(pr.id);
   const runs = await storage.listAgentRuns({ prId: pr.id });
+  const deterministicFailure = runs[0]?.metadata?.deterministicFailure as Record<string, unknown> | undefined;
   assert.equal(updated?.status, "error");
+  assert.equal(runs[0]?.initialHeadSha, "abc123");
+  assert.equal(deterministicFailure?.kind, "dependency_preflight");
+  assert.equal(deterministicFailure?.headSha, "abc123");
   assert.match(runs[0]?.lastError ?? "", /node_modules missing/);
 
   delete process.env.CODEFACTORY_HOME;
@@ -2572,6 +2659,74 @@ test("babysitPR treats audit-trail replies as non-actionable follow-up comments"
   assert.match(updatedReply?.statusReason || "", /audit trail/i);
   assert.ok(logs.some((log) => log.phase === "evaluate.comments" && log.message.includes("Ignored audit-trail follow-up comment")));
   assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("no necessary fixes identified")));
+});
+
+test("babysitPR treats footerless status replies as non-actionable", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const statusReply = makeFeedbackItem({
+    author: "octocat",
+    body: "\ud83e\uddf0 **Agent running** \u2014 `codex` is working on the fix...",
+    bodyHtml: "<p><strong>Agent running</strong> - <code>codex</code> is working on the fix...</p>",
+    decision: null,
+    status: "pending",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [statusReply],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [statusReply],
+      fetchPullSummary: async () => makePullSummary(pr),
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => undefined,
+      addReactionToComment: async () => {},
+      postPRComment: async () => undefined,
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => {
+        throw new Error("status replies should not be evaluated");
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("status replies should not trigger fixes");
+      },
+      runCommand: makeGitRunCommand({
+        localHeadSha: "abc123",
+        remoteHeadSha: "abc123",
+      }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  assert.equal(updated?.feedbackItems[0]?.status, "rejected");
+  assert.equal(updated?.feedbackItems[0]?.decision, "reject");
+  assert.match(updated?.feedbackItems[0]?.statusReason ?? "", /oh-my-pr status comment/i);
 });
 
 test("babysitPR does not auto-ignore audit-trail replies when referenced timestamps are invalid", async () => {
@@ -4721,6 +4876,119 @@ test("babysitPR resolves merge conflicts when PR is not mergeable", async () => 
   assert.match(conflictAgentPrompt, /src\/example\.ts/);
   assert.ok(logs.some((log) => log.phase === "conflict" && log.message.includes("merge conflicts")));
   assert.ok(logs.some((log) => log.phase === "conflict.agent" && log.message.includes("merge conflict resolution")));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR escalates repeated conflict repair for same head and unresolved paths", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  const now = new Date().toISOString();
+  for (const id of ["prior-conflict-1", "prior-conflict-2"]) {
+    await storage.upsertAgentRun({
+      id,
+      prId: pr.id,
+      preferredAgent: "codex",
+      resolvedAgent: "codex",
+      status: "failed",
+      phase: "run.failed",
+      prompt: null,
+      initialHeadSha: "abc123",
+      metadata: {
+        conflictRepairFailure: {
+          kind: "merge_conflict_repair",
+          headSha: "abc123",
+          baseRef: "main",
+          conflictFiles: ["src/example.ts"],
+          reason: "Agent left unresolved merge conflicts: src/example.ts",
+          firstSeenAt: now,
+          lastSeenAt: now,
+          count: 1,
+        },
+      },
+      lastError: "Agent left unresolved merge conflicts: src/example.ts",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  const pullSummary = makePullSummary(pr, { mergeable: false, headSha: "abc123" });
+  const gitRunner = makeGitRunCommand({
+    localHeadSha: "abc123",
+    remoteHeadSha: "abc123",
+  });
+  let conflictAgentCalled = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No fix needed",
+      }),
+      applyFixesWithAgent: async () => {
+        conflictAgentCalled = true;
+        throw new Error("conflict agent should not run after retry budget is exhausted");
+      },
+      runCommand: async (command: string, args: string[], opts?: Record<string, unknown>) => {
+        if (command === "git" && args[0] === "merge") {
+          return { code: 1, stdout: "", stderr: "CONFLICT (content): Merge conflict in src/example.ts" };
+        }
+        if (command === "git" && args[0] === "diff" && args[1] === "--name-only" && args[2] === "--diff-filter=U") {
+          return { code: 0, stdout: "src/example.ts\n", stderr: "" };
+        }
+        return gitRunner(command, args, opts);
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+  const runs = await storage.listAgentRuns({ prId: pr.id });
+  const currentRun = runs.find((run) => run.id !== "prior-conflict-1" && run.id !== "prior-conflict-2");
+
+  assert.equal(conflictAgentCalled, false);
+  assert.equal(updated?.status, "error");
+  assert.equal(currentRun?.status, "failed");
+  assert.equal(currentRun?.phase, "conflict.retry");
+  assert.match(currentRun?.lastError ?? "", /retry budget exhausted/i);
+  assert.ok(logs.some((log) => log.phase === "conflict.retry" && log.message.includes("retry budget exhausted")));
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -4899,6 +4899,7 @@ test("babysitPR escalates repeated conflict repair for same head and unresolved 
     lastChecked: null,
   });
   const now = new Date().toISOString();
+  const retryCheckedAt = "2026-05-01T12:34:56.000Z";
   for (const id of ["prior-conflict-1", "prior-conflict-2"]) {
     await storage.upsertAgentRun({
       id,
@@ -4956,6 +4957,7 @@ test("babysitPR escalates repeated conflict repair for same head and unresolved 
     {
       resolveAgent: async () => "codex",
       ciPollIntervalMs: 0,
+      now: () => new Date(retryCheckedAt),
       evaluateFixNecessityWithAgent: async () => ({
         needsFix: false,
         reason: "No fix needed",
@@ -4985,6 +4987,7 @@ test("babysitPR escalates repeated conflict repair for same head and unresolved 
 
   assert.equal(conflictAgentCalled, false);
   assert.equal(updated?.status, "error");
+  assert.equal(updated?.lastChecked, retryCheckedAt);
   assert.equal(currentRun?.status, "failed");
   assert.equal(currentRun?.phase, "conflict.retry");
   assert.match(currentRun?.lastError ?? "", /retry budget exhausted/i);
@@ -5200,6 +5203,33 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
+  const firstSeenAt = "2026-05-01T10:00:00.000Z";
+  const currentSeenAt = "2026-05-01T10:05:00.000Z";
+  await storage.upsertAgentRun({
+    id: "prior-conflict-agent-failure",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "failed",
+    phase: "run.failed",
+    prompt: null,
+    initialHeadSha: "abc123",
+    metadata: {
+      conflictRepairFailure: {
+        kind: "merge_conflict_repair",
+        headSha: "abc123",
+        baseRef: "main",
+        conflictFiles: ["src/conflict.ts"],
+        reason: "Agent failed to resolve merge conflicts: agent crashed",
+        firstSeenAt,
+        lastSeenAt: firstSeenAt,
+        count: 1,
+      },
+    },
+    lastError: "Agent failed to resolve merge conflicts: agent crashed",
+    createdAt: firstSeenAt,
+    updatedAt: firstSeenAt,
+  });
   const pullSummary = makePullSummary(pr, { mergeable: false });
 
   const gitRunner = makeGitRunCommand({
@@ -5226,6 +5256,7 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
     {
       resolveAgent: async () => "codex",
       ciPollIntervalMs: 0,
+      now: () => new Date(currentSeenAt),
       evaluateFixNecessityWithAgent: async () => ({
         needsFix: false,
         reason: "No fix needed",
@@ -5249,8 +5280,15 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
 
   const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
+  const runs = await storage.listAgentRuns({ prId: pr.id });
+  const currentRun = runs.find((run) => run.id !== "prior-conflict-agent-failure");
+  const conflictMarker = currentRun?.metadata?.conflictRepairFailure as Record<string, unknown> | undefined;
 
   assert.equal(updated?.status, "error");
+  assert.equal(conflictMarker?.firstSeenAt, firstSeenAt);
+  assert.equal(conflictMarker?.lastSeenAt, currentSeenAt);
+  assert.equal(conflictMarker?.count, 2);
+  assert.match(String(conflictMarker?.reason ?? ""), /codex/);
   assert.ok(logs.some((log) => log.level === "error" && log.message.includes("merge conflicts")));
 
   delete process.env.CODEFACTORY_HOME;

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1168,6 +1168,32 @@ export class PRBabysitter {
     }, 0);
   }
 
+  private async findLatestConflictRepairFailure(
+    prId: string,
+    headSha: string,
+    baseRef: string,
+    conflictFiles: string[],
+  ): Promise<ConflictRepairFailureMarker | null> {
+    const normalizedFiles = normalizeConflictFiles(conflictFiles);
+    const failedRuns = (await this.storage.listAgentRuns({ prId, status: "failed" }))
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+
+    for (const run of failedRuns) {
+      const marker = readConflictRepairFailure(run.metadata);
+      if (!marker
+        || marker.headSha !== headSha
+        || marker.baseRef !== baseRef
+        || !sameStrings(marker.conflictFiles, normalizedFiles)
+      ) {
+        continue;
+      }
+
+      return marker;
+    }
+
+    return null;
+  }
+
   private async readAgentHealth(agent: CodingAgent): Promise<AgentHealthResult> {
     const nowMs = this.now().getTime();
     const cached = this.agentHealthCache.get(agent);
@@ -3088,6 +3114,13 @@ export class PRBabysitter {
                   pullSummary.baseRef,
                   conflictFilesForMarker,
                 );
+                const previousFailure = await this.findLatestConflictRepairFailure(
+                  pr.id,
+                  pullSummary.headSha,
+                  pullSummary.baseRef,
+                  conflictFilesForMarker,
+                );
+                const failureFirstSeenAt = previousFailure?.firstSeenAt || seenAt;
                 const failureCount = previousFailures + 1;
                 await updateRunRecord({
                   metadata: {
@@ -3098,7 +3131,7 @@ export class PRBabysitter {
                       baseRef: pullSummary.baseRef,
                       conflictFiles: conflictFilesForMarker,
                       reason,
-                      firstSeenAt: seenAt,
+                      firstSeenAt: failureFirstSeenAt,
                       lastSeenAt: seenAt,
                       count: failureCount,
                     },
@@ -3122,7 +3155,7 @@ export class PRBabysitter {
                 });
                 await this.storage.updatePR(pr.id, {
                   status: "error",
-                  lastChecked: new Date().toISOString(),
+                  lastChecked: this.now().toISOString(),
                 });
                 await queueLog(pr.id, "warn", reason, {
                   phase: "conflict.retry",
@@ -3173,9 +3206,10 @@ export class PRBabysitter {
               await conflictStderr.flush();
 
               if (conflictResult.code !== 0) {
-                const failureReason = formatConciseFailureReason(conflictResult.stderr || conflictResult.stdout);
+                const failureDetail = formatConciseFailureReason(conflictResult.stderr || conflictResult.stdout);
+                const failureReason = `${agent} failed to resolve merge conflicts: ${failureDetail}`;
                 await recordConflictRepairFailure(normalizedConflictFiles, failureReason, "conflict.agent", priorConflictFailures);
-                throw new Error(`Agent failed to resolve merge conflicts (${conflictResult.code}): ${failureReason}`);
+                throw new Error(`${agent} failed to resolve merge conflicts (${conflictResult.code}): ${failureDetail}`);
               }
 
               await queueLog(pr.id, "info", "Agent completed merge conflict resolution", {
@@ -3192,7 +3226,7 @@ export class PRBabysitter {
               }
               const unresolvedFiles = normalizeConflictFiles(unresolvedAfterAgent.stdout.trim().split("\n"));
               if (unresolvedFiles.length > 0) {
-                const failureReason = `Agent left unresolved merge conflicts: ${unresolvedFiles.join(", ")}`;
+                const failureReason = `${agent} left unresolved merge conflicts: ${unresolvedFiles.join(", ")}`;
                 await recordConflictRepairFailure(unresolvedFiles, failureReason);
                 throw new Error(failureReason);
               }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -34,6 +34,7 @@ import {
   resolveReviewThread,
   resolveGitHubAuthToken,
   updateStatusReply,
+  APP_STATUS_COMMENT_PATTERN,
   type GitHubPullSummary,
   type GitHubStatusFailure,
   type ParsedPRUrl,
@@ -66,6 +67,10 @@ import {
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
 const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
 const AGENT_HEALTH_CACHE_TTL_MS = 60_000;
+const DEPENDENCY_PREFLIGHT_FAILURE_PREFIX = "Dependency preflight failed:";
+const DEPENDENCY_PREFLIGHT_FAILURE_KIND = "dependency_preflight";
+const CONFLICT_REPAIR_FAILURE_KIND = "merge_conflict_repair";
+const CONFLICT_REPAIR_RETRY_BUDGET = 2;
 const APP_NAME = "oh-my-pr";
 const APP_REPOSITORY_URL = "https://github.com/yungookim/oh-my-pr";
 const APP_REPOSITORY_LINK = `[${APP_NAME}](${APP_REPOSITORY_URL})`;
@@ -89,6 +94,26 @@ type GitHubService = {
   resolveReviewThread: typeof resolveReviewThread;
   resolveGitHubAuthToken: typeof resolveGitHubAuthToken;
   updateStatusReply: typeof updateStatusReply;
+};
+
+type DeterministicFailureMarker = {
+  kind: typeof DEPENDENCY_PREFLIGHT_FAILURE_KIND;
+  headSha: string;
+  reason: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  count: number;
+};
+
+type ConflictRepairFailureMarker = {
+  kind: typeof CONFLICT_REPAIR_FAILURE_KIND;
+  headSha: string;
+  baseRef: string;
+  conflictFiles: string[];
+  reason: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  count: number;
 };
 
 type BabysitterRuntime = {
@@ -565,11 +590,67 @@ function hasAuditTrail(
 }
 
 function looksLikeStatusReply(body: string): boolean {
-  return body.includes("**Accepted**")
-    || body.includes("**Agent running**")
-    || body.includes("**Agent failed**")
-    || body.includes("**Agent completed**")
-    || body.includes("**Resolved**");
+  return APP_STATUS_COMMENT_PATTERN.test(body);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readDependencyPreflightFailure(metadata: AgentRun["metadata"]): DeterministicFailureMarker | null {
+  const marker = metadata?.deterministicFailure;
+  if (isRecord(marker)
+    && marker.kind === DEPENDENCY_PREFLIGHT_FAILURE_KIND
+    && typeof marker.headSha === "string"
+    && typeof marker.reason === "string"
+  ) {
+    return {
+      kind: DEPENDENCY_PREFLIGHT_FAILURE_KIND,
+      headSha: marker.headSha,
+      reason: marker.reason,
+      firstSeenAt: typeof marker.firstSeenAt === "string" ? marker.firstSeenAt : "",
+      lastSeenAt: typeof marker.lastSeenAt === "string" ? marker.lastSeenAt : "",
+      count: typeof marker.count === "number" ? marker.count : 1,
+    };
+  }
+
+  return null;
+}
+
+function normalizeConflictFiles(files: string[]): string[] {
+  return Array.from(new Set(files.map((file) => file.trim()).filter(Boolean))).sort();
+}
+
+function sameStrings(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function readConflictRepairFailure(metadata: AgentRun["metadata"]): ConflictRepairFailureMarker | null {
+  const marker = metadata?.conflictRepairFailure;
+  if (!isRecord(marker)
+    || marker.kind !== CONFLICT_REPAIR_FAILURE_KIND
+    || typeof marker.headSha !== "string"
+    || typeof marker.baseRef !== "string"
+    || typeof marker.reason !== "string"
+    || !Array.isArray(marker.conflictFiles)
+  ) {
+    return null;
+  }
+
+  return {
+    kind: CONFLICT_REPAIR_FAILURE_KIND,
+    headSha: marker.headSha,
+    baseRef: marker.baseRef,
+    conflictFiles: normalizeConflictFiles(marker.conflictFiles.filter((file): file is string => typeof file === "string")),
+    reason: marker.reason,
+    firstSeenAt: typeof marker.firstSeenAt === "string" ? marker.firstSeenAt : "",
+    lastSeenAt: typeof marker.lastSeenAt === "string" ? marker.lastSeenAt : "",
+    count: typeof marker.count === "number" ? marker.count : 1,
+  };
+}
+
+function isDependencyPreflightFailureMessage(message: string): boolean {
+  return message.trim().startsWith(DEPENDENCY_PREFLIGHT_FAILURE_PREFIX);
 }
 
 function readStatusReplyRefs(metadata: AgentRun["metadata"]): Record<string, StatusReplyRef> {
@@ -1051,6 +1132,40 @@ export class PRBabysitter {
 
   private now(): Date {
     return this.clock();
+  }
+
+  private async findLatestDependencyPreflightFailure(prId: string, headSha: string): Promise<DeterministicFailureMarker | null> {
+    const failedRuns = (await this.storage.listAgentRuns({ prId, status: "failed" }))
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+
+    for (const run of failedRuns) {
+      const marker = readDependencyPreflightFailure(run.metadata);
+      const runHeadSha = marker?.headSha ?? run.initialHeadSha;
+      if (runHeadSha !== headSha) {
+        continue;
+      }
+
+      return marker?.kind === DEPENDENCY_PREFLIGHT_FAILURE_KIND ? marker : null;
+    }
+
+    return null;
+  }
+
+  private async countConflictRepairFailures(prId: string, headSha: string, baseRef: string, conflictFiles: string[]): Promise<number> {
+    const normalizedFiles = normalizeConflictFiles(conflictFiles);
+    const failedRuns = await this.storage.listAgentRuns({ prId, status: "failed" });
+    return failedRuns.reduce((count, run) => {
+      const marker = readConflictRepairFailure(run.metadata);
+      if (!marker
+        || marker.headSha !== headSha
+        || marker.baseRef !== baseRef
+        || !sameStrings(marker.conflictFiles, normalizedFiles)
+      ) {
+        return count;
+      }
+
+      return count + 1;
+    }, 0);
   }
 
   private async readAgentHealth(agent: CodingAgent): Promise<AgentHealthResult> {
@@ -1645,6 +1760,22 @@ export class PRBabysitter {
           continue;
         }
 
+        const priorDependencyFailure = pull.headSha
+          ? await this.findLatestDependencyPreflightFailure(local.id, pull.headSha)
+          : null;
+        if (priorDependencyFailure) {
+          await this.storage.addLog(local.id, "warn", "Dependency preflight previously failed for this PR head; skipping automatic babysitter run until the head changes", {
+            phase: "watcher",
+            metadata: {
+              repo: repoSlug,
+              headSha: pull.headSha,
+              reason: priorDependencyFailure.reason,
+              count: priorDependencyFailure.count,
+            },
+          });
+          continue;
+        }
+
         await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
           phase: "watcher",
           metadata: { repo: repoSlug },
@@ -2136,6 +2267,12 @@ export class PRBabysitter {
       };
 
       const pullSummary = await this.github.fetchPullSummary(octokit, parsedPr);
+      const runInitialHeadSha = replayInitialHeadSha || pullSummary.headSha;
+      if (runInitialHeadSha && runRecord.initialHeadSha !== runInitialHeadSha) {
+        await updateRunRecord({
+          initialHeadSha: runInitialHeadSha,
+        });
+      }
       if (forcedFixPrompt && replayInitialHeadSha && pullSummary.headSha !== replayInitialHeadSha) {
         skipForcedReplay = true;
         await queueLog(pr.id, "warn", `Skipping forced prompt replay because PR head moved (${replayInitialHeadSha.slice(0, 7)} -> ${pullSummary.headSha.slice(0, 7)})`, {
@@ -2381,6 +2518,19 @@ export class PRBabysitter {
           const reason = "oh-my-pr-authored agent command comment; no code change required";
           evaluatedItems.set(item.id, applyEvaluationDecision(item, false, reason));
           await queueLog(pr.id, "info", `Ignored self-authored agent command comment ${item.id}`, {
+            phase: "evaluate.comments",
+            metadata: {
+              feedbackId: item.id,
+              decision: "reject",
+            },
+          });
+          continue;
+        }
+
+        if (looksLikeStatusReply(item.body)) {
+          const reason = "oh-my-pr status comment; no code change required";
+          evaluatedItems.set(item.id, applyEvaluationDecision(item, false, reason));
+          await queueLog(pr.id, "info", `Ignored self-authored status comment ${item.id}`, {
             phase: "evaluate.comments",
             metadata: {
               feedbackId: item.id,
@@ -2717,14 +2867,33 @@ export class PRBabysitter {
             runCommand: this.runtime.runCommand,
           });
           if (!dependencyPreflight.ok) {
-            await queueLog(pr.id, "error", `Dependency preflight failed: ${dependencyPreflight.reason}`, {
+            const seenAt = this.now().toISOString();
+            if (pullSummary.headSha) {
+              const previousFailure = await this.findLatestDependencyPreflightFailure(pr.id, pullSummary.headSha);
+              const failureCount = (previousFailure?.count ?? 0) + 1;
+              const failureFirstSeenAt = previousFailure?.firstSeenAt || seenAt;
+              await updateRunRecord({
+                metadata: {
+                  ...(runRecord.metadata ?? {}),
+                  deterministicFailure: {
+                    kind: DEPENDENCY_PREFLIGHT_FAILURE_KIND,
+                    headSha: pullSummary.headSha,
+                    reason: dependencyPreflight.reason,
+                    firstSeenAt: failureFirstSeenAt,
+                    lastSeenAt: seenAt,
+                    count: failureCount,
+                  },
+                },
+              });
+            }
+            await queueLog(pr.id, "error", `${DEPENDENCY_PREFLIGHT_FAILURE_PREFIX} ${dependencyPreflight.reason}`, {
               phase: "preflight.dependencies",
               metadata: {
                 headSha: pullSummary.headSha,
                 reason: dependencyPreflight.reason,
               },
             });
-            throw new Error(`Dependency preflight failed: ${dependencyPreflight.reason}`);
+            throw new Error(`${DEPENDENCY_PREFLIGHT_FAILURE_PREFIX} ${dependencyPreflight.reason}`);
           }
           await queueLog(pr.id, "info", "Dependency preflight passed", {
             phase: "preflight.dependencies",
@@ -2899,19 +3068,73 @@ export class PRBabysitter {
                 cwd: worktreePath,
                 timeoutMs: 10000,
               });
-              const conflictFiles = conflictListResult.stdout
-                .trim()
-                .split("\n")
-                .filter((f) => f.trim().length > 0);
+              const normalizedConflictFiles = normalizeConflictFiles(conflictListResult.stdout.trim().split("\n"));
 
-              if (conflictFiles.length === 0) {
+              if (normalizedConflictFiles.length === 0) {
                 throw new Error(`Merge failed but no conflict files detected: ${mergeResult.stderr || mergeResult.stdout}`);
               }
 
-              await queueLog(pr.id, "info", `Found ${conflictFiles.length} file(s) with merge conflicts`, {
+              await queueLog(pr.id, "info", `Found ${normalizedConflictFiles.length} file(s) with merge conflicts`, {
                 phase: "conflict",
-                metadata: { conflictFiles },
+                metadata: { conflictFiles: normalizedConflictFiles },
               });
+
+              const recordConflictRepairFailure = async (files: string[], reason: string, phase = "conflict.agent", priorFailures?: number) => {
+                const conflictFilesForMarker = normalizeConflictFiles(files);
+                const seenAt = this.now().toISOString();
+                const previousFailures = priorFailures ?? await this.countConflictRepairFailures(
+                  pr.id,
+                  pullSummary.headSha,
+                  pullSummary.baseRef,
+                  conflictFilesForMarker,
+                );
+                const failureCount = previousFailures + 1;
+                await updateRunRecord({
+                  metadata: {
+                    ...(runRecord.metadata ?? {}),
+                    conflictRepairFailure: {
+                      kind: CONFLICT_REPAIR_FAILURE_KIND,
+                      headSha: pullSummary.headSha,
+                      baseRef: pullSummary.baseRef,
+                      conflictFiles: conflictFilesForMarker,
+                      reason,
+                      firstSeenAt: seenAt,
+                      lastSeenAt: seenAt,
+                      count: failureCount,
+                    },
+                  },
+                  phase,
+                });
+              };
+
+              const priorConflictFailures = await this.countConflictRepairFailures(
+                pr.id,
+                pullSummary.headSha,
+                pullSummary.baseRef,
+                normalizedConflictFiles,
+              );
+              if (priorConflictFailures >= CONFLICT_REPAIR_RETRY_BUDGET) {
+                const reason = `Merge conflict repair retry budget exhausted for ${normalizedConflictFiles.join(", ")}`;
+                await updateRunRecord({
+                  status: "failed",
+                  phase: "conflict.retry",
+                  lastError: reason,
+                });
+                await this.storage.updatePR(pr.id, {
+                  status: "error",
+                  lastChecked: new Date().toISOString(),
+                });
+                await queueLog(pr.id, "warn", reason, {
+                  phase: "conflict.retry",
+                  metadata: {
+                    headSha: pullSummary.headSha,
+                    baseRef: pullSummary.baseRef,
+                    conflictFiles: normalizedConflictFiles,
+                    priorFailures: priorConflictFailures,
+                  },
+                });
+                return;
+              }
 
               const conflictStdout = createChunkLogger(pr.id, "conflict.agent", "stdout", "info");
               const conflictStderr = createChunkLogger(pr.id, "conflict.agent", "stderr", "warn");
@@ -2928,7 +3151,7 @@ export class PRBabysitter {
                 pr,
                 pullSummary,
                 remoteName,
-                conflictFiles,
+                conflictFiles: normalizedConflictFiles,
               });
 
               await queueLog(pr.id, "info", `Launching ${agent} to resolve merge conflicts`, {
@@ -2951,6 +3174,7 @@ export class PRBabysitter {
 
               if (conflictResult.code !== 0) {
                 const failureReason = formatConciseFailureReason(conflictResult.stderr || conflictResult.stdout);
+                await recordConflictRepairFailure(normalizedConflictFiles, failureReason, "conflict.agent", priorConflictFailures);
                 throw new Error(`Agent failed to resolve merge conflicts (${conflictResult.code}): ${failureReason}`);
               }
 
@@ -2966,8 +3190,11 @@ export class PRBabysitter {
               if (unresolvedAfterAgent.code !== 0) {
                 throw new Error(formatGitFailure("checking unresolved merge conflicts", unresolvedAfterAgent));
               }
-              if (unresolvedAfterAgent.stdout.trim()) {
-                throw new Error(`Agent left unresolved merge conflicts: ${unresolvedAfterAgent.stdout.trim()}`);
+              const unresolvedFiles = normalizeConflictFiles(unresolvedAfterAgent.stdout.trim().split("\n"));
+              if (unresolvedFiles.length > 0) {
+                const failureReason = `Agent left unresolved merge conflicts: ${unresolvedFiles.join(", ")}`;
+                await recordConflictRepairFailure(unresolvedFiles, failureReason);
+                throw new Error(failureReason);
               }
 
               await commitDirtyWorktree({
@@ -3672,7 +3899,7 @@ export class PRBabysitter {
       if (error instanceof Error && error.stack) {
         log.debug({ stack: error.stack, prId }, "Babysitter failure stack");
       }
-      if (options?.rethrowOnFailure) {
+      if (options?.rethrowOnFailure && !isDependencyPreflightFailureMessage(message)) {
         throw error;
       }
     } finally {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -895,6 +895,14 @@ test("fetchFeedbackItemsForPR marks oh-my-pr status and audit comments non-actio
             user: { login: "octocat", type: "User" },
           },
           {
+            id: 204,
+            node_id: "IC_kwDO_footerless_status",
+            body: "**Agent running** - oh-my-pr dispatched `codex` to apply the accepted fix.",
+            created_at: "2026-03-15T11:01:30Z",
+            html_url: "https://github.com/yungookim/oh-my-pr/pull/1#issuecomment-204",
+            user: { login: "octocat", type: "User" },
+          },
+          {
             id: 203,
             node_id: "IC_kwDO_user",
             body: "Please fix the retry loop.",
@@ -935,12 +943,14 @@ test("fetchFeedbackItemsForPR marks oh-my-pr status and audit comments non-actio
     config,
   );
 
-  assert.equal(items.length, 3);
+  assert.equal(items.length, 4);
   assert.equal(items[0]?.status, "rejected");
   assert.match(items[0]?.statusReason ?? "", /oh-my-pr/i);
   assert.equal(items[1]?.status, "rejected");
   assert.match(items[1]?.statusReason ?? "", /audit/i);
-  assert.equal(items[2]?.status, "pending");
+  assert.equal(items[2]?.status, "rejected");
+  assert.match(items[2]?.statusReason ?? "", /oh-my-pr/i);
+  assert.equal(items[3]?.status, "pending");
 });
 
 test("fetchFeedbackItemsForPR paginates review thread comments beyond the first page", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -398,6 +398,7 @@ export function buildFeedbackAuditToken(feedbackId: string): string {
 const APP_COMMENT_FOOTER_PATTERN = /Posted by \[oh-my-pr\]\(https:\/\/github\.com\/yungookim\/oh-my-pr\)/i;
 const AGENT_COMMAND_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
 const AUDIT_TRAIL_COMMENT_PATTERN = /<!--\s*codefactory-feedback:[^>]+-->/i;
+export const APP_STATUS_COMMENT_PATTERN = /\*\*(?:Accepted|Agent running|Agent failed|Agent completed|Resolved)\*\*\s*(?:[—-]|$)/i;
 
 function classifyNonActionableAppFeedback(body: string): string | null {
   if (body.includes(AGENT_COMMAND_COMMENT_MARKER)) {
@@ -409,6 +410,10 @@ function classifyNonActionableAppFeedback(body: string): string | null {
   }
 
   if (APP_COMMENT_FOOTER_PATTERN.test(body)) {
+    return "oh-my-pr status comment";
+  }
+
+  if (APP_STATUS_COMMENT_PATTERN.test(body)) {
     return "oh-my-pr status comment";
   }
 

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -623,6 +623,61 @@ test("GET /api/activities warns when a babysitter job fails from agent authentic
   }
 });
 
+test("GET /api/activities warns when a babysitter job fails from Codex session permissions", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage, {
+    title: "fix codex warning",
+    repo: "acme/widgets",
+    number: 78,
+    url: "https://github.com/acme/widgets/pull/78",
+  });
+
+  try {
+    const job = await harness.storage.enqueueBackgroundJob({
+      kind: "babysit_pr",
+      targetId: pr.id,
+      dedupeKey: `babysit_pr:${pr.id}`,
+      payload: { preferredAgent: "codex" },
+      availableAt: "2026-04-26T10:00:00.000Z",
+    });
+    await harness.storage.claimNextBackgroundJob({
+      workerId: "worker-1",
+      leaseToken: "lease-1",
+      leaseExpiresAt: "2026-04-26T10:10:00.000Z",
+      now: "2026-04-26T10:01:00.000Z",
+    });
+    await harness.storage.failBackgroundJob(
+      job.id,
+      "lease-1",
+      "Agent health check failed for codex: codex health check failed: Error: thread/start: Codex cannot access session files at /Users/dgyk/.codex/sessions (permission denied)",
+      "2026-04-26T10:02:00.000Z",
+    );
+    await harness.storage.updatePR(pr.id, {
+      status: "error",
+      lastChecked: "2026-04-26T10:02:00.000Z",
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/activities`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      warnings?: Array<{
+        title: string;
+        fixSteps: string[];
+      }>;
+    };
+
+    assert.equal(body.warnings?.[0]?.title, "Codex authentication failed");
+    assert.deepEqual(body.warnings?.[0]?.fixSteps, [
+      "Run `codex login` on this machine.",
+      "Check ownership and permissions for ~/.codex, especially ~/.codex/sessions, so oh-my-pr can access Codex session files.",
+      "Restart oh-my-pr if it was launched before you refreshed credentials.",
+      "Rerun the babysitter for this PR.",
+    ]);
+  } finally {
+    await harness.close();
+  }
+});
+
 for (const agent of [
   { preferredAgent: "codex", label: "Codex", installName: "Codex", prNumber: 78 },
   { preferredAgent: "claude", label: "Claude", installName: "Claude Code", prNumber: 79 },

--- a/tasks/recent-log-failure-report-2026-05-02.md
+++ b/tasks/recent-log-failure-report-2026-05-02.md
@@ -1,0 +1,95 @@
+# Recent Log Failure Fix Baseline - 2026-05-02
+
+## Scope
+
+This baseline records the fixes applied after reviewing local oh-my-pr logs on May 2, 2026.
+
+Implementation branch:
+
+- `fix/log-failure-fixes`
+- Base: `origin/main@8eb4ec739dc0303325b2b83771f353dce1c2bd17`
+- Recorded at: `2026-05-02T14:10:04Z`
+
+## Latest-Code Check
+
+Before implementation, `origin/main` was fetched and verified. The latest remote commits were PR #150 hash-router/frontend log-page changes only, so the backend automation failures from the local logs were not already addressed there.
+
+Already-addressed items were left as verification-only:
+
+- Missing replay context persistence.
+- Illegal CI healing transition after escalation.
+- Conflict prompt instructions telling agents not to stage, commit, or push.
+
+## Fixes Applied
+
+### Codex Health Diagnostics
+
+Health checks now prefer actionable Codex session-permission errors over generic early stderr such as `Reading additional input from stdin...`.
+
+Expected future signal:
+
+- Codex session permission failures mention `Codex cannot access session files` or the equivalent actionable line.
+- Dashboard activity warnings classify these failures as Codex availability warnings and include `~/.codex/sessions` permission guidance.
+
+### Dependency Preflight Retry Loop
+
+Dependency preflight failures are now recorded in the durable `agent_runs` journal with failure kind `dependency_preflight` and the PR head SHA.
+
+Expected future signal:
+
+- The watcher logs one skip for the same PR/head after a dependency preflight failure.
+- It does not enqueue repeated `babysit_pr` jobs for the same failed head.
+- A new PR head SHA is allowed to retry.
+
+### Merge Conflict Repair Retry Loop
+
+Repeated conflict repair failures are budgeted by PR, head SHA, base ref, and sorted unresolved path set.
+
+Expected future signal:
+
+- After the retry budget is exhausted for the same unresolved files, the run logs `conflict.retry`, marks the PR/run failed, and does not relaunch the conflict agent.
+- App-owned conflict finalization remains unchanged: agents edit files only; the app stages, commits, pushes, and verifies.
+
+### Self-Authored Status Comments
+
+Footerless oh-my-pr status comments are now rejected at ingest when possible and ignored during runtime evaluation when they already exist as pending local feedback.
+
+Expected future signal:
+
+- No evaluator prompts for oh-my-pr status bodies such as `Accepted`, `Agent running`, `Agent failed`, `Agent completed`, or `Resolved`.
+
+## Verification
+
+Commands run from `.worktrees/log-failure-fixes`:
+
+```bash
+node --test --import tsx server/agentRunner.test.ts
+node --test --import tsx server/github.test.ts
+node --test --import tsx server/babysitter.test.ts --test-name-pattern "dependency preflight"
+node --test --import tsx server/babysitter.test.ts --test-name-pattern "footerless status"
+node --test --import tsx server/babysitter.test.ts --test-name-pattern "conflict repair"
+node --test --import tsx server/routes.test.ts --test-name-pattern "Codex session permissions"
+node --test --import tsx server/agentRunner.test.ts server/github.test.ts server/routes.test.ts server/babysitter.test.ts server/ciHealingManager.test.ts
+npm run check
+node --test --import tsx server/*.test.ts
+npm run build
+git diff --check
+```
+
+Results:
+
+- Focused suites passed.
+- `npm run check` passed.
+- Full server suite passed: 428 passed, 1 skipped, 0 failed.
+- Production build passed.
+- `git diff --check` passed.
+
+## Future Log Review Boundary
+
+For future local-log analysis, treat log rows before this branch lands as pre-fix evidence. Only count these as regressions if they appear after the merge commit for `fix/log-failure-fixes`:
+
+- Repeated dependency preflight failures for the same PR/head SHA after the first durable marker.
+- Repeated conflict-agent launches for the same PR/head/base/unresolved path set after budget exhaustion.
+- Codex health warnings that hide the session-permission root cause behind generic stderr.
+- Agent evaluator prompts for oh-my-pr-authored status comments.
+- Replay-context or escalated-healing transition errors after `origin/main@8eb4ec7`.


### PR DESCRIPTION
## Summary
- surface actionable Codex session permission failures and dashboard repair steps
- persist deterministic dependency-preflight failures and conflict-repair retry markers to stop same-head loops
- ignore oh-my-pr footerless status comments during ingest/evaluation and add a new log-review baseline

## Test Plan
- [x] claude -p /simplify on changed files, with safe findings applied
- [x] npm run check
- [x] node --test --import tsx server/*.test.ts
- [x] npm run build
- [x] git diff --check