### PR TITLE
fix: clarify drain mode blocking

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -328,6 +328,24 @@ new automation work.
 
 ---
 
+#### `POST /api/repos/release`
+
+Queue a manual release run for the latest unreleased merged PR in a watched
+repository. The route returns once the durable release job has been stored, not
+when the release finishes. Returns `409` when drain mode is active.
+
+**Body**
+```json
+{ "repo": "owner/repo" }
+```
+Accepts `"owner/repo"` slugs or full `https://github.com/owner/repo` URLs.
+
+**Response** `201` — [ReleaseRun object](#releaserun)
+**Response** `400` — invalid body or repository slug
+**Response** `409` — drain mode is active, or no unreleased merged PR exists
+
+---
+
 ### Pull Requests
 
 #### `GET /api/prs`
@@ -465,11 +483,13 @@ Valid values: `"accept"` | `"reject"` | `"flag"`
 #### `POST /api/prs/:id/feedback/:feedbackId/retry`
 
 Re-queue a failed or warned feedback item by scheduling another durable
-babysit pass for the PR.
+babysit pass for the PR. Returns `409` when drain mode is active; the feedback
+item is left unchanged and no babysit job is queued.
 
 **Response** `200` — updated [PR object](#pr)
 **Response** `404` — PR or feedback item not found
 **Response** `400` — item is not in a retryable state
+**Response** `409` — drain mode is active
 
 ---
 
@@ -488,7 +508,8 @@ List the full question/answer history for a PR.
 Ask the configured AI agent a question about the PR.  The question is stored
 immediately; a durable background job fills in the answer asynchronously. Both
 the question row and the queued answer job persist in SQLite, so pending
-questions survive app restarts.
+questions survive app restarts. Returns `409` when drain mode is active, before
+storing the question or queueing the answer job.
 
 **Body**
 ```json
@@ -497,6 +518,7 @@ questions survive app restarts.
 Maximum 2000 characters.
 
 **Response** `201` — [PRQuestion object](#prquestion) (answer will be `null` until the agent responds)
+**Response** `409` — drain mode is active
 
 ---
 
@@ -711,10 +733,14 @@ Enable or disable drain mode. When enabled, the dispatcher stops claiming new
 automation jobs but still claims `sync_watched_repos` jobs so repository status
 can refresh. Other queued rows remain intact in SQLite. Already-running
 handlers are allowed to finish, and `waitForIdle` also waits on any started
-babysitter or release work before reporting success. Endpoints that explicitly
-gate manual automation work, such as `POST /api/prs/:id/apply` and
-`POST /api/prs/:id/babysit`, return `409` while drain mode is active; other
-APIs may still enqueue work that remains pending until drain mode is disabled.
+babysitter or release work before reporting success.
+
+Manual agent-triggering endpoints return `409` instead of storing new work
+while drain mode is active. This includes dashboard **Run now**
+(`POST /api/prs/:id/apply`), `POST /api/prs/:id/babysit`, feedback retry,
+PR Q&A, manual repository release, and release retry. Drain-safe routes such
+as `POST /api/repos/sync` may still enqueue status refresh work that does not
+start new agent automation.
 
 **Body**
 ```json
@@ -787,11 +813,12 @@ Get one release run by its internal oh-my-pr ID.
 #### `POST /api/releases/:id/retry`
 
 Reset an existing release run to `detected` and queue it for durable
-reprocessing. The retry request itself is accepted during drain mode, but the
-queued job will not be claimed until drain mode is disabled.
+reprocessing. Returns `409` when drain mode is active; the release run is left
+unchanged and no release job is queued.
 
 **Response** `200` — updated [ReleaseRun object](#releaserun)
 **Response** `404` — not found
+**Response** `409` — drain mode is active
 
 ---
 

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -300,6 +300,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["repo settings API", "/api/repos/settings"],
     ["activity API", "/api/activities"],
     ["config API", "/api/config"],
+    ["runtime API", "/api/runtime"],
     ["healing session API", "/api/healing-sessions"],
   ] satisfies SourceExpectation[]) {
     assertHasQueryKey(sourceFile, label, endpoint);
@@ -311,6 +312,15 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasApiRequest(sourceFile, "manual release mutation", "POST", "/api/repos/release");
   assertHasApiRequest(sourceFile, "failed activity clear mutation", "DELETE", "/api/activities/failed");
   assertHasApiRequest(sourceFile, "ask agent mutation", "POST", /`\/api\/prs\/\$\{prId\}\/questions`/);
+  assertHasTestId(sourceFile, "dashboard drain banner", "dashboard-drain-banner");
+  assertHasTestId(sourceFile, "dashboard drain reason", "dashboard-drain-reason");
+  assertHasTestId(sourceFile, "activity drain note", "activity-drain-note");
+  assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
+  assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");
+  assertHasStringValue(sourceFile, "drained PR copy", "Background and manual runs are paused by drain mode.");
+  assertHasStringValue(sourceFile, "drained ask copy", "Ask Agent is paused by drain mode.");
+  assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
+  assertHasExpression(sourceFile, "dashboard drain state", /\bglobalDrainMode\b/);
 });
 
 test("dashboard finds latest target activity without sorting the full activity list", async () => {

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -6,7 +6,7 @@ import { Activity as ActivityIcon } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
 import { getRepoAddControlsOpen } from "@/lib/repoAddControls";
-import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, LogEntry, OperatorWarning, PR, PRQuestion, ReleaseRun, WatchedRepo } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, LogEntry, OperatorWarning, PR, PRQuestion, ReleaseRun, RuntimeState, WatchedRepo } from "@shared/schema";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import {
@@ -99,6 +99,12 @@ const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
 };
 const MAX_VISIBLE_LOGS = 200;
 const TRACKED_REPOS_OPEN_KEY = "oh-my-pr:tracked-repos-open";
