### PR TITLE
feat: add remote web login

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -1,8 +1,10 @@
 # oh-my-pr — Local API & MCP Server
 
-> **Security notice**: Every API endpoint is restricted to the local machine.
-> Requests arriving from any non-loopback address are rejected with `HTTP 403`.
-> oh-my-pr is a **local-first** tool; never expose its port to the internet.
+> **Security notice**: Loopback API access is allowed without login. Remote web
+> and API access is disabled unless `OH_MY_PR_WEB_USERNAME` and
+> `OH_MY_PR_WEB_PASSWORD` are set, and then requires a signed dashboard session.
+> Put TLS in front of the server before using remote access on an untrusted
+> network.
 
 ---
 
@@ -44,7 +46,7 @@ structured tool calls without writing a single line of HTTP client code.
 
 ```
 ┌─────────────────────────────────┐
-│  local machine only             │
+│  local-first machine            │
 │                                 │
 │  ┌──────────┐    HTTP           │
 │  │ OpenClaw │──────────────┐    │
@@ -84,9 +86,10 @@ npm run dev
 npm run build && npm start
 ```
 
-The server binds to `0.0.0.0:5001` (configurable via `PORT`), but the
-localhost-only middleware rejects every `/api/*` call that does not originate
-from `127.0.0.1` or `::1`.
+The server binds to `0.0.0.0:5001` (configurable via `PORT`). Requests from
+`127.0.0.1` or `::1` can call `/api/*` directly. Remote requests require a web
+login when `OH_MY_PR_WEB_USERNAME` and `OH_MY_PR_WEB_PASSWORD` are configured;
+otherwise they are rejected.
 
 If you enable deployment healing for Vercel or Railway repositories, install
 and authenticate the matching platform CLI on the same machine:
@@ -118,24 +121,50 @@ OH_MY_PR_PORT=5001 npm run mcp
 
 ## Security model
 
-### Localhost-only enforcement
+### Local-first enforcement
 
-The middleware in `server/localOnly.ts` runs before every `/api/*` handler.
-It checks the resolved IP address of each incoming request:
+The web access middleware runs before every protected `/api/*` handler. It
+checks the resolved IP address of each incoming request:
 
 | Source IP              | Allowed? |
 |------------------------|----------|
-| `127.0.0.1`            | ✅ yes   |
-| `::1`                  | ✅ yes   |
-| `::ffff:127.x.x.x`     | ✅ yes   |
-| `127.x.x.x` (any /8)  | ✅ yes   |
-| Everything else        | ❌ 403   |
+| `127.0.0.1`            | yes, no login required |
+| `::1`                  | yes, no login required |
+| `::ffff:127.x.x.x`     | yes, no login required |
+| `127.x.x.x` (any /8)  | yes, no login required |
+| Everything else        | yes only after dashboard login |
 
 **What this means in practice**
 
-- Only processes running on the same machine can call the API.
-- Docker containers, VMs, LAN peers, and the internet are all rejected.
-- The UI (served at `/`) is unaffected — it uses a browser on the same host.
+- Processes running on the same machine can call the API without login.
+- Docker containers, VMs, LAN peers, and the internet need a dashboard session.
+- Remote login is opt-in; without credentials, non-loopback API calls receive
+  `403`.
+- The UI is served at `/`; remote browsers see a login screen before API data
+  loads.
+
+### Remote dashboard login
+
+Set these variables before starting the server:
+
+```bash
+OH_MY_PR_WEB_USERNAME=operator
+OH_MY_PR_WEB_PASSWORD='choose-a-long-password'
+OH_MY_PR_SESSION_SECRET='choose-a-long-random-secret'
+```
+
+`OH_MY_PR_SESSION_SECRET` is optional; when omitted, oh-my-pr creates an
+in-memory secret at startup and existing sessions are invalidated on restart.
+Use HTTPS at the proxy/load-balancer layer before sending credentials across an
+untrusted network.
+
+The login endpoints are:
+
+| Route | Description |
+|-------|-------------|
+| `GET /api/auth/status` | Return whether the current caller needs login and is authenticated |
+| `POST /api/auth/login` | Authenticate with `{ "username": "...", "password": "..." }` |
+| `POST /api/auth/logout` | Destroy the current dashboard session |
 
 ### Running behind a reverse proxy
 
