### PR TITLE
[codex] avoid drain mode for transient agent health timeouts

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -735,6 +735,12 @@ can refresh. Other queued rows remain intact in SQLite. Already-running
 handlers are allowed to finish, and `waitForIdle` also waits on any started
 babysitter or release work before reporting success.
 
+oh-my-pr may also enable drain mode automatically when an agent health check
+reports deterministic unavailability, such as a missing CLI, auth failure, or
+unsupported agent setting. Transient health-check failures, including command
+timeouts, skip the affected automation cycle with an `Automation skipped` log
+instead of setting `drainMode`.
+
 Manual agent-triggering endpoints return `409` instead of storing new work
 while drain mode is active. This includes dashboard **Run now**
 (`POST /api/prs/:id/apply`), `POST /api/prs/:id/babysit`, feedback retry,

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -248,7 +248,7 @@ oh-my-pr --no-log-file
 <li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex. If the default run fails and a code-owner fallback is launched, the fallback uses the same resolved agent; enabling <strong>Fallback to next coding agent</strong> lets oh-my-pr resolve that fallback to the other local CLI when needed.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
-<li><strong>Runtime drain mode</strong> — Pause new background automation and manual agent-triggering actions from Settings while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return <code>409</code> instead of queueing new agent work.</li>
+<li><strong>Runtime drain mode</strong> — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return <code>409</code> instead of queueing new agent work.</li>
 <li><strong>Ignored bots</strong> — Add or remove bot logins whose comments and reviews should be ignored.</li>
 <li><strong>PR comment branding</strong> — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the <code>Posted by oh-my-pr</code> footer.</li>
 <li><strong>GitHub progress replies</strong> — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.</li>
@@ -256,6 +256,9 @@ oh-my-pr --no-log-file
 <li><strong>Deployment healing</strong> — Not yet exposed in the dashboard; use <code>PATCH /api/config</code> for the deployment-healing keys listed below.</li>
 <li><strong>Theme</strong> — Toggle between light and dark mode.</li>
 </ul>
+<h3>Agent Health and Drain Mode</h3>
+<p>Drain mode is reserved for failures that need operator action. oh-my-pr enables it when the selected agent is deterministically unavailable, such as a missing CLI, auth failure, or unsupported agent setting.</p>
+<p>Transient agent health failures, including health-check timeouts, do not enable drain mode. Affected PRs log <code>Automation skipped</code>, leave existing queued or running feedback state intact, and can be retried on the next poll or manual run.</p>
 <h2>Repository Watch Settings</h2>
 <p>Watched repositories also have repo-level settings exposed in the dashboard&#39;s repository list and through <code>GET /api/repos/settings</code> plus <code>PATCH /api/repos/settings</code>.</p>
 <table>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -63,13 +63,19 @@ The settings page in the dashboard provides a UI for:
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex. If the default run fails and a code-owner fallback is launched, the fallback uses the same resolved agent; enabling **Fallback to next coding agent** lets oh-my-pr resolve that fallback to the other local CLI when needed.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
-- **Runtime drain mode** — Pause new background automation and manual agent-triggering actions from Settings while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
+- **Runtime drain mode** — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
 - **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.
 - **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
 - **Theme** — Toggle between light and dark mode.
+
+### Agent Health and Drain Mode
+
+Drain mode is reserved for failures that need operator action. oh-my-pr enables it when the selected agent is deterministically unavailable, such as a missing CLI, auth failure, or unsupported agent setting.
+
+Transient agent health failures, including health-check timeouts, do not enable drain mode. Affected PRs log `Automation skipped`, leave existing queued or running feedback state intact, and can be retried on the next poll or manual run.
 
 ## Repository Watch Settings
 

