### PR TITLE
fix: stop repeated conflict repair loops

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -132,6 +132,17 @@ function assertSourceDoesNotMatch(source: string, label: string, unexpected: Reg
   assert.ok(!unexpected.test(source), `Expected ${label} not to match ${unexpected}`);
 }
 
+function getFunctionText(sourceFile: ts.SourceFile, name: string) {
+  let functionText: string | undefined;
+  walk(sourceFile, (node) => {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      functionText = node.getText(sourceFile);
+    }
+  });
+  assert.ok(functionText, `Expected ${name} function to exist`);
+  return functionText;
+}
+
 function assertHasJsxTag(sourceFile: ts.SourceFile, label: string, tagName: string) {
   let found = false;
   walk(sourceFile, (node) => {
@@ -300,6 +311,16 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasApiRequest(sourceFile, "manual release mutation", "POST", "/api/repos/release");
   assertHasApiRequest(sourceFile, "failed activity clear mutation", "DELETE", "/api/activities/failed");
   assertHasApiRequest(sourceFile, "ask agent mutation", "POST", /`\/api\/prs\/\$\{prId\}\/questions`/);
+});
+
+test("dashboard finds latest target activity without sorting the full activity list", async () => {
+  const { sourceFile } = await parseProjectFile("client/src/pages/dashboard.tsx");
+  const helper = getFunctionText(sourceFile, "latestActivityForTarget");
+
+  assert.match(helper, /\.reduce\(/);
+  assert.doesNotMatch(helper, /\.filter\(/);
+  assert.doesNotMatch(helper, /\.sort\(/);
+  assert.match(helper, /Date\.parse/);
 });
 
 test("settings keeps the QA-tested configuration, token, and runtime controls wired", async () => {

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -65,6 +65,20 @@ function formatPollInterval(pollIntervalMs?: number): string {
   return `${seconds}s`;
 }
 
+function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
+  return activities
+    .filter((activity) => activity.targetId === targetId)
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+}
+
+function getPRFeedbackFailureReason(pr: PR): string | null {
+  const failedItem = pr.feedbackItems.find((item) =>
+    (item.status === "failed" || item.status === "warning") && Boolean(item.statusReason),
+  );
+
+  return failedItem?.statusReason ?? null;
+}
+
 const WATCH_SCOPE_OPTIONS = [
   { value: "mine", label: "My PRs only" },
   { value: "team", label: "My PRs + teammates" },
@@ -204,7 +218,12 @@ function ActivityRow({ activity }: { activity: ActivityItem }) {
           <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
         )}
         {activity.status === "failed" && activity.lastError && (
-          <span className="block truncate text-[11px] leading-4 text-destructive">{activity.lastError}</span>
+          <span
+            className="block whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+            title={activity.lastError}
+          >
+            {activity.lastError}
+          </span>
         )}
       </span>
       {timeLabel && (
@@ -433,10 +452,12 @@ const PRRow = memo(function PRRow({
   pr,
   isSelected,
   onSelect,
+  failureMessage,
 }: {
   pr: PR;
   isSelected: boolean;
   onSelect: (id: string) => void;
+  failureMessage?: string | null;
 }) {
   const checkedAt = formatClock(pr.lastChecked);
   const watchEnabled = isPRWatchEnabled(pr);
@@ -482,6 +503,12 @@ const PRRow = memo(function PRRow({
               dotClassName="h-1.5 w-1.5"
               hintClassName="text-[10px] normal-case tracking-normal text-success-foreground/75"
             />
+          )}
+          {pr.status === "error" && failureMessage && (
+            <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+              <span className="font-medium uppercase tracking-wider">Error:</span>{" "}
+              <span className="break-words">{failureMessage}</span>
+            </div>
           )}
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
             <a
@@ -551,6 +578,9 @@ function FeedbackRow({
 
   const createdAt = formatClock(item.createdAt);
   const collapsedByDefault = isFeedbackCollapsedByDefault(item.status);
+  const prominentStatusReason = (item.status === "failed" || item.status === "warning") && item.statusReason
+    ? item.statusReason
+    : null;
 
   return (
     <Collapsible.Root defaultOpen={!collapsedByDefault} className="border-b border-border">
@@ -571,6 +601,12 @@ function FeedbackRow({
               <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
               {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
             </div>
+            {prominentStatusReason && (
+              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+                <span className="font-medium uppercase tracking-wider">Failure reason:</span>{" "}
+                {prominentStatusReason}
+              </div>
+            )}
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {!readOnly && (item.status === "failed" || item.status === "warning") && (
@@ -624,9 +660,16 @@ function FeedbackRow({
           ) : (
             <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-foreground/80">{item.body}</p>
           )}
-          {(item.statusReason || item.decisionReason) && (
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              {item.statusReason || item.decisionReason}
+          {item.statusReason && !prominentStatusReason && (
+            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+              <span className="font-medium uppercase tracking-wider text-foreground/70">Status reason:</span>{" "}
+              {item.statusReason}
+            </p>
+          )}
+          {item.decisionReason && (
+            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+              <span className="font-medium uppercase tracking-wider text-foreground/70">Decision reason:</span>{" "}
+              {item.decisionReason}
             </p>
           )}
         </div>
@@ -692,7 +735,9 @@ function LogPanel({ prId }: { prId: string | null }) {
                     {log.phase && <span className="border border-border px-1 py-0">{log.phase}</span>}
                     {log.runId && <span className="normal-case text-foreground/45">run {log.runId.slice(0, 8)}</span>}
                   </div>
-                  <div className="mt-1 break-words text-foreground/75">{log.message}</div>
+                  <div className={`mt-1 break-words ${log.level === "error" ? "text-destructive" : "text-foreground/75"}`}>
+                    {log.message}
+                  </div>
                   {metadataText && (
                     <pre className="mt-1 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">
                       {metadataText}
@@ -799,8 +844,14 @@ function HealingPanel({
   );
 }
 
-function RightPanel({ prId }: { prId: string | null }) {
+function RightPanel({ prId, prStatus }: { prId: string | null; prStatus?: PR["status"] | null }) {
   const [tab, setTab] = useState<"activity" | "ask">("ask");
+
+  useEffect(() => {
+    if (prStatus === "error") {
+      setTab("activity");
+    }
+  }, [prId, prStatus]);
 
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
@@ -1051,6 +1102,10 @@ export default function Dashboard() {
 
   const selectedPR = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
   const selectedPRWatchEnabled = selectedPR ? isPRWatchEnabled(selectedPR) : true;
+  const selectedFailedActivity = selectedPR ? latestActivityForTarget(activities.failed, selectedPR.id) : undefined;
+  const selectedPRErrorMessage = selectedPR?.status === "error"
+    ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
+    : null;
   const repoAddControlsOpen = getRepoAddControlsOpen(addControlsOpen, repos.length);
 
   const addMutation = useMutation({
@@ -1526,6 +1581,11 @@ export default function Dashboard() {
                   pr={pr}
                   isSelected={pr.id === selectedPRId}
                   onSelect={setSelectedPRId}
+                  failureMessage={
+                    pr.status === "error"
+                      ? latestActivityForTarget(activities.failed, pr.id)?.lastError ?? getPRFeedbackFailureReason(pr)
+                      : null
+                  }
                 />
               ))
             )}
@@ -1610,6 +1670,15 @@ export default function Dashboard() {
                     hintClassName="text-[11px] normal-case tracking-normal text-success-foreground/75"
                   />
                 )}
+                {selectedPRErrorMessage && (
+                  <div
+                    className="mt-2 border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] leading-5 text-destructive"
+                    data-testid="selected-pr-error"
+                  >
+                    <div className="text-[10px] font-medium uppercase tracking-wider">Automation error</div>
+                    <div className="mt-1 whitespace-pre-wrap break-words">{selectedPRErrorMessage}</div>
+                  </div>
+                )}
                 <div className="text-[11px] text-muted-foreground">
                   {selectedPRWatchEnabled
                     ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
@@ -1640,7 +1709,7 @@ export default function Dashboard() {
           )}
         </div>
 
-        <RightPanel prId={selectedPRId} />
+        <RightPanel prId={selectedPRId} prStatus={selectedPR?.status ?? null} />
       </div>
     </div>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -66,9 +66,15 @@ function formatPollInterval(pollIntervalMs?: number): string {
 }
 
 function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
-  return activities
-    .filter((activity) => activity.targetId === targetId)
-    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+  return activities.reduce((latest, activity) => {
+    if (activity.targetId !== targetId) {
+      return latest;
+    }
+    if (!latest || Date.parse(activity.updatedAt) > Date.parse(latest.updatedAt)) {
+      return activity;
+    }
+    return latest;
+  }, undefined as ActivityItem | undefined);
 }
 
 function getPRFeedbackFailureReason(pr: PR): string | null {

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -315,7 +315,7 @@ export default function Logs() {
               <span className="shrink-0 text-muted-foreground">{formatTime(r.time)}</span>
               <span className={`shrink-0 w-12 ${LEVEL_COLOR[r.level]}`}>{r.level}</span>
               {r.source && <span className="shrink-0 text-muted-foreground">[{r.source}]</span>}
-              <span className="grow">
+              <span className={`grow ${r.level === "error" || r.level === "fatal" ? "text-destructive" : ""}`}>
                 {r.msg}
                 {Object.keys(r.fields).length > 0 && (
                   <span className="text-muted-foreground"> {JSON.stringify(r.fields)}</span>

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -48,6 +48,7 @@ function makePullSummary(pr: { url: string }, overrides?: Record<string, unknown
     headRepoFullName: "alex-morgan-o/lolodex",
     headRepoCloneUrl: "https://github.com/alex-morgan-o/lolodex.git",
     baseRef: "main",
+    baseSha: "base123",
     mergeable: true as boolean | null,
     ...overrides,
   };
@@ -115,6 +116,10 @@ function makeGitRunCommand(params?: {
 
     if (args[0] === "-C" && args[2] === "worktree" && args[3] === "remove") {
       return { code: 0, stdout: "worktree removed\n", stderr: "" };
+    }
+
+    if (args[0] === "grep" && args[1] === "-n" && args[2] === "-E") {
+      return { code: 1, stdout: "", stderr: "" };
     }
 
     return { code: 0, stdout: "", stderr: "" };
@@ -536,6 +541,9 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
         branch: "feature/example",
         author: "octocat",
         url: "https://github.com/octo/example/pull/42",
+        headSha: "head123",
+        baseRef: "main",
+        baseSha: "base123",
       }],
     }),
     {
@@ -622,6 +630,8 @@ test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures",
         author: "octocat",
         url: "https://github.com/octo/example/pull/42",
         headSha: "head-same",
+        baseRef: "main",
+        baseSha: "base123",
       }],
     }),
     {
@@ -648,6 +658,196 @@ test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures",
   const logs = await storage.getLogs(pr.id);
   assert.equal(jobs.length, 0);
   assert.ok(logs.some((log) => log.message.includes("Dependency preflight previously failed")));
+});
+
+test("syncAndBabysitTrackedRepos skips terminal conflict repair failures for the same head and base", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Same conflict",
+    repo: "octo/example",
+    branch: "feature/conflict",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+  const now = new Date().toISOString();
+  await storage.upsertAgentRun({
+    id: "terminal-conflict-run",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "failed",
+    phase: "run.failed",
+    prompt: null,
+    initialHeadSha: "head-same",
+    metadata: {
+      conflictRepairFailure: {
+        kind: "merge_conflict_repair",
+        headSha: "head-same",
+        baseRef: "main",
+        baseSha: "base-same",
+        conflictFiles: ["src/example.ts"],
+        reason: "codex left unresolved merge conflicts: src/example.ts",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        count: 2,
+      },
+    },
+    lastError: "codex left unresolved merge conflicts: src/example.ts",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Same conflict",
+        branch: "feature/conflict",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+        headSha: "head-same",
+        baseRef: "main",
+        baseSha: "base-same",
+      }],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should not invoke babysitPR directly when a scheduler is provided");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(jobs.length, 0);
+  assert.equal(updated?.status, "error");
+  assert.ok(logs.some((log) => log.phase === "watcher" && log.message.includes("failed twice")));
+});
+
+test("syncAndBabysitTrackedRepos resumes after terminal conflict repair when head or base changes", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const now = new Date().toISOString();
+  const prs = await Promise.all([43, 44].map((number) => storage.addPR({
+    number,
+    title: `Conflict changed ${number}`,
+    repo: "octo/example",
+    branch: `feature/conflict-${number}`,
+    author: "octocat",
+    url: `https://github.com/octo/example/pull/${number}`,
+    status: "error",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  })));
+
+  for (const pr of prs) {
+    await storage.upsertAgentRun({
+      id: `terminal-conflict-run-${pr.number}`,
+      prId: pr.id,
+      preferredAgent: "codex",
+      resolvedAgent: "codex",
+      status: "failed",
+      phase: "run.failed",
+      prompt: null,
+      initialHeadSha: "head-old",
+      metadata: {
+        conflictRepairFailure: {
+          kind: "merge_conflict_repair",
+          headSha: "head-old",
+          baseRef: "main",
+          baseSha: "base-old",
+          conflictFiles: ["src/example.ts"],
+          reason: "codex left unresolved merge conflicts: src/example.ts",
+          firstSeenAt: now,
+          lastSeenAt: now,
+          count: 2,
+        },
+      },
+      lastError: "codex left unresolved merge conflicts: src/example.ts",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [
+        {
+          number: 43,
+          title: "Conflict changed 43",
+          branch: "feature/conflict-43",
+          author: "octocat",
+          url: "https://github.com/octo/example/pull/43",
+          headSha: "head-new",
+          baseRef: "main",
+          baseSha: "base-old",
+        },
+        {
+          number: 44,
+          title: "Conflict changed 44",
+          branch: "feature/conflict-44",
+          author: "octocat",
+          url: "https://github.com/octo/example/pull/44",
+          headSha: "head-old",
+          baseRef: "main",
+          baseSha: "base-new",
+        },
+      ],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should not invoke babysitPR directly when a scheduler is provided");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const queued = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+
+  assert.deepEqual(queued.map((job) => job.targetId).sort(), prs.map((pr) => pr.id).sort());
 });
 
 test("syncAndBabysitTrackedRepos repairs missing review-thread metadata on archived PRs", async () => {
@@ -4915,6 +5115,7 @@ test("babysitPR escalates repeated conflict repair for same head and unresolved 
           kind: "merge_conflict_repair",
           headSha: "abc123",
           baseRef: "main",
+          baseSha: "base123",
           conflictFiles: ["src/example.ts"],
           reason: "Agent left unresolved merge conflicts: src/example.ts",
           firstSeenAt: now,
@@ -4990,8 +5191,8 @@ test("babysitPR escalates repeated conflict repair for same head and unresolved 
   assert.equal(updated?.lastChecked, retryCheckedAt);
   assert.equal(currentRun?.status, "failed");
   assert.equal(currentRun?.phase, "conflict.retry");
-  assert.match(currentRun?.lastError ?? "", /retry budget exhausted/i);
-  assert.ok(logs.some((log) => log.phase === "conflict.retry" && log.message.includes("retry budget exhausted")));
+  assert.match(currentRun?.lastError ?? "", /failed twice/i);
+  assert.ok(logs.some((log) => log.phase === "conflict.retry" && log.message.includes("failed twice")));
 
   delete process.env.CODEFACTORY_HOME;
 });
@@ -5219,6 +5420,7 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
         kind: "merge_conflict_repair",
         headSha: "abc123",
         baseRef: "main",
+        baseSha: "base123",
         conflictFiles: ["src/conflict.ts"],
         reason: "Agent failed to resolve merge conflicts: agent crashed",
         firstSeenAt,
@@ -5290,6 +5492,102 @@ test("babysitPR errors when conflict resolution agent fails", async () => {
   assert.equal(conflictMarker?.count, 2);
   assert.match(String(conflictMarker?.reason ?? ""), /codex/);
   assert.ok(logs.some((log) => log.level === "error" && log.message.includes("merge conflicts")));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR records conflict repair failure when agent leaves conflict markers", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  const pullSummary = makePullSummary(pr, { mergeable: false });
+  const gitRunner = makeGitRunCommand({
+    localHeadSha: "abc123",
+    remoteHeadSha: "abc123",
+  });
+  let conflictDiffChecks = 0;
+  let commitAttempted = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No fix needed",
+      }),
+      applyFixesWithAgent: async () => {
+        return { code: 0, stdout: "resolved\n", stderr: "" };
+      },
+      runCommand: async (command: string, args: string[], opts?: Record<string, unknown>) => {
+        if (command === "git" && args[0] === "merge") {
+          return { code: 1, stdout: "", stderr: "CONFLICT" };
+        }
+        if (command === "git" && args[0] === "diff" && args[1] === "--name-only" && args[2] === "--diff-filter=U") {
+          conflictDiffChecks += 1;
+          if (conflictDiffChecks > 1) {
+            const cwd = String(opts?.cwd ?? worktreeRoot);
+            await mkdir(path.join(cwd, "src"), { recursive: true });
+            await writeFile(path.join(cwd, "src/conflict.ts"), "<<<<<<< HEAD\nconst value = 1;\n=======\nconst value = 2;\n>>>>>>> branch\n");
+          }
+          return {
+            code: 0,
+            stdout: conflictDiffChecks === 1 ? "src/conflict.ts\n" : "",
+            stderr: "",
+          };
+        }
+        if (command === "git" && args[0] === "commit") {
+          commitAttempted = true;
+        }
+        return gitRunner(command, args, opts);
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const runs = await storage.listAgentRuns({ prId: pr.id });
+  const currentRun = runs[0];
+  const conflictMarker = currentRun?.metadata?.conflictRepairFailure as Record<string, unknown> | undefined;
+
+  assert.equal(commitAttempted, false);
+  assert.equal(updated?.status, "error");
+  assert.equal(currentRun?.status, "failed");
+  assert.match(currentRun?.lastError ?? "", /left merge conflict markers/i);
+  assert.deepEqual(conflictMarker?.conflictFiles, ["src/conflict.ts"]);
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -751,6 +751,100 @@ test("syncAndBabysitTrackedRepos skips terminal conflict repair failures for the
   assert.ok(logs.some((log) => log.phase === "watcher" && log.message.includes("failed twice")));
 });
 
+test("syncAndBabysitTrackedRepos does not repeat terminal conflict logs for PRs already in error", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Same conflict",
+    repo: "octo/example",
+    branch: "feature/conflict",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "error",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+  const now = new Date().toISOString();
+  const checkedAt = "2026-05-03T12:00:00.000Z";
+  await storage.upsertAgentRun({
+    id: "terminal-conflict-run",
+    prId: pr.id,
+    preferredAgent: "codex",
+    resolvedAgent: "codex",
+    status: "failed",
+    phase: "run.failed",
+    prompt: null,
+    initialHeadSha: "head-same",
+    metadata: {
+      conflictRepairFailure: {
+        kind: "merge_conflict_repair",
+        headSha: "head-same",
+        baseRef: "main",
+        baseSha: "base-same",
+        conflictFiles: ["src/example.ts"],
+        reason: "codex left unresolved merge conflicts: src/example.ts",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        count: 2,
+      },
+    },
+    lastError: "codex left unresolved merge conflicts: src/example.ts",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Same conflict",
+        branch: "feature/conflict",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+        headSha: "head-same",
+        baseRef: "main",
+        baseSha: "base-same",
+      }],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      now: () => new Date(checkedAt),
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should not invoke babysitPR directly when a scheduler is provided");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(jobs.length, 0);
+  assert.equal(updated?.status, "error");
+  assert.equal(updated?.lastChecked, checkedAt);
+  assert.equal(logs.filter((log) => log.phase === "watcher" && log.message.includes("failed twice")).length, 0);
+});
+
 test("syncAndBabysitTrackedRepos resumes after terminal conflict repair when head or base changes", async () => {
   const storage = new MemStorage();
   const backgroundJobQueue = new BackgroundJobQueue(storage);
@@ -5523,6 +5617,7 @@ test("babysitPR records conflict repair failure when agent leaves conflict marke
     remoteHeadSha: "abc123",
   });
   let conflictDiffChecks = 0;
+  let gitGrepArgs: string[] | null = null;
   let commitAttempted = false;
 
   const babysitter = new PRBabysitter(
@@ -5557,16 +5652,15 @@ test("babysitPR records conflict repair failure when agent leaves conflict marke
         }
         if (command === "git" && args[0] === "diff" && args[1] === "--name-only" && args[2] === "--diff-filter=U") {
           conflictDiffChecks += 1;
-          if (conflictDiffChecks > 1) {
-            const cwd = String(opts?.cwd ?? worktreeRoot);
-            await mkdir(path.join(cwd, "src"), { recursive: true });
-            await writeFile(path.join(cwd, "src/conflict.ts"), "<<<<<<< HEAD\nconst value = 1;\n=======\nconst value = 2;\n>>>>>>> branch\n");
-          }
           return {
             code: 0,
             stdout: conflictDiffChecks === 1 ? "src/conflict.ts\n" : "",
             stderr: "",
           };
+        }
+        if (command === "git" && args[0] === "grep") {
+          gitGrepArgs = args;
+          return { code: 0, stdout: "src/conflict.ts\0", stderr: "" };
         }
         if (command === "git" && args[0] === "commit") {
           commitAttempted = true;
@@ -5583,6 +5677,7 @@ test("babysitPR records conflict repair failure when agent leaves conflict marke
   const currentRun = runs[0];
   const conflictMarker = currentRun?.metadata?.conflictRepairFailure as Record<string, unknown> | undefined;
 
+  assert.deepEqual(gitGrepArgs?.slice(-2), ["--", "src/conflict.ts"]);
   assert.equal(commitAttempted, false);
   assert.equal(updated?.status, "error");
   assert.equal(currentRun?.status, "failed");

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { access } from "fs/promises";
+import { access, readFile } from "fs/promises";
 import path from "path";
 import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR } from "@shared/schema";
 import type { IStorage } from "./storage";
@@ -77,6 +77,13 @@ const APP_REPOSITORY_LINK = `[${APP_NAME}](${APP_REPOSITORY_URL})`;
 export const APP_COMMENT_FOOTER = `Posted by ${APP_REPOSITORY_LINK}`;
 const AUDIT_TOKEN_PATTERN = /\bcodefactory-feedback:[^\s<>()[\]{}"']+/g;
 
+export class TerminalBabysitterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TerminalBabysitterError";
+  }
+}
+
 type GitHubService = {
   addReactionToComment: typeof addReactionToComment;
   buildOctokit: typeof buildOctokit;
@@ -109,6 +116,7 @@ type ConflictRepairFailureMarker = {
   kind: typeof CONFLICT_REPAIR_FAILURE_KIND;
   headSha: string;
   baseRef: string;
+  baseSha: string;
   conflictFiles: string[];
   reason: string;
   firstSeenAt: string;
@@ -621,6 +629,47 @@ function normalizeConflictFiles(files: string[]): string[] {
   return Array.from(new Set(files.map((file) => file.trim()).filter(Boolean))).sort();
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+async function findFilesWithConflictMarkers(worktreePath: string, files: string[]): Promise<string[]> {
+  const filesWithMarkers: string[] = [];
+  const markerPattern = /^(<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|)/m;
+
+  for (const file of normalizeConflictFiles(files)) {
+    try {
+      const content = await readFile(path.join(worktreePath, file), "utf8");
+      if (markerPattern.test(content)) {
+        filesWithMarkers.push(file);
+      }
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return filesWithMarkers;
+}
+
+function buildTerminalConflictRepairReason(params: {
+  conflictFiles: string[];
+  headSha: string;
+  baseRef: string;
+  baseSha: string;
+  lastReason?: string;
+}): string {
+  const headLabel = params.headSha ? params.headSha.slice(0, 7) : "unknown head";
+  const baseLabel = params.baseSha
+    ? `${params.baseRef} (${params.baseSha.slice(0, 7)})`
+    : params.baseRef || "unknown base";
+  const files = params.conflictFiles.length > 0 ? params.conflictFiles.join(", ") : "the same conflict paths";
+  const suffix = params.lastReason ? ` Last failure: ${params.lastReason}` : "";
+  return `Merge conflict repair failed twice for ${files} at head ${headLabel} against base ${baseLabel}; stopping automatic babysitter runs until the PR head or base changes.${suffix}`;
+}
+
 function sameStrings(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
@@ -631,6 +680,7 @@ function readConflictRepairFailure(metadata: AgentRun["metadata"]): ConflictRepa
     || marker.kind !== CONFLICT_REPAIR_FAILURE_KIND
     || typeof marker.headSha !== "string"
     || typeof marker.baseRef !== "string"
+    || typeof marker.baseSha !== "string"
     || typeof marker.reason !== "string"
     || !Array.isArray(marker.conflictFiles)
   ) {
@@ -641,6 +691,7 @@ function readConflictRepairFailure(metadata: AgentRun["metadata"]): ConflictRepa
     kind: CONFLICT_REPAIR_FAILURE_KIND,
     headSha: marker.headSha,
     baseRef: marker.baseRef,
+    baseSha: marker.baseSha,
     conflictFiles: normalizeConflictFiles(marker.conflictFiles.filter((file): file is string => typeof file === "string")),
     reason: marker.reason,
     firstSeenAt: typeof marker.firstSeenAt === "string" ? marker.firstSeenAt : "",
@@ -1151,14 +1202,14 @@ export class PRBabysitter {
     return null;
   }
 
-  private async countConflictRepairFailures(prId: string, headSha: string, baseRef: string, conflictFiles: string[]): Promise<number> {
+  private async countConflictRepairFailures(prId: string, headSha: string, baseSha: string, conflictFiles: string[]): Promise<number> {
     const normalizedFiles = normalizeConflictFiles(conflictFiles);
     const failedRuns = await this.storage.listAgentRuns({ prId, status: "failed" });
     return failedRuns.reduce((count, run) => {
       const marker = readConflictRepairFailure(run.metadata);
       if (!marker
         || marker.headSha !== headSha
-        || marker.baseRef !== baseRef
+        || marker.baseSha !== baseSha
         || !sameStrings(marker.conflictFiles, normalizedFiles)
       ) {
         return count;
@@ -1171,7 +1222,7 @@ export class PRBabysitter {
   private async findLatestConflictRepairFailure(
     prId: string,
     headSha: string,
-    baseRef: string,
+    baseSha: string,
     conflictFiles: string[],
   ): Promise<ConflictRepairFailureMarker | null> {
     const normalizedFiles = normalizeConflictFiles(conflictFiles);
@@ -1182,13 +1233,60 @@ export class PRBabysitter {
       const marker = readConflictRepairFailure(run.metadata);
       if (!marker
         || marker.headSha !== headSha
-        || marker.baseRef !== baseRef
+        || marker.baseSha !== baseSha
         || !sameStrings(marker.conflictFiles, normalizedFiles)
       ) {
         continue;
       }
 
       return marker;
+    }
+
+    return null;
+  }
+
+  private async findTerminalConflictRepairFailureForHead(
+    prId: string,
+    headSha: string,
+    baseSha: string,
+  ): Promise<ConflictRepairFailureMarker | null> {
+    const failedRuns = (await this.storage.listAgentRuns({ prId, status: "failed" }))
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+    const grouped = new Map<string, { marker: ConflictRepairFailureMarker; count: number }>();
+
+    for (const run of failedRuns) {
+      const marker = readConflictRepairFailure(run.metadata);
+      if (!marker
+        || marker.headSha !== headSha
+        || marker.baseSha !== baseSha
+      ) {
+        continue;
+      }
+
+      const key = JSON.stringify(marker.conflictFiles);
+      const existing = grouped.get(key);
+      if (existing) {
+        existing.count += 1;
+        existing.marker = {
+          ...existing.marker,
+          count: Math.max(existing.marker.count, marker.count, existing.count),
+        };
+      } else {
+        grouped.set(key, {
+          marker,
+          count: 1,
+        });
+      }
+    }
+
+    for (const group of Array.from(grouped.values())) {
+      const count = Math.max(group.count, group.marker.count);
+      if (count >= CONFLICT_REPAIR_RETRY_BUDGET) {
+        return {
+          ...group.marker,
+          count,
+        };
+      }
     }
 
     return null;
@@ -1797,6 +1895,36 @@ export class PRBabysitter {
               headSha: pull.headSha,
               reason: priorDependencyFailure.reason,
               count: priorDependencyFailure.count,
+            },
+          });
+          continue;
+        }
+
+        const terminalConflictFailure = pull.headSha && pull.baseSha
+          ? await this.findTerminalConflictRepairFailureForHead(local.id, pull.headSha, pull.baseSha)
+          : null;
+        if (terminalConflictFailure) {
+          const reason = buildTerminalConflictRepairReason({
+            conflictFiles: terminalConflictFailure.conflictFiles,
+            headSha: terminalConflictFailure.headSha,
+            baseRef: terminalConflictFailure.baseRef,
+            baseSha: terminalConflictFailure.baseSha,
+            lastReason: terminalConflictFailure.reason,
+          });
+          await this.storage.updatePR(local.id, {
+            status: "error",
+            lastChecked: this.now().toISOString(),
+          });
+          await this.storage.addLog(local.id, "warn", reason, {
+            phase: "watcher",
+            metadata: {
+              repo: repoSlug,
+              headSha: pull.headSha,
+              baseSha: pull.baseSha,
+              baseRef: pull.baseRef,
+              conflictFiles: terminalConflictFailure.conflictFiles,
+              count: terminalConflictFailure.count,
+              priorReason: terminalConflictFailure.reason,
             },
           });
           continue;
@@ -3111,13 +3239,13 @@ export class PRBabysitter {
                 const previousFailures = priorFailures ?? await this.countConflictRepairFailures(
                   pr.id,
                   pullSummary.headSha,
-                  pullSummary.baseRef,
+                  pullSummary.baseSha,
                   conflictFilesForMarker,
                 );
                 const previousFailure = await this.findLatestConflictRepairFailure(
                   pr.id,
                   pullSummary.headSha,
-                  pullSummary.baseRef,
+                  pullSummary.baseSha,
                   conflictFilesForMarker,
                 );
                 const failureFirstSeenAt = previousFailure?.firstSeenAt || seenAt;
@@ -3129,6 +3257,7 @@ export class PRBabysitter {
                       kind: CONFLICT_REPAIR_FAILURE_KIND,
                       headSha: pullSummary.headSha,
                       baseRef: pullSummary.baseRef,
+                      baseSha: pullSummary.baseSha,
                       conflictFiles: conflictFilesForMarker,
                       reason,
                       firstSeenAt: failureFirstSeenAt,
@@ -3138,16 +3267,23 @@ export class PRBabysitter {
                   },
                   phase,
                 });
+                return failureCount;
               };
 
               const priorConflictFailures = await this.countConflictRepairFailures(
                 pr.id,
                 pullSummary.headSha,
-                pullSummary.baseRef,
+                pullSummary.baseSha,
                 normalizedConflictFiles,
               );
               if (priorConflictFailures >= CONFLICT_REPAIR_RETRY_BUDGET) {
-                const reason = `Merge conflict repair retry budget exhausted for ${normalizedConflictFiles.join(", ")}`;
+                const reason = buildTerminalConflictRepairReason({
+                  conflictFiles: normalizedConflictFiles,
+                  headSha: pullSummary.headSha,
+                  baseRef: pullSummary.baseRef,
+                  baseSha: pullSummary.baseSha,
+                });
+                await recordConflictRepairFailure(normalizedConflictFiles, reason, "conflict.retry", priorConflictFailures);
                 await updateRunRecord({
                   status: "failed",
                   phase: "conflict.retry",
@@ -3162,11 +3298,12 @@ export class PRBabysitter {
                   metadata: {
                     headSha: pullSummary.headSha,
                     baseRef: pullSummary.baseRef,
+                    baseSha: pullSummary.baseSha,
                     conflictFiles: normalizedConflictFiles,
                     priorFailures: priorConflictFailures,
                   },
                 });
-                return;
+                throw new TerminalBabysitterError(reason);
               }
 
               const conflictStdout = createChunkLogger(pr.id, "conflict.agent", "stdout", "info");
@@ -3208,7 +3345,16 @@ export class PRBabysitter {
               if (conflictResult.code !== 0) {
                 const failureDetail = formatConciseFailureReason(conflictResult.stderr || conflictResult.stdout);
                 const failureReason = `${agent} failed to resolve merge conflicts: ${failureDetail}`;
-                await recordConflictRepairFailure(normalizedConflictFiles, failureReason, "conflict.agent", priorConflictFailures);
+                const failureCount = await recordConflictRepairFailure(normalizedConflictFiles, failureReason, "conflict.agent", priorConflictFailures);
+                if (failureCount >= CONFLICT_REPAIR_RETRY_BUDGET) {
+                  throw new TerminalBabysitterError(buildTerminalConflictRepairReason({
+                    conflictFiles: normalizedConflictFiles,
+                    headSha: pullSummary.headSha,
+                    baseRef: pullSummary.baseRef,
+                    baseSha: pullSummary.baseSha,
+                    lastReason: failureReason,
+                  }));
+                }
                 throw new Error(`${agent} failed to resolve merge conflicts (${conflictResult.code}): ${failureDetail}`);
               }
 
@@ -3227,7 +3373,32 @@ export class PRBabysitter {
               const unresolvedFiles = normalizeConflictFiles(unresolvedAfterAgent.stdout.trim().split("\n"));
               if (unresolvedFiles.length > 0) {
                 const failureReason = `${agent} left unresolved merge conflicts: ${unresolvedFiles.join(", ")}`;
-                await recordConflictRepairFailure(unresolvedFiles, failureReason);
+                const failureCount = await recordConflictRepairFailure(unresolvedFiles, failureReason);
+                if (failureCount >= CONFLICT_REPAIR_RETRY_BUDGET) {
+                  throw new TerminalBabysitterError(buildTerminalConflictRepairReason({
+                    conflictFiles: unresolvedFiles,
+                    headSha: pullSummary.headSha,
+                    baseRef: pullSummary.baseRef,
+                    baseSha: pullSummary.baseSha,
+                    lastReason: failureReason,
+                  }));
+                }
+                throw new Error(failureReason);
+              }
+
+              const markerFiles = await findFilesWithConflictMarkers(worktreePath, normalizedConflictFiles);
+              if (markerFiles.length > 0) {
+                const failureReason = `${agent} left merge conflict markers in ${markerFiles.join(", ")}`;
+                const failureCount = await recordConflictRepairFailure(markerFiles, failureReason);
+                if (failureCount >= CONFLICT_REPAIR_RETRY_BUDGET) {
+                  throw new TerminalBabysitterError(buildTerminalConflictRepairReason({
+                    conflictFiles: markerFiles,
+                    headSha: pullSummary.headSha,
+                    baseRef: pullSummary.baseRef,
+                    baseSha: pullSummary.baseSha,
+                    lastReason: failureReason,
+                  }));
+                }
                 throw new Error(failureReason);
               }
 
@@ -3885,7 +4056,7 @@ export class PRBabysitter {
       const message = error instanceof Error ? error.message : String(error);
       await updateRunRecord({
         status: "failed",
-        phase: "run.failed",
+        phase: runRecord.status === "failed" ? runRecord.phase : "run.failed",
         lastError: message,
       });
       const currentPr = await this.storage.getPR(prId);
@@ -3919,12 +4090,12 @@ export class PRBabysitter {
             rejected: updatedCounters.rejected,
             flagged: updatedCounters.flagged,
             status: isNonCritical ? "watching" : "error",
-            lastChecked: new Date().toISOString(),
+            lastChecked: this.now().toISOString(),
           });
         } else {
           await this.storage.updatePR(currentPr.id, {
             status: isNonCritical ? "watching" : "error",
-            lastChecked: new Date().toISOString(),
+            lastChecked: this.now().toISOString(),
           });
         }
       }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { access, readFile } from "fs/promises";
+import { access } from "fs/promises";
 import path from "path";
 import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR } from "@shared/schema";
 import type { IStorage } from "./storage";
@@ -629,29 +629,33 @@ function normalizeConflictFiles(files: string[]): string[] {
   return Array.from(new Set(files.map((file) => file.trim()).filter(Boolean))).sort();
 }
 
-function isMissingFileError(error: unknown): boolean {
-  return isRecord(error) && error.code === "ENOENT";
-}
-
-async function findFilesWithConflictMarkers(worktreePath: string, files: string[]): Promise<string[]> {
-  const filesWithMarkers: string[] = [];
-  const markerPattern = /^(<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|)/m;
-
-  for (const file of normalizeConflictFiles(files)) {
-    try {
-      const content = await readFile(path.join(worktreePath, file), "utf8");
-      if (markerPattern.test(content)) {
-        filesWithMarkers.push(file);
-      }
-    } catch (error) {
-      if (isMissingFileError(error)) {
-        continue;
-      }
-      throw error;
-    }
+async function findFilesWithConflictMarkers(
+  runGitCommand: typeof runCommand,
+  worktreePath: string,
+  files: string[],
+): Promise<string[]> {
+  const normalizedFiles = normalizeConflictFiles(files);
+  if (normalizedFiles.length === 0) {
+    return [];
   }
 
-  return filesWithMarkers;
+  const markerPattern = "^(<<<<<<<|=======|>>>>>>>|\\|\\|\\|\\|\\|\\|\\|)";
+  const result = await runGitCommand(
+    "git",
+    ["grep", "-z", "-l", "-I", "-E", markerPattern, "--", ...normalizedFiles],
+    {
+      cwd: worktreePath,
+      timeoutMs: 5000,
+    },
+  );
+  if (result.code === 1) {
+    return [];
+  }
+  if (result.code !== 0) {
+    throw new Error(formatGitFailure("checking merge conflict markers", result));
+  }
+
+  return normalizeConflictFiles(result.stdout.split("\0"));
 }
 
 function buildTerminalConflictRepairReason(params: {
@@ -1904,29 +1908,34 @@ export class PRBabysitter {
           ? await this.findTerminalConflictRepairFailureForHead(local.id, pull.headSha, pull.baseSha)
           : null;
         if (terminalConflictFailure) {
-          const reason = buildTerminalConflictRepairReason({
-            conflictFiles: terminalConflictFailure.conflictFiles,
-            headSha: terminalConflictFailure.headSha,
-            baseRef: terminalConflictFailure.baseRef,
-            baseSha: terminalConflictFailure.baseSha,
-            lastReason: terminalConflictFailure.reason,
-          });
-          await this.storage.updatePR(local.id, {
-            status: "error",
-            lastChecked: this.now().toISOString(),
-          });
-          await this.storage.addLog(local.id, "warn", reason, {
-            phase: "watcher",
-            metadata: {
-              repo: repoSlug,
-              headSha: pull.headSha,
-              baseSha: pull.baseSha,
-              baseRef: pull.baseRef,
+          const lastChecked = this.now().toISOString();
+          if (local.status !== "error") {
+            const reason = buildTerminalConflictRepairReason({
               conflictFiles: terminalConflictFailure.conflictFiles,
-              count: terminalConflictFailure.count,
-              priorReason: terminalConflictFailure.reason,
-            },
-          });
+              headSha: terminalConflictFailure.headSha,
+              baseRef: terminalConflictFailure.baseRef,
+              baseSha: terminalConflictFailure.baseSha,
+              lastReason: terminalConflictFailure.reason,
+            });
+            await this.storage.updatePR(local.id, {
+              status: "error",
+              lastChecked,
+            });
+            await this.storage.addLog(local.id, "warn", reason, {
+              phase: "watcher",
+              metadata: {
+                repo: repoSlug,
+                headSha: pull.headSha,
+                baseSha: pull.baseSha,
+                baseRef: pull.baseRef,
+                conflictFiles: terminalConflictFailure.conflictFiles,
+                count: terminalConflictFailure.count,
+                priorReason: terminalConflictFailure.reason,
+              },
+            });
+          } else {
+            await this.storage.updatePR(local.id, { lastChecked });
+          }
           continue;
         }
 
@@ -3386,7 +3395,11 @@ export class PRBabysitter {
                 throw new Error(failureReason);
               }
 
-              const markerFiles = await findFilesWithConflictMarkers(worktreePath, normalizedConflictFiles);
+              const markerFiles = await findFilesWithConflictMarkers(
+                this.runtime.runCommand,
+                worktreePath,
+                normalizedConflictFiles,
+              );
               if (markerFiles.length > 0) {
                 const failureReason = `${agent} left merge conflict markers in ${markerFiles.join(", ")}`;
                 const failureCount = await recordConflictRepairFailure(markerFiles, failureReason);

--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BackgroundJobDispatcher, CancelBackgroundJobError } from "./backgroundJobDispatcher";
+import { BackgroundJobDispatcher, CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
 
@@ -304,6 +304,45 @@ test("BackgroundJobDispatcher retries transient handler errors before completing
     assert.equal(stored?.status, "completed");
     assert.equal(stored?.attemptCount, 2);
     assert.equal(stored?.lastError, null);
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher fails terminal handler errors without retrying", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    maxAttempts: 3,
+    retryBackoffMs: 0,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        throw new TerminalBackgroundJobError("merge conflict repair failed twice");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 500);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(attempts, 1);
+    assert.equal(stored?.status, "failed");
+    assert.equal(stored?.attemptCount, 1);
+    assert.match(stored?.lastError ?? "", /merge conflict repair failed twice/);
   } finally {
     dispatcher.stop();
   }

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -17,6 +17,13 @@ export class CancelBackgroundJobError extends Error {
   }
 }
 
+export class TerminalBackgroundJobError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TerminalBackgroundJobError";
+  }
+}
+
 export class BackgroundJobDispatcher {
   private readonly storage: IStorage;
   private readonly queue: BackgroundJobQueue;
@@ -280,6 +287,9 @@ export class BackgroundJobDispatcher {
   private resolveFailureAction(job: BackgroundJob, error: unknown): "cancel" | "retry" | "fail" {
     if (error instanceof CancelBackgroundJobError) {
       return "cancel";
+    }
+    if (error instanceof TerminalBackgroundJobError) {
+      return "fail";
     }
     return job.attemptCount < this.maxAttempts ? "retry" : "fail";
   }

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CancelBackgroundJobError } from "./backgroundJobDispatcher";
+import { TerminalBabysitterError } from "./babysitter";
+import { CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
@@ -135,6 +136,34 @@ test("babysit_pr handler cancels jobs whose PR row is missing", async () => {
     handlers.babysit_pr!(job),
     (error: unknown) => error instanceof CancelBackgroundJobError
       && error.message.includes("missing-pr"),
+  );
+});
+
+test("babysit_pr handler marks terminal babysitter failures as terminal background failures", async () => {
+  const storage = new MemStorage();
+  const prId = await seedPR(storage);
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "babysit_pr",
+    prId,
+    `babysit_pr:${prId}`,
+    { preferredAgent: "codex" },
+  );
+
+  const handlers = createBackgroundJobHandlers({
+    storage,
+    babysitter: {
+      syncAndBabysitTrackedRepos: async () => undefined,
+      runQueuedBabysitPR: async () => {
+        throw new TerminalBabysitterError("merge conflict repair failed twice");
+      },
+    },
+  });
+
+  await assert.rejects(
+    handlers.babysit_pr!(job),
+    (error: unknown) => error instanceof TerminalBackgroundJobError
+      && error.message.includes("failed twice"),
   );
 });
 

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -1,7 +1,7 @@
 import type { BackgroundJob, DeploymentPlatform } from "@shared/schema";
 import type { CodingAgent } from "./agentRunner";
-import type { PRBabysitter } from "./babysitter";
-import { CancelBackgroundJobError, type BackgroundJobHandlers } from "./backgroundJobDispatcher";
+import { TerminalBabysitterError, type PRBabysitter } from "./babysitter";
+import { CancelBackgroundJobError, TerminalBackgroundJobError, type BackgroundJobHandlers } from "./backgroundJobDispatcher";
 import { createAdapter } from "./deploymentAdapters";
 import type { DeploymentHealingManager } from "./deploymentHealingManager";
 import { runDeploymentHealingRepair } from "./deploymentHealingAgent";
@@ -69,7 +69,14 @@ export function createBackgroundJobHandlers(params: {
 
         const preferredAgent = readCodingAgentPayload(job, "preferredAgent")
           ?? (await storage.getConfig()).codingAgent;
-        await babysitter.runQueuedBabysitPR(pr.id, preferredAgent);
+        try {
+          await babysitter.runQueuedBabysitPR(pr.id, preferredAgent);
+        } catch (error) {
+          if (error instanceof TerminalBabysitterError) {
+            throw new TerminalBackgroundJobError(error.message);
+          }
+          throw error;
+        }
       }
       : undefined,
 

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -701,6 +701,7 @@ test("listOpenPullsForRepo retries transient GitHub connection resets", async ()
           },
           base: {
             ref: "main",
+            sha: "base123",
             repo: {
               full_name: "owner/repo",
               clone_url: "https://github.com/owner/repo.git",
@@ -719,6 +720,7 @@ test("listOpenPullsForRepo retries transient GitHub connection resets", async ()
 
   assert.equal(attempts, 2);
   assert.equal(pulls[0]?.number, 42);
+  assert.equal(pulls[0]?.baseSha, "base123");
 });
 
 test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored", async () => {
@@ -1501,6 +1503,7 @@ test("fetchPullSummary falls back to the repo default branch when the base ref i
           user: { login: "alice" },
           base: {
             ref: null,
+            sha: "base124",
             repo: {
               full_name: "octo/example",
               clone_url: "https://github.com/octo/example.git",
@@ -1527,6 +1530,7 @@ test("fetchPullSummary falls back to the repo default branch when the base ref i
   );
 
   assert.equal(summary.baseRef, "develop");
+  assert.equal(summary.baseSha, "base124");
 });
 
 test("fetchPullCloseState falls back to the repo default branch when the base ref is missing", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -42,6 +42,7 @@ export type GitHubPullSummary = {
   headRepoFullName: string;
   headRepoCloneUrl: string;
   baseRef: string;
+  baseSha: string;
   mergeable: boolean | null;
 };
 
@@ -1009,6 +1010,7 @@ export async function fetchPullSummary(
     headRepoFullName: pull.head?.repo?.full_name || `${parsed.owner}/${parsed.repo}`,
     headRepoCloneUrl: pull.head?.repo?.clone_url || `https://github.com/${parsed.owner}/${parsed.repo}.git`,
     baseRef,
+    baseSha: pull.base?.sha || "",
     mergeable: typeof pull.mergeable === "boolean" ? pull.mergeable : null,
   };
 }
@@ -1635,6 +1637,7 @@ export async function listOpenPullsForRepo(
     headRepoFullName: pull.head?.repo?.full_name || `${repo.owner}/${repo.repo}`,
     headRepoCloneUrl: pull.head?.repo?.clone_url || `https://github.com/${repo.owner}/${repo.repo}.git`,
     baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
+    baseSha: pull.base?.sha || "",
     mergeable: null,
   }));
 }


### PR DESCRIPTION
Summary:
- add baseSha to conflict-repair fingerprints and stop watcher enqueueing when the same head/base/conflict paths have failed twice
- make terminal babysitter failures fail background jobs without generic retries
- highlight automation errors more clearly in PR rows, PR details, activity, and logs

Testing:
- npm run check
- npm run test
- npm run build
- git diff --check