@@ -1158,7 +1187,8 @@ All error responses share this shape:
 | Status | Meaning |
 |--------|---------|
 | `400`  | Validation error (bad input) |
-| `403`  | Request blocked — not from localhost |
+| `401`  | Login required or invalid credentials |
+| `403`  | Request blocked — remote login is not configured |
 | `404`  | Resource not found |
 | `409`  | Conflict — e.g. drain mode is active |
 | `500`  | Internal server error |
@@ -1173,6 +1203,9 @@ All error responses share this shape:
 | `OH_MY_PR_PORT`      | `5001`         | Port the MCP server connects to (MCP only) |
 | `OH_MY_PR_HOME`      | `~/.oh-my-pr` | Directory for SQLite DB, logs, repos, worktrees |
 | `CODEFACTORY_HOME`   | —              | Legacy alias used only when `OH_MY_PR_HOME` is not set |
+| `OH_MY_PR_WEB_USERNAME` | —           | Username for opt-in remote dashboard/API login |
+| `OH_MY_PR_WEB_PASSWORD` | —           | Password for opt-in remote dashboard/API login |
+| `OH_MY_PR_SESSION_SECRET` | generated at startup | Secret for signing remote dashboard sessions |
 | `GITHUB_TOKEN`       | —              | Fallback GitHub token after saved app tokens and before `gh auth` |
 | `NODE_ENV`           | `development`  | Set to `production` for production builds |
 | `TAURI_DEV`          | —              | Set to skip auto-opening the browser (used by Tauri) |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ oh-my-pr can be used in a few ways:
 - local REST API: see [LOCAL_API.md](LOCAL_API.md)
 - optional Tauri desktop shell
 
+Local browser and API access work without a dashboard login. To use the web
+dashboard from another machine, set remote web credentials before starting the
+server:
+
+```bash
+OH_MY_PR_WEB_USERNAME=operator \
+OH_MY_PR_WEB_PASSWORD='choose-a-long-password' \
+OH_MY_PR_SESSION_SECRET='choose-a-long-random-secret' \
+oh-my-pr
+```
+
+Remote API requests then require a signed dashboard session. Put TLS in front
+of the server before using remote access over an untrusted network.
+
 ### Logging
 
 Server output is structured (pino) and goes to two destinations by default:
@@ -158,7 +172,9 @@ npm install
 npm run dev
 ```
 
-The dashboard is available at `http://localhost:5001` by default. All `/api/*` routes are restricted to loopback callers.
+The dashboard is available at `http://localhost:5001` by default. Loopback API
+requests work without login; remote dashboard/API access requires
+`OH_MY_PR_WEB_USERNAME` and `OH_MY_PR_WEB_PASSWORD`.
 
 ## Docs
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import Changelogs from "@/pages/changelogs";
 import Releases from "@/pages/releases";
 import Logs from "@/pages/logs";
 import NotFound from "@/pages/not-found";
+import { WebLoginGate } from "@/components/WebLoginGate";
 
 function AppRouter() {
   return (
@@ -31,9 +32,11 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <Toaster />
-          <Router hook={useHashLocation}>
-            <AppRouter />
-          </Router>
+          <WebLoginGate>
+            <Router hook={useHashLocation}>
+              <AppRouter />
+            </Router>
+          </WebLoginGate>
         </TooltipProvider>
       </QueryClientProvider>
     </ThemeProvider>

--- a/client/src/components/WebLoginGate.tsx
+++ b/client/src/components/WebLoginGate.tsx
@@ -51,7 +51,8 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
       })
       .catch((authError: unknown) => {
         if (!cancelled) {
-          setError(authError instanceof Error ? authError.message : "Could not check login state.");
+          const message = authError instanceof Error ? authError.message : "";
+          setError(getErrorMessage(message, "Could not check login state."));
         }
       });
 
@@ -81,7 +82,11 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
       }
 
       setPassword("");
-      setStatus(JSON.parse(responseText) as AuthStatus);
+      try {
+        setStatus(JSON.parse(responseText) as AuthStatus);
+      } catch {
+        setError(getErrorMessage(responseText, "Login failed."));
+      }
     } finally {
       setSubmitting(false);
     }