--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -3,7 +3,7 @@ import { chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promi
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { applyFixesWithAgent, checkAgentHealth, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
+import { applyFixesWithAgent, checkAgentHealth, detectAgentUnavailability, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
 
 test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
   const result = await runCommand(
@@ -74,6 +74,17 @@ test("evaluateFixNecessityWithAgent throws a clear error when codex writes no ou
     process.env.PATH = originalPath;
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("detectAgentUnavailability classifies session permission failures as auth failures", () => {
+  assert.equal(
+    detectAgentUnavailability("codex health check failed: Error: thread/start: Permission denied"),
+    "auth",
+  );
+  assert.equal(
+    detectAgentUnavailability("claude health check failed: ERROR: Failed to create session: Operation not permitted"),
+    "auth",
+  );
 });
 
 test("checkAgentHealth surfaces actionable codex session permission errors", async () => {

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -26,13 +26,26 @@ const AGENTS: CodingAgent[] = ["codex", "claude"];
 
 export type AgentUnavailabilityKind = "auth" | "cli_missing" | "unknown_agent";
 
+const AGENT_SESSION_AUTH_PATTERNS = [
+  "cannot access session files",
+  "permission denied",
+  "failed to create session",
+];
+
 const AGENT_AUTH_PATTERNS = [
   "failed to authenticate",
   "authentication failed",
   "authentication_error",
   "invalid authentication credentials",
   "api error: 401",
-  "cannot access session files",
+  ...AGENT_SESSION_AUTH_PATTERNS,
+];
+
+const AGENT_HEALTH_ACTIONABLE_PATTERNS = [
+  ...AGENT_SESSION_AUTH_PATTERNS,
+  "timed out",
+  "failed",
+  "error:",
 ];
 
 const AGENT_CLI_MISSING_PATTERNS = [
@@ -45,10 +58,10 @@ export function detectAgentUnavailability(message: string): AgentUnavailabilityK
   if (lower.includes("unknown coding agent")) {
     return "unknown_agent";
   }
-  if (AGENT_AUTH_PATTERNS.some((needle) => lower.includes(needle))) {
+  if (includesAnyPattern(lower, AGENT_AUTH_PATTERNS)) {
     return "auth";
   }
-  if (AGENT_CLI_MISSING_PATTERNS.some((needle) => lower.includes(needle))) {
+  if (includesAnyPattern(lower, AGENT_CLI_MISSING_PATTERNS)) {
     return "cli_missing";
   }
   return null;
@@ -338,11 +351,15 @@ function summarizeHealthFailure(result: CommandResult): string {
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
   const actionable = lines.findLast((line) =>
-    /cannot access session files|permission denied|failed to create session|timed out|failed|error:/i.test(line)
+    includesAnyPattern(line.toLowerCase(), AGENT_HEALTH_ACTIONABLE_PATTERNS)
       && !/^reading additional input from stdin/i.test(line)
   );
   const raw = actionable ?? lines[0] ?? "no output";
   return raw.length > 220 ? `${raw.slice(0, 217).trimEnd()}...` : raw;
+}
+
+function includesAnyPattern(message: string, patterns: readonly string[]): boolean {
+  return patterns.some((needle) => message.includes(needle));
 }
 
 export async function runCommand(

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -24,10 +24,11 @@ export type AgentHealthResult =
 
 const AGENTS: CodingAgent[] = ["codex", "claude"];
 
-export type AgentUnavailabilityKind = "auth" | "cli_missing";
+export type AgentUnavailabilityKind = "auth" | "cli_missing" | "unknown_agent";
 
 const AGENT_AUTH_PATTERNS = [
   "failed to authenticate",
+  "authentication failed",
   "authentication_error",
   "invalid authentication credentials",
   "api error: 401",
@@ -41,6 +42,9 @@ const AGENT_CLI_MISSING_PATTERNS = [
 
 export function detectAgentUnavailability(message: string): AgentUnavailabilityKind | null {
   const lower = message.toLowerCase();
+  if (lower.includes("unknown coding agent")) {
+    return "unknown_agent";
+  }
   if (AGENT_AUTH_PATTERNS.some((needle) => lower.includes(needle))) {
     return "auth";
   }

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -200,6 +200,11 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
       "Rerun the babysitter for this PR.",
     ],
     cli_missing: buildCliMissingFixSteps("Claude", "claude"),
+    unknown_agent: [
+      "Open Settings and choose a supported coding agent.",
+      "Restart oh-my-pr if the agent setting was changed outside the app.",
+      "Rerun the babysitter for this PR.",
+    ],
   },
   Codex: {
     auth: [
@@ -209,6 +214,11 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
       "Rerun the babysitter for this PR.",
     ],
     cli_missing: buildCliMissingFixSteps("Codex", "codex"),
+    unknown_agent: [
+      "Open Settings and choose a supported coding agent.",
+      "Restart oh-my-pr if the agent setting was changed outside the app.",
+      "Rerun the babysitter for this PR.",
+    ],
   },
 };
 

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -1433,6 +1433,73 @@ test("syncAndBabysitTrackedRepos pauses automation when the selected agent is un
   assert.ok(logs.some((log) => log.message.includes("Automation paused")));
 });
 
+test("syncAndBabysitTrackedRepos does not enter drain mode for transient agent health timeouts", async () => {
+  const storage = new MemStorage();
+  const queuedItem = makeFeedbackItem({
+    id: "gh-review-comment-queued",
+    auditToken: "codefactory-feedback:gh-review-comment-queued",
+    decision: "accept",
+    status: "queued",
+    statusReason: "Queued",
+  });
+  const inProgressItem = makeFeedbackItem({
+    id: "gh-review-comment-running",
+    auditToken: "codefactory-feedback:gh-review-comment-running",
+    decision: "accept",
+    status: "in_progress",
+    statusReason: "Running",
+  });
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Needs watching",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [queuedItem, inProgressItem],
+    accepted: 2,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  await storage.updateConfig({ watchedRepos: ["octo/example"], codingAgent: "codex" });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        throw new Error("watcher should skip this cycle when agent health times out");
+      },
+    }) as never,
+    {
+      resolveAgent: async () => "codex",
+      checkAgentHealth: async () => ({
+        ok: false,
+        reason: "codex health check failed: Command timed out after 30000ms",
+      }),
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const runtimeState = await storage.getRuntimeState();
+  const logs = await storage.getLogs(pr.id);
+  const updated = await storage.getPR(pr.id);
+  assert.equal(runtimeState.drainMode, false);
+  assert.equal(runtimeState.drainReason, null);
+  assert.equal(updated?.feedbackItems[0]?.status, "queued");
+  assert.equal(updated?.feedbackItems[1]?.status, "in_progress");
+  assert.ok(logs.some((log) => log.message.includes("Automation skipped")));
+  assert.ok(logs.some((log) => log.message.includes("Command timed out after 30000ms")));
+  assert.ok(logs.every((log) => !log.message.includes("Automation paused")));
+});
+
 test("syncAndBabysitTrackedRepos does not queue release evaluation for closed-unmerged PRs", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -6,6 +6,7 @@ import type { IStorage } from "./storage";
 import {
   applyFixesWithAgent,
   checkAgentHealth,
+  detectAgentUnavailability,
   evaluateFixNecessityWithAgent,
   isAgentUnavailableError,
   resolveAgent,
@@ -1405,8 +1406,17 @@ export class PRBabysitter {
       return;
     }
 
-    await this.pauseAutomationForAgentFailure(agent, health.reason, prIds);
-    throw new Error(`Agent health check failed for ${agent}: ${health.reason}`);
+    const message = `Agent health check failed for ${agent}: ${health.reason}`;
+    if (detectAgentUnavailability(health.reason) !== null) {
+      await this.pauseAutomationForAgentFailure(agent, health.reason, prIds);
+    } else {
+      await Promise.all(prIds.map(async (prId) => {
+        await this.storage.addLog(prId, "warn", `Automation skipped: ${message}`, {
+          phase: "agent.health",
+        });
+      }));
+    }
+    throw new Error(message);
   }
 
   private async supersedeActiveHealingSessionsForArchivedPr(prId: string): Promise<void> {

--- a/tasks/drain-mode-log-fix-baseline-2026-05-05.md
+++ b/tasks/drain-mode-log-fix-baseline-2026-05-05.md
@@ -1,0 +1,74 @@
+# Drain Mode Log Fix Baseline - 2026-05-05
+
+## Scope
+
+Reviewed local oh-my-pr runtime state and logs after the report that drain mode was blocking new agent runs too often.
+
+Evidence sources:
+
+- `/Users/dgyk/.oh-my-pr/state.sqlite`
+- `/Users/dgyk/.oh-my-pr/log/server.log`
+- `/Users/dgyk/.oh-my-pr/log/2026-05-02` through `/Users/dgyk/.oh-my-pr/log/2026-05-05`
+
+Recorded at: `2026-05-05T11:58Z`
+
+## Findings
+
+Current persisted runtime state was not draining:
+
+- `drain_mode = 0`
+- `drain_requested_at = NULL`
+- `drain_reason = NULL`
+
+Recent real PR logs showed repeated automatic pauses from Codex health checks:
+
+- `2026-05-02T19:51:13Z`: multiple PRs paused with `codex health check failed: Reading additional input from stdin...`
+- `2026-05-03T17:32:41Z`: repeated Codex health pauses across redseal PRs.
+- `2026-05-04T12:42:38Z`: two PRs paused with `codex health check failed: Command timed out after 30000ms`.
+
+`server.log` also contained many drain enable/disable rows from test-fixture traffic, so future reviews should prefer persisted PR logs and SQLite rows over raw `server.log` counts when classifying live drain incidents.
+
+## Fix Applied
+
+The automatic agent-health path no longer enters global drain mode for transient health failures such as a Codex health-check timeout.
+
+Expected behavior after this change:
+
+- Deterministic agent unavailability still pauses automation with drain mode:
+  - missing CLI,
+  - authentication failures,
+  - Codex session permission failures,
+  - unknown configured agent.
+- Transient health-check failures log `Automation skipped: Agent health check failed...` for affected PRs and skip/fail the current cycle or job through existing queue behavior.
+- A single 30s health probe timeout should not persist `runtime_state.drain_mode = 1`.
+
+## Verification
+
+Commands run from `/Users/dgyk/Dev/oh-my-pr`:
+
+```bash
+node --test --import tsx server/babysitter.test.ts --test-name-pattern "transient agent health timeouts"
+node --test --import tsx server/babysitter.test.ts --test-name-pattern "transient agent health timeouts|pauses automation when the selected agent is unhealthy"
+node --test --import tsx server/agentRunner.test.ts server/babysitter.test.ts
+npm run check
+npm run test
+```
+
+Results:
+
+- Regression first failed before the fix because `runtimeState.drainMode` became `true`.
+- Focused and adjacent test suites passed after the fix.
+- `npm run check` passed.
+- `npm run test` passed: 452 passed, 0 failed.
+
+## Future Log Review Boundary
+
+For future local-log analysis, treat log rows before this branch lands as pre-fix evidence. Only count these as regressions if they appear after the merge commit for this fix:
+
+- `runtime_state.drain_mode = 1` caused only by `Command timed out after 30000ms`.
+- `Automation paused: Agent health check failed for codex: ... Command timed out after 30000ms`.
+- New `Drain mode enabled` rows whose `drainReason` is only a transient Codex timeout.
+
+Expected healthy signal:
+
+- Timeout-shaped Codex health failures produce `Automation skipped` logs and do not leave durable drain mode enabled.


### PR DESCRIPTION
## Summary

- keep global drain mode for deterministic agent unavailability only: auth, missing CLI, Codex session permission failures, or unknown configured agents
- treat transient health-check failures such as Codex 30s timeouts as current-cycle skips instead of durable runtime drain
- add regression coverage and a local log-analysis baseline for future drain-mode reviews

## Root Cause

The babysitter health gate persisted drain mode for every failed agent health check. Recent local logs showed Codex health-check timeouts being treated the same as durable auth or CLI failures, which paused new agent runs more often than intended.

## Verification

- claude -p /simplify server/agentRunner.ts server/babysitter.ts server/babysitter.test.ts tasks/drain-mode-log-fix-baseline-2026-05-05.md
- node --test --import tsx server/agentRunner.test.ts server/babysitter.test.ts
- node --test --import tsx server/appRuntime.test.ts server/routes.test.ts server/agentRunner.test.ts server/babysitter.test.ts
- npm run check
- npm run test (452 passed, 0 failed)