+const DRAIN_PAUSED_LABEL = "Paused";
+const DRAIN_PAUSED_TITLE = "Paused by drain mode";
+const MANUAL_RUNS_BLOCKED_COPY = "Manual runs are blocked while global automation is paused.";
+const GLOBAL_DRAIN_PR_COPY = "Background and manual runs are paused by drain mode.";
+const ASK_DRAIN_COPY = "Ask Agent is paused by drain mode.";
+const QUEUED_DRAIN_COPY = "Queued automation is paused until drain mode is disabled.";
 
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
 type RepoSettings = WatchedRepo & {
@@ -283,10 +289,12 @@ function ActivityMenu({
   activities,
   onClearFailed,
   isClearingFailed,
+  globalDrainMode,
 }: {
   activities: ActivitySnapshot;
   onClearFailed: () => void;
   isClearingFailed: boolean;
+  globalDrainMode: boolean;
 }) {
   const failedCount = activities.failed.length;
   const inProgressCount = activities.inProgress.length;
@@ -341,8 +349,54 @@ function ActivityMenu({
           items={activities.queued}
           emptyLabel="Queue is empty."
         />
+        {globalDrainMode && queuedCount > 0 && (
+          <div
+            className="border-t border-border px-2 py-2 text-[11px] text-muted-foreground"
+            data-testid="activity-drain-note"
+          >
+            {QUEUED_DRAIN_COPY}
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function DashboardDrainBanner({ runtimeState }: { runtimeState: RuntimeState | undefined }) {
+  if (!runtimeState?.drainMode) {
+    return null;
+  }
+
+  return (
+    <div
+      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-[12px]"
+      data-testid="dashboard-drain-banner"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-destructive">
+            {DRAIN_PAUSED_TITLE}
+          </div>
+          {runtimeState.drainReason ? (
+            <div
+              className="mt-1 break-words text-foreground/80"
+              data-testid="dashboard-drain-reason"
+            >
+              {runtimeState.drainReason}
+            </div>
+          ) : null}
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            {MANUAL_RUNS_BLOCKED_COPY}
+          </div>
+        </div>
+        <Link
+          href="/settings"
+          className="shrink-0 border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        >
+          Settings
+        </Link>
+      </div>
+    </div>
   );
 }
 
@@ -550,10 +604,12 @@ function FeedbackRow({
   item,
   prId,
   readOnly,
+  globalDrainMode = false,
 }: {
   item: FeedbackItem;
   prId: string;
   readOnly?: boolean;
+  globalDrainMode?: boolean;
 }) {
   const overrideMutation = useMutation({
     mutationFn: async (decision: string) => {
@@ -619,13 +675,13 @@ function FeedbackRow({
               <button
                 type="button"
                 onClick={() => retryMutation.mutate()}
-                disabled={retryMutation.isPending}
+                disabled={retryMutation.isPending || globalDrainMode}
                 data-testid={`retry-${item.id}`}
                 aria-label={`Retry feedback from ${item.author}`}
-                title="Retry feedback item"
+                title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Retry feedback item"}
                 className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
               >
-                Retry
+                {globalDrainMode ? DRAIN_PAUSED_LABEL : "Retry"}
               </button>
             )}
             <Collapsible.Trigger asChild>
@@ -850,7 +906,15 @@ function HealingPanel({
   );
 }
 
-function RightPanel({ prId, prStatus }: { prId: string | null; prStatus?: PR["status"] | null }) {
+function RightPanel({
+  prId,
+  prStatus,
+  globalDrainMode,
+}: {
+  prId: string | null;
+  prStatus?: PR["status"] | null;
+  globalDrainMode: boolean;
+}) {
   const [tab, setTab] = useState<"activity" | "ask">("ask");
 
   useEffect(() => {
@@ -891,7 +955,7 @@ function RightPanel({ prId, prStatus }: { prId: string | null; prStatus?: PR["st
         {tab === "activity" ? (
           <LogPanel prId={prId} />
         ) : prId ? (
-          <QAPanel prId={prId} />
+          <QAPanel prId={prId} globalDrainMode={globalDrainMode} />
         ) : (
           <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
             Select a PR to ask questions.
@@ -902,7 +966,7 @@ function RightPanel({ prId, prStatus }: { prId: string | null; prStatus?: PR["st
   );
 }
 
-function QAPanel({ prId }: { prId: string }) {
+function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boolean }) {
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -926,6 +990,8 @@ function QAPanel({ prId }: { prId: string }) {
     if (scroller) scroller.scrollTop = scroller.scrollHeight;
   }, [questions.length, questions[questions.length - 1]?.status]);
 
+  const askDisabled = askMutation.isPending || !input.trim() || globalDrainMode;
+
   return (
     <div className="flex h-full flex-col">
       <div className="border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
@@ -934,7 +1000,9 @@ function QAPanel({ prId }: { prId: string }) {
       <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
         {questions.length === 0 ? (
           <span className="text-[12px] text-muted-foreground">
-            Ask questions about this PR — the agent will read activity logs, feedback, and status to answer.
+            {globalDrainMode
+              ? ASK_DRAIN_COPY
+              : "Ask questions about this PR — the agent will read activity logs, feedback, and status to answer."}
           </span>
         ) : (
           questions.map((q) => (
@@ -967,7 +1035,7 @@ function QAPanel({ prId }: { prId: string }) {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (input.trim() && !askMutation.isPending) askMutation.mutate(input.trim());
+          if (!askDisabled) askMutation.mutate(input.trim());
         }}
         className="border-t border-border p-3"
       >
@@ -976,18 +1044,20 @@ function QAPanel({ prId }: { prId: string }) {
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Was the review done? Why did this fail?"
+            placeholder={globalDrainMode ? "Drain mode is enabled." : "Was the review done? Why did this fail?"}
             aria-label="Question for selected pull request"
+            disabled={globalDrainMode}
             data-testid="input-question"
             className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           />
           <button
             type="submit"
-            disabled={askMutation.isPending || !input.trim()}
+            disabled={askDisabled}
+            title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Ask agent"}
             data-testid="button-ask"
             className="border border-border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
           >
-            {askMutation.isPending ? "..." : "Ask"}
+            {globalDrainMode ? DRAIN_PAUSED_LABEL : askMutation.isPending ? "..." : "Ask"}
           </button>
         </div>
         {askMutation.isError && (
@@ -1085,6 +1155,11 @@ export default function Dashboard() {
     refetchInterval: 3000,
   });
 
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 3000,
+  });
+
   const { data: repos = [] } = useQuery<RepoSettings[]>({
     queryKey: ["/api/repos/settings"],
     refetchInterval: 5000,
@@ -1113,6 +1188,7 @@ export default function Dashboard() {
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
   const repoAddControlsOpen = getRepoAddControlsOpen(addControlsOpen, repos.length);
+  const globalDrainMode = runtimeState?.drainMode === true;
 
   const addMutation = useMutation({
     mutationFn: async (url: string) => {
@@ -1332,12 +1408,14 @@ export default function Dashboard() {
             activities={activities}
             onClearFailed={() => clearFailedActivitiesMutation.mutate()}
             isClearingFailed={clearFailedActivitiesMutation.isPending}
+            globalDrainMode={globalDrainMode}
           />
         </div>
       </header>
 
       <OnboardingPanel />
       <OperatorWarningsBanner warnings={activities.warnings} />
+      <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
         <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-y-auto border-b border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-b-0 lg:border-r">
@@ -1554,11 +1632,12 @@ export default function Dashboard() {
                                 <button
                                   type="button"
                                   onClick={() => manualReleaseMutation.mutate(repo.repo)}
-                                  disabled={manualReleaseMutation.isPending}
+                                  disabled={manualReleaseMutation.isPending || globalDrainMode}
+                                  title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Queue manual release"}
                                   data-testid={`tracked-repo-manual-release-${repo.repo.replace("/", "-")}`}
                                   className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
                                 >
-                                  {manualReleasePending ? "Releasing..." : "Release"}
+                                  {globalDrainMode ? DRAIN_PAUSED_LABEL : manualReleasePending ? "Releasing..." : "Release"}
                                 </button>
                               </div>
                             </div>
@@ -1647,11 +1726,12 @@ export default function Dashboard() {
                       <button
                         type="button"
                         onClick={() => applyMutation.mutate(selectedPR.id)}
-                        disabled={applyMutation.isPending || selectedPR.status === "processing"}
+                        disabled={applyMutation.isPending || selectedPR.status === "processing" || globalDrainMode}
+                        title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Run babysitter now"}
                         data-testid="button-apply"
                         className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
                       >
-                        {selectedPR.status === "processing" ? "Running" : "Run now"}
+                        {globalDrainMode ? DRAIN_PAUSED_LABEL : selectedPR.status === "processing" ? "Running" : "Run now"}
                       </button>
                       <button
                         type="button"
@@ -1686,9 +1766,11 @@ export default function Dashboard() {
                   </div>
                 )}
                 <div className="text-[11px] text-muted-foreground">
-                  {selectedPRWatchEnabled
-                    ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
-                    : "Background watch is paused for this PR; manual runs still work."}
+                  {globalDrainMode
+                    ? GLOBAL_DRAIN_PR_COPY
+                    : selectedPRWatchEnabled
+                      ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
+                      : "Background watch is paused for this PR; manual runs still work."}
                 </div>
               </div>
 
@@ -1703,7 +1785,13 @@ export default function Dashboard() {
                   </div>
                 ) : (
                   selectedPR.feedbackItems.map((item) => (
-                    <FeedbackRow key={item.id} item={item} prId={selectedPR.id} readOnly={isArchived} />
+                    <FeedbackRow
+                      key={item.id}
+                      item={item}
+                      prId={selectedPR.id}
+                      readOnly={isArchived}
+                      globalDrainMode={globalDrainMode}
+                    />
                   ))
                 )}
               </div>
@@ -1715,7 +1803,11 @@ export default function Dashboard() {
           )}
         </div>
 
-        <RightPanel prId={selectedPRId} prStatus={selectedPR?.status ?? null} />
+        <RightPanel
+          prId={selectedPRId}
+          prStatus={selectedPR?.status ?? null}
+          globalDrainMode={globalDrainMode}
+        />
       </div>
     </div>
   );

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -247,7 +247,7 @@ oh-my-pr --no-log-file
 <li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
-<li><strong>Runtime drain mode</strong> — Pause new automation runs from Settings while allowing in-flight runs to finish.</li>
+<li><strong>Runtime drain mode</strong> — Pause new background automation and manual agent-triggering actions from Settings while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return <code>409</code> instead of queueing new agent work.</li>
 <li><strong>Ignored bots</strong> — Add or remove bot logins whose comments and reviews should be ignored.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
 <li><strong>GitHub progress replies</strong> — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.</li>
@@ -286,6 +286,7 @@ oh-my-pr --no-log-file
 <h2>Manual Repository Releases</h2>
 <p>Each watched repository row in the dashboard includes a <strong>Release</strong> button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.</p>
 <p>Manual release runs are allowed even when <code>autoCreateReleases</code> is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns <code>409</code> and no release run is created.</p>
+<p>Runtime drain mode also blocks manual release creation and release retries until drain mode is disabled. Release work already in flight is allowed to finish.</p>
 <h2>App Update Banner</h2>
 <p>On builds where <code>APP_VERSION</code> is a stable semver string, the dashboard calls
 <code>GET /api/app-update</code> and compares the running version to the latest stable

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -63,7 +63,7 @@ The settings page in the dashboard provides a UI for:
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
-- **Runtime drain mode** — Pause new automation runs from Settings while allowing in-flight runs to finish.
+- **Runtime drain mode** — Pause new background automation and manual agent-triggering actions from Settings while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
 - **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
@@ -90,6 +90,8 @@ PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setti
 Each watched repository row in the dashboard includes a **Release** button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.
 
 Manual release runs are allowed even when `autoCreateReleases` is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns `409` and no release run is created.
+
+Runtime drain mode also blocks manual release creation and release retries until drain mode is disabled. Release work already in flight is allowed to finish.
 
 ## App Update Banner
 

--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { chmod, copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { checkAgentHealth, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
+import { applyFixesWithAgent, checkAgentHealth, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
 
 test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
   const result = await runCommand(
@@ -107,6 +107,83 @@ test("checkAgentHealth surfaces actionable codex session permission errors", asy
       assert.match(result.reason, /cannot access session files/i);
       assert.doesNotMatch(result.reason, /Reading additional input from stdin/);
     }
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("checkAgentHealth reports codex timeouts instead of stdin prelude", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-timeout-bin-"));
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeCodexPath,
+      [
+        "#!/bin/sh",
+        "echo 'Reading additional input from stdin...' >&2",
+        "echo 'Command timed out after 30000ms' >&2",
+        "exit 124",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeCodexPath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+
+    const result = await checkAgentHealth("codex");
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /timed out after 30000ms/i);
+      assert.doesNotMatch(result.reason, /Reading additional input from stdin/);
+    }
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("applyFixesWithAgent runs codex without deprecated full-auto flag", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-codex-apply-bin-"));
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  const argsPath = path.join(tempRoot, "args.txt");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeCodexPath,
+      [
+        "#!/bin/sh",
+        `printf '%s\\n' "$@" > "${argsPath}"`,
+        "exit 0",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeCodexPath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+
+    await applyFixesWithAgent({
+      agent: "codex",
+      cwd: process.cwd(),
+      prompt: "Fix the issue.",
+    });
+
+    const args = (await readFile(argsPath, "utf8"))
+      .split(/\r?\n/)
+      .filter(Boolean);
+    assert.ok(args.includes("--sandbox"));
+    assert.ok(args.includes("workspace-write"));
+    assert.ok(!args.includes("--full-auto"), `unexpected args: ${args.join(" ")}`);
   } finally {
     process.env.PATH = originalPath;
     await rm(tempRoot, { recursive: true, force: true });

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -249,7 +249,6 @@ export async function applyFixesWithAgent(params: {
       [
         "exec",
         "--skip-git-repo-check",
-        "--full-auto",
         "--sandbox",
         "workspace-write",
         prompt,
@@ -334,7 +333,7 @@ function summarizeHealthFailure(result: CommandResult): string {
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
   const actionable = lines.findLast((line) =>
-    /cannot access session files|permission denied|failed to create session|failed|error:/i.test(line)
+    /cannot access session files|permission denied|failed to create session|timed out|failed|error:/i.test(line)
       && !/^reading additional input from stdin/i.test(line)
   );
   const raw = actionable ?? lines[0] ?? "no output";

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { NewPR } from "@shared/schema";
 import { createAppRuntime, mapMergedPullsToReleaseSummaries } from "./appRuntime";
+import { _resetRingBufferForTests, readRingBuffer } from "./logger";
 import { MemStorage } from "./memoryStorage";
 
 async function seedPR(storage: MemStorage, overrides: Partial<NewPR> = {}) {
@@ -98,6 +99,32 @@ test("runtime setWatchEnabled updates the PR and emits a change event", async ()
   } finally {
     unsubscribe();
   }
+});
+
+test("runtime setDrainMode logs enable and disable transitions", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+
+  _resetRingBufferForTests();
+
+  await runtime.setDrainMode({
+    enabled: true,
+    reason: "Agent health check failed for codex",
+  });
+  await runtime.setDrainMode({
+    enabled: false,
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+  const ring = readRingBuffer().join("\n");
+  assert.match(ring, /Drain mode enabled/);
+  assert.match(ring, /Agent health check failed for codex/);
+  assert.match(ring, /Drain mode disabled/);
 });
 
 test("runtime askQuestion persists the question and enqueues a durable job", async () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -655,6 +655,43 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     );
   };
 
+  const buildManualDrainBlockMessage = (runtimeState: RuntimeState): string => {
+    const base = "Drain mode is enabled. Manual runs are blocked until drain mode is disabled.";
+    return runtimeState.drainReason ? `${base} Reason: ${runtimeState.drainReason}` : base;
+  };
+
+  const rejectManualRunDuringDrain = async (
+    runtimeState: RuntimeState,
+    options: {
+      pr?: PR;
+      logMessageBase?: string;
+      metadata?: Record<string, unknown>;
+    } = {},
+  ): Promise<never> => {
+    const message = buildManualDrainBlockMessage(runtimeState);
+    const logMessageBase = options.logMessageBase ?? "Manual run blocked because drain mode is enabled";
+    const logMessage = runtimeState.drainReason
+      ? `${logMessageBase}. Reason: ${runtimeState.drainReason}`
+      : `${logMessageBase}.`;
+    const metadata = {
+      drainReason: runtimeState.drainReason,
+      drainRequestedAt: runtimeState.drainRequestedAt,
+      ...options.metadata,
+    };
+
+    if (options.pr) {
+      await storage.addLog(options.pr.id, "warn", logMessage, {
+        phase: "run",
+        metadata,
+      });
+      notifyChange();
+    } else {
+      log.warn(metadata, logMessageBase);
+    }
+
+    throw new AppRuntimeError(409, message);
+  };
+
   const runtime: AppRuntime = {
     async start() {
       if (started) {
@@ -734,6 +771,16 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         drainRequestedAt: input.enabled ? new Date().toISOString() : null,
         drainReason: input.enabled ? input.reason ?? null : null,
       });
+
+      if (input.enabled) {
+        log.warn({
+          drainRequestedAt: updated.drainRequestedAt,
+          drainReason: updated.drainReason,
+          waitForIdle: Boolean(input.waitForIdle),
+        }, "Drain mode enabled");
+      } else {
+        log.info("Drain mode disabled");
+      }
 
       if (input.enabled && input.waitForIdle) {
         const drained = await waitForBackgroundIdle(input.timeoutMs ?? 120_000);
@@ -828,6 +875,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       }
 
       const canonical = formatRepoSlug(parsedRepo);
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        await rejectManualRunDuringDrain(runtimeState, {
+          logMessageBase: "Manual release run blocked because drain mode is enabled",
+          metadata: { repo: canonical },
+        });
+      }
+
       const release = await releaseManager.enqueueManualRepoRelease(canonical);
       if (!release) {
         throw new AppRuntimeError(409, `No unreleased merged pull requests found for ${canonical}`);
@@ -1004,7 +1059,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const pr = assertFound(await storage.getPR(id), "PR not found");
       const runtime = await storage.getRuntimeState();
       if (runtime.drainMode) {
-        throw new AppRuntimeError(409, "Drain mode is enabled. Manual runs are blocked until drain mode is disabled.");
+        await rejectManualRunDuringDrain(runtime, {
+          pr,
+          logMessageBase: "Manual babysitter run blocked because drain mode is enabled",
+        });
       }
 
       const config = await storage.getConfig();
@@ -1021,7 +1079,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const pr = assertFound(await storage.getPR(id), "PR not found");
       const runtime = await storage.getRuntimeState();
       if (runtime.drainMode) {
-        throw new AppRuntimeError(409, "Drain mode is enabled. Manual runs are blocked until drain mode is disabled.");
+        await rejectManualRunDuringDrain(runtime, {
+          pr,
+          logMessageBase: "Manual babysitter run blocked because drain mode is enabled",
+        });
       }
 
       const config = await storage.getConfig();
@@ -1050,6 +1111,25 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async retryFeedback(prId, feedbackId) {
+      const pr = assertFound(await storage.getPR(prId), "PR not found");
+      const item = pr.feedbackItems.find((candidate) => candidate.id === feedbackId);
+      if (!item) {
+        throw new AppRuntimeError(404, "Feedback item not found");
+      }
+
+      if (item.status !== "failed" && item.status !== "warning") {
+        throw new AppRuntimeError(400, "Only failed or warning items can be retried");
+      }
+
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        await rejectManualRunDuringDrain(runtimeState, {
+          pr,
+          logMessageBase: "Manual feedback retry blocked because drain mode is enabled",
+          metadata: { feedbackId },
+        });
+      }
+
       const result = await babysitter.retryFeedbackItem(prId, feedbackId);
       if (result.kind === "pr_not_found") {
         throw new AppRuntimeError(404, "PR not found");
@@ -1086,8 +1166,16 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         }
         throw error;
       }
-      const entry = await storage.addQuestion(prId, parsed.question);
 
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        await rejectManualRunDuringDrain(runtimeState, {
+          pr,
+          logMessageBase: "Manual question run blocked because drain mode is enabled",
+        });
+      }
+
+      const entry = await storage.addQuestion(prId, parsed.question);
       try {
         await scheduleBackgroundJob(
           "answer_pr_question",
@@ -1178,6 +1266,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async retryReleaseRun(id) {
+      const existing = assertFound(await storage.getReleaseRun(id), "Release run not found");
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        await rejectManualRunDuringDrain(runtimeState, {
+          logMessageBase: "Manual release retry blocked because drain mode is enabled",
+          metadata: {
+            releaseRunId: id,
+            repo: existing.repo,
+          },
+        });
+      }
+
       const release = await releaseManager.retryReleaseRun(id);
       if (!release) {
         throw new AppRuntimeError(404, "Release run not found");

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import test from "node:test";
 import express from "express";
 import type { Octokit } from "@octokit/rest";
-import type { AppUpdateStatus, NewPR } from "@shared/schema";
+import type { AppUpdateStatus, FeedbackItem, NewPR } from "@shared/schema";
 import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
 import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 import { MemStorage } from "./memoryStorage";
@@ -79,6 +79,32 @@ function makeMergedSummary(overrides: Partial<ReleaseAgentPullSummary> = {}): Re
     repo: "acme/widgets",
     mergedAt: "2026-04-24T12:00:00.000Z",
     mergeSha: "manual-release-sha",
+    ...overrides,
+  };
+}
+
+function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    id: "feedback-1",
+    author: "reviewer",
+    body: "Please fix this",
+    bodyHtml: "<p>Please fix this</p>",
+    replyKind: "review_thread",
+    sourceId: "review-comment-1",
+    sourceNodeId: "node-1",
+    sourceUrl: "https://github.com/acme/widgets/pull/42#discussion_r1",
+    threadId: "thread-1",
+    threadResolved: false,
+    auditToken: "audit-1",
+    file: "src/widget.ts",
+    line: 12,
+    type: "review_comment",
+    createdAt: "2026-05-03T17:00:00.000Z",
+    decision: "accept",
+    decisionReason: null,
+    action: "Fix the widget",
+    status: "failed",
+    statusReason: "codex health check timed out after 30000ms",
     ...overrides,
   };
 }
@@ -225,6 +251,42 @@ test("POST /api/prs/:id/questions enqueues a durable answer_pr_question job", as
   }
 });
 
+test("POST /api/prs/:id/questions reports drain reason and does not queue an answer job", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage);
+  await harness.storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-05-03T17:32:41.034Z",
+    drainReason: "Agent health check failed for codex: codex health check timed out after 30000ms",
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/prs/${pr.id}/questions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ question: "What changed?" }),
+    });
+
+    assert.equal(response.status, 409);
+    const body = await response.json() as { error?: string };
+    assert.match(body.error ?? "", /manual runs are blocked/i);
+    assert.match(body.error ?? "", /codex health check timed out/i);
+
+    const questions = await harness.storage.getQuestions(pr.id);
+    assert.equal(questions.length, 0);
+
+    const jobs = await harness.storage.listBackgroundJobs({
+      kind: "answer_pr_question",
+      status: "queued",
+    });
+    assert.equal(jobs.length, 0);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/prs/:id/babysit enqueues a durable babysit_pr job", async () => {
   const harness = await createHarness();
   const pr = await seedPR(harness.storage);
@@ -243,6 +305,80 @@ test("POST /api/prs/:id/babysit enqueues a durable babysit_pr job", async () => 
     assert.equal(jobs.length, 1);
     assert.equal(jobs[0].targetId, pr.id);
     assert.equal(jobs[0].payload.preferredAgent, "claude");
+  } finally {
+    await harness.close();
+  }
+});
+
+for (const endpoint of ["apply", "babysit"] as const) {
+  test(`POST /api/prs/:id/${endpoint} reports drain reason and records blocked manual attempt`, async () => {
+    const harness = await createHarness();
+    const pr = await seedPR(harness.storage);
+    await harness.storage.updateRuntimeState({
+      drainMode: true,
+      drainRequestedAt: "2026-05-03T17:32:41.034Z",
+      drainReason: "Agent health check failed for codex: codex health check timed out after 30000ms",
+    });
+
+    try {
+      const response = await fetch(`${harness.baseUrl}/api/prs/${pr.id}/${endpoint}`, {
+        method: "POST",
+      });
+
+      assert.equal(response.status, 409);
+      const body = await response.json() as { error?: string };
+      assert.match(body.error ?? "", /manual runs are blocked/i);
+      assert.match(body.error ?? "", /codex health check timed out/i);
+
+      const jobs = await harness.storage.listBackgroundJobs({
+        kind: "babysit_pr",
+        status: "queued",
+      });
+      assert.equal(jobs.length, 0);
+
+      const logs = await harness.storage.getLogs(pr.id);
+      assert.ok(logs.some((log) =>
+        log.level === "warn"
+        && log.phase === "run"
+        && log.message.includes("Manual babysitter run blocked because drain mode is enabled")
+        && log.message.includes("codex health check timed out")
+      ));
+    } finally {
+      await harness.close();
+    }
+  });
+}
+
+test("POST /api/prs/:id/feedback/:feedbackId/retry reports drain reason and does not queue a babysit job", async () => {
+  const feedback = makeFeedbackItem();
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage, {
+    feedbackItems: [feedback],
+  });
+  await harness.storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-05-03T17:32:41.034Z",
+    drainReason: "Agent health check failed for codex: codex health check timed out after 30000ms",
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/prs/${pr.id}/feedback/${feedback.id}/retry`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 409);
+    const body = await response.json() as { error?: string };
+    assert.match(body.error ?? "", /manual runs are blocked/i);
+    assert.match(body.error ?? "", /codex health check timed out/i);
+
+    const jobs = await harness.storage.listBackgroundJobs({
+      kind: "babysit_pr",
+      status: "queued",
+    });
+    assert.equal(jobs.length, 0);
+
+    const updated = await harness.storage.getPR(pr.id);
+    assert.equal(updated?.feedbackItems[0]?.status, "failed");
   } finally {
     await harness.close();
   }
@@ -859,6 +995,44 @@ test("POST /api/repos/release queues a manual release run for the requested repo
   }
 });
 
+test("POST /api/repos/release reports drain reason and does not queue release work", async () => {
+  const storage = new MemStorage();
+  const harness = await createHarness(storage, {
+    releaseManager: makeReleaseManagerForRoutes(storage),
+  });
+  await harness.storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-05-03T17:32:41.034Z",
+    drainReason: "Agent health check failed for codex: codex health check timed out after 30000ms",
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/repos/release`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ repo: "acme/widgets" }),
+    });
+
+    assert.equal(response.status, 409);
+    const body = await response.json() as { error?: string };
+    assert.match(body.error ?? "", /manual runs are blocked/i);
+    assert.match(body.error ?? "", /codex health check timed out/i);
+
+    const releaseRuns = await harness.storage.listReleaseRuns();
+    assert.equal(releaseRuns.length, 0);
+
+    const jobs = await harness.storage.listBackgroundJobs({
+      kind: "process_release_run",
+      status: "queued",
+    });
+    assert.equal(jobs.length, 0);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release returns 409 when the repo has no unreleased merged PRs", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {
@@ -879,6 +1053,62 @@ test("POST /api/repos/release returns 409 when the repo has no unreleased merged
     assert.equal(response.status, 409);
     const body = await response.json() as { error: string };
     assert.match(body.error, /No unreleased merged pull requests found for acme\/widgets/);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("POST /api/releases/:id/retry reports drain reason and does not queue release work", async () => {
+  const storage = new MemStorage();
+  const harness = await createHarness(storage, {
+    releaseManager: makeReleaseManagerForRoutes(storage),
+  });
+  const release = await storage.createReleaseRun({
+    repo: "acme/widgets",
+    baseBranch: "main",
+    triggerPrNumber: 42,
+    triggerPrTitle: "Manual release",
+    triggerPrUrl: "https://github.com/acme/widgets/pull/42",
+    triggerMergeSha: "manual-release-sha",
+    triggerMergedAt: "2026-04-24T12:00:00.000Z",
+    source: "manual",
+    status: "error",
+    decisionReason: "Manual release requested",
+    recommendedBump: "patch",
+    proposedVersion: "v1.2.4",
+    releaseTitle: "Manual release",
+    releaseNotes: "Manual release notes",
+    includedPrs: [],
+    targetSha: null,
+    githubReleaseId: null,
+    githubReleaseUrl: null,
+    error: "release agent failed",
+    completedAt: null,
+  });
+  await harness.storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-05-03T17:32:41.034Z",
+    drainReason: "Agent health check failed for codex: codex health check timed out after 30000ms",
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/releases/${release.id}/retry`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 409);
+    const body = await response.json() as { error?: string };
+    assert.match(body.error ?? "", /manual runs are blocked/i);
+    assert.match(body.error ?? "", /codex health check timed out/i);
+
+    const updated = await harness.storage.getReleaseRun(release.id);
+    assert.equal(updated?.status, "error");
+
+    const jobs = await harness.storage.listBackgroundJobs({
+      kind: "process_release_run",
+      status: "queued",
+    });
+    assert.equal(jobs.length, 0);
   } finally {
     await harness.close();
   }


### PR DESCRIPTION
## Summary
- show dashboard-wide drain-mode state, reason, queued-work note, and paused manual controls
- return drain reason and record blocked attempts for manual babysitter, retry, ask-agent, release, and release-retry actions
- remove deprecated Codex --full-auto usage and surface timeout health failures instead of the stdin prelude

## Verification
- node --test --import tsx server/routes.test.ts
- node --test --import tsx client/src/lib/fullAppQaSurface.test.ts
- node --test --import tsx server/agentRunner.test.ts server/appRuntime.test.ts server/routes.test.ts client/src/lib/fullAppQaSurface.test.ts
- npm run check
- npm run build
- npm run test:all

Dev server: http://127.0.0.1:5002