@@ -91,7 +96,7 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
         <div className="border border-border px-4 py-3 text-xs uppercase text-muted-foreground">
-          Loading oh-my-pr
+          {error ?? "Loading oh-my-pr"}
         </div>
       </div>
     );

--- a/client/src/components/WebLoginGate.tsx
+++ b/client/src/components/WebLoginGate.tsx
@@ -1,0 +1,160 @@
+import { FormEvent, ReactNode, useEffect, useState } from "react";
+
+interface AuthStatus {
+  requiresLogin: boolean;
+  loginConfigured: boolean;
+  authenticated: boolean;
+  username: string | null;
+}
+
+interface WebLoginGateProps {
+  children: ReactNode;
+}
+
+function getErrorMessage(responseText: string, fallback: string): string {
+  try {
+    const parsed = JSON.parse(responseText) as { message?: unknown; error?: unknown };
+    if (typeof parsed.message === "string") {
+      return parsed.message;
+    }
+    if (typeof parsed.error === "string") {
+      return parsed.error;
+    }
+  } catch {
+    return responseText || fallback;
+  }
+
+  return responseText || fallback;
+}
+
+export function WebLoginGate({ children }: WebLoginGateProps) {
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/auth/status")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+        return await response.json() as AuthStatus;
+      })
+      .then((nextStatus) => {
+        if (!cancelled) {
+          setStatus(nextStatus);
+        }
+      })
+      .catch((authError: unknown) => {
+        if (!cancelled) {
+          setError(authError instanceof Error ? authError.message : "Could not check login state.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function submitLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+      const responseText = await response.text();
+
+      if (!response.ok) {
+        setError(getErrorMessage(responseText, "Login failed."));
+        return;
+      }
+
+      setPassword("");
+      setStatus(JSON.parse(responseText) as AuthStatus);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!status) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+        <div className="border border-border px-4 py-3 text-xs uppercase text-muted-foreground">
+          Loading oh-my-pr
+        </div>
+      </div>
+    );
+  }
+
+  if (!status.requiresLogin || status.authenticated) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <form
+        className="w-full max-w-sm border border-border bg-card p-5"
+        onSubmit={submitLogin}
+      >
+        <div className="mb-5 space-y-1">
+          <p className="text-[10px] uppercase text-muted-foreground">Remote access</p>
+          <h1 className="text-base font-semibold">Sign in to oh-my-pr</h1>
+        </div>
+
+        {!status.loginConfigured ? (
+          <div className="border border-warning-border bg-warning-muted p-3 text-xs text-warning-foreground">
+            Remote login is not configured on this server.
+          </div>
+        ) : (
+          <>
+            <label className="mb-3 block text-xs">
+              <span className="mb-1 block text-muted-foreground">Username</span>
+              <input
+                className="w-full border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
+                autoComplete="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+              />
+            </label>
+
+            <label className="mb-4 block text-xs">
+              <span className="mb-1 block text-muted-foreground">Password</span>
+              <input
+                className="w-full border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
+                autoComplete="current-password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </label>
+
+            {error && (
+              <div className="mb-4 border border-destructive bg-background p-3 text-xs text-destructive">
+                {error}
+              </div>
+            )}
+
+            <button
+              className="w-full border border-primary bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={submitting}
+              type="submit"
+            >
+              {submitting ? "Signing in" : "Sign in"}
+            </button>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
-import { localOnlyMiddleware } from "./localOnly";
+import { configureWebAuth } from "./webAuth";
 import { createServer } from "http";
 import { childLogger, logger } from "./logger";
 
@@ -26,9 +26,10 @@ app.use(
 
 app.use(express.urlencoded({ extended: false }));
 
-// Restrict every /api route to local-machine callers only.
-// Any request arriving from a non-loopback IP is rejected with 403.
-app.use("/api", localOnlyMiddleware);
+// Keep loopback API access local-first while allowing authenticated remote
+// dashboard sessions when web credentials are configured.
+const webAuth = configureWebAuth(app);
+app.use("/api", webAuth.apiAccessMiddleware);
 
 export function log(message: string, source = "express") {
   logger.info({ source }, message);

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,23 @@ const serverLog = childLogger("server");
 const app = express();
 const httpServer = createServer(app);
 
+function readTrustProxySetting(value: string | undefined): boolean | number | string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "false") {
+    return false;
+  }
+  if (trimmed === "true") {
+    return true;
+  }
+
+  const numericValue = Number(trimmed);
+  if (Number.isInteger(numericValue) && numericValue >= 0) {
+    return numericValue;
+  }
+
+  return trimmed;
+}
+
 declare module "http" {
   interface IncomingMessage {
     rawBody: unknown;
@@ -28,6 +45,7 @@ app.use(express.urlencoded({ extended: false }));
 
 // Keep loopback API access local-first while allowing authenticated remote
 // dashboard sessions when web credentials are configured.
+app.set("trust proxy", readTrustProxySetting(process.env.OH_MY_PR_TRUST_PROXY));
 const webAuth = configureWebAuth(app);
 app.use("/api", webAuth.apiAccessMiddleware);
 

--- a/server/localOnly.ts
+++ b/server/localOnly.ts
@@ -1,13 +1,12 @@
 /**
  * localOnly.ts
  *
- * Express middleware that restricts every API route to requests originating
- * from the local machine (127.0.0.1 / ::1 / ::ffff:127.0.0.1).
+ * Express helpers for recognizing requests originating from the local machine
+ * (127.0.0.1 / ::1 / ::ffff:127.0.0.1).
  *
- * Any request that arrives from a non-loopback address is rejected with
- * HTTP 403 before it reaches any route handler.  This enforces the security
- * boundary described in LOCAL_API.md: oh-my-pr is a local-first tool and
- * must never be reachable from external networks.
+ * The middleware below preserves the strict local-only behavior for callers
+ * that need it. The web server uses the exported loopback helper so local
+ * callers can bypass dashboard login while remote callers authenticate.
  *
  * Usage
  * -----
@@ -29,7 +28,7 @@ const LOOPBACK_ADDRESSES = new Set([
  * Returns `true` when the raw IP string is a loopback address.
  * Handles IPv4, IPv6, and IPv4-mapped IPv6 (::ffff:127.x.x.x).
  */
-function isLoopback(ip: string | undefined): boolean {
+export function isLoopbackAddress(ip: string | undefined): boolean {
   if (!ip) return false;
 
   // Strip brackets from IPv6 literals (e.g. "[::1]")
@@ -63,7 +62,7 @@ export function localOnlyMiddleware(
   // Express sets req.ip after trust-proxy resolution; fall back to socket address.
   const ip = req.ip ?? req.socket?.remoteAddress;
 
-  if (!isLoopback(ip)) {
+  if (!isLoopbackAddress(ip)) {
     res.status(403).json({
       error: "Forbidden",
       message:

--- a/server/webAuth.test.ts
+++ b/server/webAuth.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import test from "node:test";
+import express from "express";
+import { configureWebAuth, readWebAuthConfig } from "./webAuth";
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function createHarness(config = {
+  username: "operator",
+  password: "correct horse battery staple",
+  sessionSecret: "test-session-secret",
+}) {
+  const app = express();
+  app.set("trust proxy", 1);
+  app.use(express.json());
+
+  const auth = configureWebAuth(app, config);
+  app.use("/api", auth.apiAccessMiddleware);
+  app.get("/api/secret", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  const server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected an ephemeral test server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close(): Promise<void> {
+      await closeServer(server);
+    },
+  };
+}
+
+test("readWebAuthConfig trims username and session secret but preserves password", () => {
+  const config = readWebAuthConfig({
+    OH_MY_PR_WEB_USERNAME: " operator ",
+    OH_MY_PR_WEB_PASSWORD: "  password with spaces  ",
+    OH_MY_PR_SESSION_SECRET: " secret ",
+  });
+
+  assert.deepEqual(config, {
+    username: "operator",
+    password: "  password with spaces  ",
+    sessionSecret: "secret",
+  });
+});
+
+test("loopback callers can use protected API routes without login", async () => {
+  const harness = await createHarness();
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/secret`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+  } finally {
+    await harness.close();
+  }
+});
+
+test("remote callers must log in before using protected API routes", async () => {
+  const harness = await createHarness();
+  const remoteHeaders = { "X-Forwarded-For": "203.0.113.10" };
+
+  try {
+    const blocked = await fetch(`${harness.baseUrl}/api/secret`, {
+      headers: remoteHeaders,
+    });
+    assert.equal(blocked.status, 401);
+
+    const login = await fetch(`${harness.baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        ...remoteHeaders,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "operator",
+        password: "correct horse battery staple",
+      }),
+    });
+    assert.equal(login.status, 200);
+    assert.equal((await login.json() as { authenticated: boolean }).authenticated, true);
+
+    const cookie = login.headers.get("set-cookie");
+    assert.ok(cookie);
+
+    const allowed = await fetch(`${harness.baseUrl}/api/secret`, {
+      headers: {
+        ...remoteHeaders,
+        Cookie: cookie,
+      },
+    });
+    assert.equal(allowed.status, 200);
+    assert.deepEqual(await allowed.json(), { ok: true });
+  } finally {
+    await harness.close();
+  }
+});
+
+test("logout clears remote API access for the current session", async () => {
+  const harness = await createHarness();
+  const remoteHeaders = { "X-Forwarded-For": "203.0.113.10" };
+
+  try {
+    const login = await fetch(`${harness.baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        ...remoteHeaders,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "operator",
+        password: "correct horse battery staple",
+      }),
+    });
+    const cookie = login.headers.get("set-cookie");
+    assert.ok(cookie);
+
+    const logout = await fetch(`${harness.baseUrl}/api/auth/logout`, {
+      method: "POST",
+      headers: {
+        ...remoteHeaders,
+        Cookie: cookie,
+      },
+    });
+    assert.equal(logout.status, 200);
+
+    const blocked = await fetch(`${harness.baseUrl}/api/secret`, {
+      headers: {
+        ...remoteHeaders,
+        Cookie: cookie,
+      },
+    });
+    assert.equal(blocked.status, 401);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("remote callers cannot log in when credentials are not configured", async () => {
+  const harness = await createHarness({});
+  const remoteHeaders = { "X-Forwarded-For": "203.0.113.10" };
+
+  try {
+    const status = await fetch(`${harness.baseUrl}/api/auth/status`, {
+      headers: remoteHeaders,
+    });
+    assert.deepEqual(await status.json(), {
+      requiresLogin: true,
+      loginConfigured: false,
+      authenticated: false,
+      username: null,
+    });
+
+    const response = await fetch(`${harness.baseUrl}/api/secret`, {
+      headers: remoteHeaders,
+    });
+    assert.equal(response.status, 403);
+  } finally {
+    await harness.close();
+  }
+});

--- a/server/webAuth.ts
+++ b/server/webAuth.ts
@@ -73,14 +73,10 @@ function isLoopbackRequest(req: Request): boolean {
 }
 
 function safeEqual(actual: string, expected: string): boolean {
-  const actualBuffer = Buffer.from(actual);
-  const expectedBuffer = Buffer.from(expected);
+  const actualHash = crypto.createHash("sha256").update(actual).digest();
+  const expectedHash = crypto.createHash("sha256").update(expected).digest();
 
-  if (actualBuffer.length !== expectedBuffer.length) {
-    return false;
-  }
-
-  return crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+  return crypto.timingSafeEqual(actualHash, expectedHash);
 }
 
 function buildAuthStatus(req: Request, credentials: WebAuthCredentials | null): AuthStatus {
@@ -135,6 +131,11 @@ function destroySession(req: Request): Promise<void> {
   });
 }
 
+function buildSessionPhaseError(phase: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`Web auth ${phase} failed: ${message}`, { cause: error });
+}
+
 export function configureWebAuth(app: Express, config = readWebAuthConfig()): WebAuthHandlers {
   const credentials = getCredentials(config);
   const sessionSecret = config.sessionSecret ?? crypto.randomBytes(32).toString("hex");
@@ -151,7 +152,7 @@ export function configureWebAuth(app: Express, config = readWebAuthConfig()): We
       cookie: {
         httpOnly: true,
         sameSite: "lax",
-        secure: false,
+        secure: process.env.NODE_ENV === "production",
         maxAge: SESSION_MAX_AGE_MS,
       },
     }),
@@ -168,7 +169,7 @@ export function configureWebAuth(app: Express, config = readWebAuthConfig()): We
     res.json(buildAuthStatus(req, credentials));
   });
 
-  app.post("/api/auth/login", loginLimiter, async (req, res) => {
+  app.post("/api/auth/login", loginLimiter, async (req, res, next) => {
     if (!credentials) {
       res.status(403).json({
         error: "Remote login is not configured",
@@ -188,17 +189,29 @@ export function configureWebAuth(app: Express, config = readWebAuthConfig()): We
       return;
     }
 
-    await regenerateSession(req);
-    req.session.authenticatedWebUser = credentials.username;
-    await saveSession(req);
+    let phase = "session regeneration";
+    try {
+      await regenerateSession(req);
+      req.session.authenticatedWebUser = credentials.username;
+      phase = "session save";
+      await saveSession(req);
+    } catch (error) {
+      next(buildSessionPhaseError(phase, error));
+      return;
+    }
 
     res.json(buildAuthStatus(req, credentials));
   });
 
-  app.post("/api/auth/logout", async (req, res) => {
-    if (req.session.authenticatedWebUser) {
-      await destroySession(req);
-      res.clearCookie(SESSION_NAME);
+  app.post("/api/auth/logout", async (req, res, next) => {
+    try {
+      if (req.session.authenticatedWebUser) {
+        await destroySession(req);
+        res.clearCookie(SESSION_NAME);
+      }
+    } catch (error) {
+      next(buildSessionPhaseError("session destroy", error));
+      return;
     }
 
     res.json(buildAuthStatus(req, credentials));

--- a/server/webAuth.ts
+++ b/server/webAuth.ts
@@ -1,0 +1,233 @@
+import crypto from "node:crypto";
+import type { Express, NextFunction, Request, RequestHandler, Response } from "express";
+import session from "express-session";
+import createMemoryStore from "memorystore";
+import { rateLimit } from "express-rate-limit";
+import { isLoopbackAddress } from "./localOnly";
+
+const USERNAME_ENV = "OH_MY_PR_WEB_USERNAME";
+const PASSWORD_ENV = "OH_MY_PR_WEB_PASSWORD";
+const SESSION_SECRET_ENV = "OH_MY_PR_SESSION_SECRET";
+const SESSION_NAME = "oh-my-pr.sid";
+const SESSION_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+const MemoryStore = createMemoryStore(session);
+
+declare module "express-session" {
+  interface SessionData {
+    authenticatedWebUser?: string;
+  }
+}
+
+export interface WebAuthConfig {
+  username?: string;
+  password?: string;
+  sessionSecret?: string;
+}
+
+interface WebAuthCredentials {
+  username: string;
+  password: string;
+}
+
+interface AuthStatus {
+  requiresLogin: boolean;
+  loginConfigured: boolean;
+  authenticated: boolean;
+  username: string | null;
+}
+
+export interface WebAuthHandlers {
+  apiAccessMiddleware: RequestHandler;
+}
+
+function trimEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function readWebAuthConfig(env: NodeJS.ProcessEnv = process.env): WebAuthConfig {
+  return {
+    username: trimEnv(env[USERNAME_ENV]),
+    password: env[PASSWORD_ENV],
+    sessionSecret: trimEnv(env[SESSION_SECRET_ENV]),
+  };
+}
+
+function getCredentials(config: WebAuthConfig): WebAuthCredentials | null {
+  if (!config.username || !config.password) {
+    return null;
+  }
+
+  return {
+    username: config.username,
+    password: config.password,
+  };
+}
+
+function getRequestIp(req: Request): string | undefined {
+  return req.ip ?? req.socket?.remoteAddress;
+}
+
+function isLoopbackRequest(req: Request): boolean {
+  return isLoopbackAddress(getRequestIp(req));
+}
+
+function safeEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+
+  if (actualBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function buildAuthStatus(req: Request, credentials: WebAuthCredentials | null): AuthStatus {
+  const requiresLogin = !isLoopbackRequest(req);
+  const sessionUser = req.session?.authenticatedWebUser ?? null;
+  const authenticated = !requiresLogin || Boolean(credentials && sessionUser === credentials.username);
+
+  return {
+    requiresLogin,
+    loginConfigured: credentials !== null,
+    authenticated,
+    username: authenticated && credentials ? credentials.username : null,
+  };
+}
+
+function regenerateSession(req: Request): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.session.regenerate((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function saveSession(req: Request): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.session.save((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function destroySession(req: Request): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.session.destroy((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+export function configureWebAuth(app: Express, config = readWebAuthConfig()): WebAuthHandlers {
+  const credentials = getCredentials(config);
+  const sessionSecret = config.sessionSecret ?? crypto.randomBytes(32).toString("hex");
+
+  app.use(
+    session({
+      name: SESSION_NAME,
+      secret: sessionSecret,
+      store: new MemoryStore({
+        checkPeriod: SESSION_MAX_AGE_MS,
+      }),
+      resave: false,
+      saveUninitialized: false,
+      cookie: {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: false,
+        maxAge: SESSION_MAX_AGE_MS,
+      },
+    }),
+  );
+
+  const loginLimiter = rateLimit({
+    windowMs: 5 * 60 * 1000,
+    limit: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  app.get("/api/auth/status", (req, res) => {
+    res.json(buildAuthStatus(req, credentials));
+  });
+
+  app.post("/api/auth/login", loginLimiter, async (req, res) => {
+    if (!credentials) {
+      res.status(403).json({
+        error: "Remote login is not configured",
+        message: `Set ${USERNAME_ENV} and ${PASSWORD_ENV} before using remote web access.`,
+      });
+      return;
+    }
+
+    const username = typeof req.body?.username === "string" ? req.body.username : "";
+    const password = typeof req.body?.password === "string" ? req.body.password : "";
+
+    if (!safeEqual(username, credentials.username) || !safeEqual(password, credentials.password)) {
+      res.status(401).json({
+        error: "Invalid credentials",
+        message: "Username or password is incorrect.",
+      });
+      return;
+    }
+
+    await regenerateSession(req);
+    req.session.authenticatedWebUser = credentials.username;
+    await saveSession(req);
+
+    res.json(buildAuthStatus(req, credentials));
+  });
+
+  app.post("/api/auth/logout", async (req, res) => {
+    if (req.session.authenticatedWebUser) {
+      await destroySession(req);
+      res.clearCookie(SESSION_NAME);
+    }
+
+    res.json(buildAuthStatus(req, credentials));
+  });
+
+  return {
+    apiAccessMiddleware(req: Request, res: Response, next: NextFunction): void {
+      if (isLoopbackRequest(req)) {
+        next();
+        return;
+      }
+
+      if (!credentials) {
+        res.status(403).json({
+          error: "Remote access is not configured",
+          message: `Set ${USERNAME_ENV} and ${PASSWORD_ENV} to allow remote dashboard login.`,
+        });
+        return;
+      }
+
+      if (req.session?.authenticatedWebUser === credentials.username) {
+        next();
+        return;
+      }
+
+      res.status(401).json({
+        error: "Login required",
+        message: "Sign in to use oh-my-pr from this network address.",
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add opt-in username/password login for non-loopback web/API access.
- Keep loopback callers login-free for the local-first workflow.
- Add a compact dashboard login gate, auth/session middleware, focused auth regression coverage, and docs for remote credentials.

Closes #162

## Verification
- `node --import tsx --test server/webAuth.test.ts` passes.
- `npm run check` passes.
- `npm run lint` passes.
- `npm run build` passes.
- Production smoke on `PORT=5099` passed for `GET /api/auth/status`, `POST /api/auth/login`, and `GET /`.
- `npm run test` fails only at existing `server/agentRunner.test.ts` test `evaluateFixNecessityWithAgent throws a clear error when codex writes no output file`; the fake copied Homebrew Node binary aborts before the assertion because `@rpath/libnode.141.dylib` is unavailable from the temp fake-codex directory.
- `npm run test:all` fails at the same existing `server/agentRunner.test.ts` failure.
