### PR TITLE
feat: customize GitHub reply branding

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -645,7 +645,9 @@ Partially update the configuration.  Only the provided fields are changed.
   "autoResolveMergeConflicts": true,
   "autoCreateReleases": true,
   "autoUpdateDocs": true,
+  "githubCommentAppName": "oh-my-pr",
   "includeRepositoryLinksInGitHubComments": true,
+  "postGitHubProgressReplies": false,
   "autoHealCI": false,
   "maxHealingAttemptsPerSession": 3,
   "maxHealingAttemptsPerFingerprint": 2,
@@ -982,7 +984,9 @@ Install the oh-my-pr code-review GitHub Actions workflow on a repository.
   autoResolveMergeConflicts: boolean;
   autoCreateReleases: boolean;
   autoUpdateDocs: boolean;
+  githubCommentAppName: string; // Defaults to "oh-my-pr"; blank removes the GitHub reply signature
   includeRepositoryLinksInGitHubComments: boolean;
+  postGitHubProgressReplies: boolean;
   autoHealCI: boolean;
   maxHealingAttemptsPerSession: number;
   maxHealingAttemptsPerFingerprint: number;

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -467,11 +467,40 @@ export default function Settings() {
                 ) : null}
               </div>
 
+              <div className="flex flex-col gap-2">
+                <label htmlFor="settings-github-comment-app-name" className="text-sm">
+                  GitHub reply signature
+                </label>
+                <div className="text-[11px] text-muted-foreground">
+                  Replace the app name shown in public GitHub replies. Leave blank to remove it.
+                </div>
+                <input
+                  id="settings-github-comment-app-name"
+                  key={config?.githubCommentAppName ?? "oh-my-pr"}
+                  type="text"
+                  defaultValue={config?.githubCommentAppName ?? "oh-my-pr"}
+                  placeholder="leave blank to remove"
+                  onBlur={(e) => {
+                    const githubCommentAppName = e.target.value;
+                    if (githubCommentAppName !== (config?.githubCommentAppName ?? "oh-my-pr")) {
+                      updateConfigMutation.mutate({ githubCommentAppName });
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.currentTarget.blur();
+                    }
+                  }}
+                  disabled={updateConfigMutation.isPending}
+                  className="w-full border border-border bg-transparent px-2 py-1 text-sm focus:border-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                />
+              </div>
+
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm">Repository links in PR comments</div>
                   <div className="text-[11px] text-muted-foreground">
-                    Link oh-my-pr back to its repository in agent-authored GitHub PR comments and footers.
+                    Link the reply signature back to the project repository in agent-authored GitHub PR comments and footers.
                   </div>
                 </div>
                 <input

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import type { Config, RuntimeState } from "@shared/schema";
@@ -17,7 +17,13 @@ export default function Settings() {
 
   const [newGithubToken, setNewGithubToken] = useState("");
   const [showTokenInput, setShowTokenInput] = useState(false);
+  const [githubCommentAppNameDraft, setGithubCommentAppNameDraft] = useState("oh-my-pr");
   const githubTokens = config?.githubTokens ?? (config?.githubToken ? [config.githubToken] : []);
+  const githubCommentAppName = config?.githubCommentAppName ?? "oh-my-pr";
+
+  useEffect(() => {
+    setGithubCommentAppNameDraft(githubCommentAppName);
+  }, [githubCommentAppName]);
 
   const updateGithubTokens = (tokens: string[]) => {
     updateConfigMutation.mutate({ githubTokens: tokens });
@@ -476,10 +482,10 @@ export default function Settings() {
                 </div>
                 <input
                   id="settings-github-comment-app-name"
-                  key={config?.githubCommentAppName ?? "oh-my-pr"}
                   type="text"
-                  defaultValue={config?.githubCommentAppName ?? "oh-my-pr"}
+                  value={githubCommentAppNameDraft}
                   placeholder="leave blank to remove"
+                  onChange={(e) => setGithubCommentAppNameDraft(e.target.value)}
                   onBlur={(e) => {
                     const githubCommentAppName = e.target.value;
                     if (githubCommentAppName !== (config?.githubCommentAppName ?? "oh-my-pr")) {

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -65,7 +65,7 @@ The settings page in the dashboard provides a UI for:
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **Runtime drain mode** — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
 - **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.
-- **PR comment branding** — Toggle whether agent-authored GitHub PR comments link back to oh-my-pr and include the `Posted by oh-my-pr` footer.
+- **PR comment branding** — Customize the app name shown in agent-authored GitHub PR comments, or remove that signature entirely. Toggle whether the signature links back to oh-my-pr and includes the `Posted by oh-my-pr` footer.
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
@@ -115,14 +115,15 @@ release check fails, the banner stays hidden and the API falls back quietly.
 
 ## PR Comment Branding
 
-Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr. Each comment references the app name and, by default, appends a `Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)` footer that links back to this repository.
+Agent-authored GitHub PR comments posted by the babysitter — follow-up replies on review threads, agent-command acknowledgements, status updates, and CI alerts — are branded as oh-my-pr by default. Each comment references the configured app name and, by default, appends a `Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)` footer that links back to this repository. Set the GitHub reply signature to a different name to replace `oh-my-pr`, or leave it blank to remove the visible app signature from GitHub replies and footers.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `Repository links in PR comments` | `true` | When enabled, babysitter comments render the app name as a Markdown link to the oh-my-pr repo and append the `Posted by oh-my-pr` footer. When disabled, comments reference `oh-my-pr` as plain text and omit the footer. |
+| `GitHub reply signature` | `oh-my-pr` | App name shown in public GitHub replies and `Posted by ...` footers. Leave blank to remove the signature. |
+| `Repository links in PR comments` | `true` | When enabled, babysitter comments render the configured app name as a Markdown link to the oh-my-pr repo and append the `Posted by ...` footer. When disabled, comments reference the configured app name as plain text and omit the footer. |
 | `GitHub progress replies` | `false` | When enabled, the babysitter posts public status replies on accepted review feedback as it moves from queued to running, completed, and resolved. When disabled, it still posts the final follow-up reply without intermediate public progress updates. |
 
-These toggles are available in the dashboard settings page and as `includeRepositoryLinksInGitHubComments` plus `postGitHubProgressReplies` (booleans) in `GET /api/config`, `PATCH /api/config`, and the MCP `update_config` tool. Turning repository links off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.
+These settings are available in the dashboard settings page and as `githubCommentAppName` (string), `includeRepositoryLinksInGitHubComments` (boolean), and `postGitHubProgressReplies` (boolean) in `GET /api/config`, `PATCH /api/config`, and the MCP `update_config` tool. Turning repository links off is useful for private forks or environments where operators do not want outgoing PR comments to link to the upstream oh-my-pr repository.
 
 ## CI Healing Settings
 

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -167,18 +167,21 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
     codingAgent: "codex",
     autoUpdateDocs: false,
     includeRepositoryLinksInGitHubComments: false,
+    githubCommentAppName: "Review Bot",
     postGitHubProgressReplies: true,
   });
 
   assert.equal(updated.codingAgent, "codex");
   assert.equal(updated.autoUpdateDocs, false);
   assert.equal(updated.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(updated.githubCommentAppName, "Review Bot");
   assert.equal(updated.postGitHubProgressReplies, true);
 
   const config = await runtime.getConfig();
   assert.equal(config.codingAgent, "codex");
   assert.equal(config.autoUpdateDocs, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(config.githubCommentAppName, "Review Bot");
   assert.equal(config.postGitHubProgressReplies, true);
 });
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -75,8 +75,7 @@ const CONFLICT_REPAIR_RETRY_BUDGET = 2;
 const CODE_OWNER_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const APP_NAME = "oh-my-pr";
 const APP_REPOSITORY_URL = "https://github.com/yungookim/oh-my-pr";
-const APP_REPOSITORY_LINK = `[${APP_NAME}](${APP_REPOSITORY_URL})`;
-export const APP_COMMENT_FOOTER = `Posted by ${APP_REPOSITORY_LINK}`;
+export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
 const AUDIT_TOKEN_PATTERN = /\bcodefactory-feedback:[^\s<>()[\]{}"']+/g;
 
 export class TerminalBabysitterError extends Error {
@@ -966,14 +965,37 @@ function computeHealingImprovementScore(
   };
 }
 
-function formatAppName(includeRepositoryLinksInGitHubComments: boolean): string {
-  return includeRepositoryLinksInGitHubComments ? APP_REPOSITORY_LINK : APP_NAME;
+function formatAppName(githubCommentAppName: string, includeRepositoryLinksInGitHubComments: boolean): string {
+  const appName = githubCommentAppName.trim();
+  if (!appName) {
+    return "";
+  }
+
+  return includeRepositoryLinksInGitHubComments ? `[${appName}](${APP_REPOSITORY_URL})` : appName;
+}
+
+export function formatAppCommentFooter(
+  githubCommentAppName: string,
+  includeRepositoryLinksInGitHubComments: boolean,
+): string {
+  const appName = formatAppName(githubCommentAppName, includeRepositoryLinksInGitHubComments);
+  return appName ? `Posted by ${appName}` : "";
+}
+
+function formatIncludedAppCommentFooter(
+  includeRepositoryLinksInGitHubComments: boolean,
+  githubCommentAppName: string,
+): string {
+  return includeRepositoryLinksInGitHubComments
+    ? formatAppCommentFooter(githubCommentAppName, includeRepositoryLinksInGitHubComments)
+    : "";
 }
 
 function buildFeedbackFollowUpBody(
   headSha: string,
   item: FeedbackItem,
   includeRepositoryLinksInGitHubComments: boolean,
+  githubCommentAppName: string,
   agentSummary?: string,
 ): string {
   const shortSha = headSha.trim() ? headSha.trim().slice(0, 7) : "";
@@ -1001,8 +1023,12 @@ function buildFeedbackFollowUpBody(
   }
 
   parts.push("", `<!-- ${item.auditToken} -->`);
-  if (includeRepositoryLinksInGitHubComments) {
-    parts.push("", APP_COMMENT_FOOTER);
+  const footer = formatIncludedAppCommentFooter(
+    includeRepositoryLinksInGitHubComments,
+    githubCommentAppName,
+  );
+  if (footer) {
+    parts.push("", footer);
   }
 
   return parts.join("\n");
@@ -1026,15 +1052,23 @@ function isCodeFactoryComment(body: string): boolean {
   return body.includes(CODEFACTORY_COMMENT_MARKER);
 }
 
-function formatAgentCommandGitHubComment(
+export function formatAgentCommandGitHubComment(
   agent: CodingAgent,
   prompt: string,
   includeRepositoryLinksInGitHubComments: boolean,
+  githubCommentAppName: string,
 ): string {
   const fence = buildCodeFence(prompt);
+  const appName = formatAppName(githubCommentAppName, includeRepositoryLinksInGitHubComments);
+  const footer = formatIncludedAppCommentFooter(
+    includeRepositoryLinksInGitHubComments,
+    githubCommentAppName,
+  );
   return [
     CODEFACTORY_COMMENT_MARKER,
-    `\ud83e\udd16 **${formatAppName(includeRepositoryLinksInGitHubComments)}** dispatched \`${agent}\` with the following prompt:`,
+    appName
+      ? `\ud83e\udd16 **${appName}** dispatched \`${agent}\` with the following prompt:`
+      : `\ud83e\udd16 Dispatched \`${agent}\` with the following prompt:`,
     "",
     "<details>",
     "<summary>Agent prompt (click to expand)</summary>",
@@ -1044,37 +1078,67 @@ function formatAgentCommandGitHubComment(
     fence.close,
     "",
     "</details>",
-    ...(includeRepositoryLinksInGitHubComments ? ["", APP_COMMENT_FOOTER] : []),
+    ...(footer ? ["", footer] : []),
   ].join("\n");
 }
 
-function appendStatusLine(existingBody: string, line: string): string {
-  const { bodyWithoutFooter, hadFooter } = splitAppCommentFooter(existingBody);
+function appendStatusLine(
+  existingBody: string,
+  line: string,
+  includeRepositoryLinksInGitHubComments: boolean,
+  githubCommentAppName: string,
+): string {
+  const footer = formatIncludedAppCommentFooter(
+    includeRepositoryLinksInGitHubComments,
+    githubCommentAppName,
+  );
+  const { bodyWithoutFooter, hadFooter } = splitAppCommentFooter(existingBody, footer);
   const nextBody = bodyWithoutFooter ? `${bodyWithoutFooter}\n${line}` : line;
-  return hadFooter ? `${nextBody}\n\n${APP_COMMENT_FOOTER}` : nextBody;
+  return hadFooter && footer ? `${nextBody}\n\n${footer}` : nextBody;
 }
 
-function splitAppCommentFooter(body: string): { bodyWithoutFooter: string; hadFooter: boolean } {
+function splitAppCommentFooter(body: string, footer: string): { bodyWithoutFooter: string; hadFooter: boolean } {
   const trimmedBody = body.trimEnd();
-  if (trimmedBody === APP_COMMENT_FOOTER) {
-    return { bodyWithoutFooter: "", hadFooter: true };
+  const possibleFooters = [
+    footer,
+    APP_COMMENT_FOOTER,
+  ].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index);
+
+  for (const possibleFooter of possibleFooters) {
+    if (trimmedBody === possibleFooter) {
+      return { bodyWithoutFooter: "", hadFooter: true };
+    }
+
+    const suffix = "\n\n" + possibleFooter;
+    if (trimmedBody.endsWith(suffix)) {
+      return { bodyWithoutFooter: trimmedBody.slice(0, -suffix.length), hadFooter: true };
+    }
   }
 
-  const suffix = "\n\n" + APP_COMMENT_FOOTER;
-  if (trimmedBody.endsWith(suffix)) {
-    return { bodyWithoutFooter: trimmedBody.slice(0, -suffix.length), hadFooter: true };
+  const linkedFooterPattern = /\n\nPosted by \[[^\]\n]+\]\(https:\/\/github\.com\/yungookim\/oh-my-pr\)$/;
+  const linkedFooterMatch = trimmedBody.match(linkedFooterPattern);
+  if (linkedFooterMatch?.index !== undefined) {
+    return { bodyWithoutFooter: trimmedBody.slice(0, linkedFooterMatch.index), hadFooter: true };
   }
 
   return { bodyWithoutFooter: body, hadFooter: false };
 }
 
-function withOptionalAppCommentFooter(body: string, includeRepositoryLinksInGitHubComments: boolean): string {
-  if (!includeRepositoryLinksInGitHubComments) {
+function withOptionalAppCommentFooter(
+  body: string,
+  includeRepositoryLinksInGitHubComments: boolean,
+  githubCommentAppName: string,
+): string {
+  const footer = formatIncludedAppCommentFooter(
+    includeRepositoryLinksInGitHubComments,
+    githubCommentAppName,
+  );
+  if (!footer) {
     return body;
   }
 
-  const { bodyWithoutFooter } = splitAppCommentFooter(body);
-  return bodyWithoutFooter ? `${bodyWithoutFooter}\n\n${APP_COMMENT_FOOTER}` : APP_COMMENT_FOOTER;
+  const { bodyWithoutFooter } = splitAppCommentFooter(body, footer);
+  return bodyWithoutFooter ? `${bodyWithoutFooter}\n\n${footer}` : footer;
 }
 
 function formatCommand(command: string, args: string[]): string {
@@ -2786,6 +2850,7 @@ export class PRBabysitter {
       }
 
       const includeRepositoryLinksInGitHubComments = config.includeRepositoryLinksInGitHubComments;
+      const githubCommentAppName = config.githubCommentAppName;
       const postGitHubProgressReplies = config.postGitHubProgressReplies;
       // Track status reply comments so we can update them with progress.
       const statusReplies = new Map<string, StatusReplyRef>(
@@ -2827,7 +2892,12 @@ export class PRBabysitter {
         const ref = await recoverStatusReplyRef(feedbackId);
         if (!ref) return;
         try {
-          const newBody = appendStatusLine(ref.body, line);
+          const newBody = appendStatusLine(
+            ref.body,
+            line,
+            includeRepositoryLinksInGitHubComments,
+            githubCommentAppName,
+          );
           await this.github.updateStatusReply(octokit, parsedPr, ref, newBody);
           await persistStatusReplyRef(feedbackId, ref);
         } catch (error) {
@@ -2835,7 +2905,12 @@ export class PRBabysitter {
           const recovered = item ? findStatusReplyRefForFeedback(item, pr.feedbackItems) : null;
           if (recovered && recovered.commentDatabaseId !== ref.commentDatabaseId) {
             try {
-              const newBody = appendStatusLine(recovered.body, line);
+              const newBody = appendStatusLine(
+                recovered.body,
+                line,
+                includeRepositoryLinksInGitHubComments,
+                githubCommentAppName,
+              );
               await this.github.updateStatusReply(octokit, parsedPr, recovered, newBody);
               statusReplies.set(feedbackId, recovered);
               await persistStatusReplyRef(feedbackId, recovered);
@@ -2865,7 +2940,12 @@ export class PRBabysitter {
           await this.github.postPRComment(
             octokit,
             parsedPr,
-            formatAgentCommandGitHubComment(agent, prompt, includeRepositoryLinksInGitHubComments),
+            formatAgentCommandGitHubComment(
+              agent,
+              prompt,
+              includeRepositoryLinksInGitHubComments,
+              githubCommentAppName,
+            ),
           );
         } catch (error) {
           await logBestEffortFailure(
@@ -3004,7 +3084,11 @@ export class PRBabysitter {
                 octokit,
                 parsedPr,
                 item,
-                withOptionalAppCommentFooter(STATUS_MESSAGES.accepted, includeRepositoryLinksInGitHubComments),
+                withOptionalAppCommentFooter(
+                  STATUS_MESSAGES.accepted,
+                  includeRepositoryLinksInGitHubComments,
+                  githubCommentAppName,
+                ),
               );
               if (ref) {
                 statusReplies.set(item.id, ref);
@@ -4076,6 +4160,7 @@ export class PRBabysitter {
             headShaForFollowUp,
             item,
             includeRepositoryLinksInGitHubComments,
+            githubCommentAppName,
             agentSummaries.get(item.auditToken),
           );
           await this.github.postFollowUpForFeedbackItem(octokit, parsedPr, item, body, { resolve: shouldResolveThread });
@@ -4177,15 +4262,20 @@ export class PRBabysitter {
 
           // Alert the user by posting a comment on the PR.
           try {
+            const appName = formatAppName(githubCommentAppName, includeRepositoryLinksInGitHubComments);
+            const footer = formatIncludedAppCommentFooter(
+              includeRepositoryLinksInGitHubComments,
+              githubCommentAppName,
+            );
             const alertBody = [
-              `## \u26a0\ufe0f ${formatAppName(includeRepositoryLinksInGitHubComments)} CI Alert`,
+              appName ? `## \u26a0\ufe0f ${appName} CI Alert` : "## \u26a0\ufe0f CI Alert",
               "",
               `The babysitter pushed changes (commit \`${headShaForFollowUp.slice(0, 7)}\`), but CI/CD checks are still failing:`,
               "",
               ...ciResult.failures.map((f) => `- **${f.context}**: ${f.description}${f.targetUrl ? ` ([details](${f.targetUrl}))` : ""}`),
               "",
               "Manual investigation may be required.",
-              ...(includeRepositoryLinksInGitHubComments ? ["", APP_COMMENT_FOOTER] : []),
+              ...(footer ? ["", footer] : []),
             ].join("\n");
             await this.github.postPRComment(octokit, parsedPr, alertBody);
           } catch (error) {

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -29,6 +29,7 @@ describe("DEFAULT_CONFIG", () => {
       "autoCreateReleases",
       "autoUpdateDocs",
       "includeRepositoryLinksInGitHubComments",
+      "githubCommentAppName",
       "postGitHubProgressReplies",
       "autoHealCI",
       "maxHealingAttemptsPerSession",
@@ -126,6 +127,10 @@ describe("DEFAULT_CONFIG", () => {
 
   it("includes repository links in GitHub comments by default", () => {
     assert.equal(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments, true);
+  });
+
+  it("uses oh-my-pr as the default GitHub reply signature", () => {
+    assert.equal(DEFAULT_CONFIG.githubCommentAppName, "oh-my-pr");
   });
 
   it("does not post GitHub progress replies by default", () => {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CONFIG: Config = {
   autoCreateReleases: false,
   autoUpdateDocs: true,
   includeRepositoryLinksInGitHubComments: true,
+  githubCommentAppName: "oh-my-pr",
   postGitHubProgressReplies: false,
   autoHealCI: false,
   maxHealingAttemptsPerSession: 3,

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -41,6 +41,7 @@ const config: Config = {
   autoCreateReleases: true,
   autoUpdateDocs: true,
   includeRepositoryLinksInGitHubComments: true,
+  githubCommentAppName: "oh-my-pr",
   postGitHubProgressReplies: false,
   autoHealCI: false,
   maxHealingAttemptsPerSession: 3,

--- a/server/github.ts
+++ b/server/github.ts
@@ -396,7 +396,7 @@ export function buildFeedbackAuditToken(feedbackId: string): string {
   return `codefactory-feedback:${feedbackId}`;
 }
 
-const APP_COMMENT_FOOTER_PATTERN = /Posted by \[oh-my-pr\]\(https:\/\/github\.com\/yungookim\/oh-my-pr\)/i;
+const APP_COMMENT_FOOTER_PATTERN = /Posted by \[[^\]]+\]\(https:\/\/github\.com\/yungookim\/oh-my-pr\)/i;
 const AGENT_COMMAND_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
 const AUDIT_TRAIL_COMMENT_PATTERN = /<!--\s*codefactory-feedback:[^>]+-->/i;
 export const APP_STATUS_COMMENT_PATTERN = /\*\*(?:Accepted|Agent running|Agent failed|Agent completed|Resolved)\*\*\s*(?:[—-]|$)/i;

--- a/server/githubReplyBranding.test.ts
+++ b/server/githubReplyBranding.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  APP_COMMENT_FOOTER,
+  formatAppCommentFooter,
+  formatAgentCommandGitHubComment,
+} from "./babysitter";
+
+test("GitHub reply branding defaults to oh-my-pr", () => {
+  assert.equal(
+    APP_COMMENT_FOOTER,
+    "Posted by [oh-my-pr](https://github.com/yungookim/oh-my-pr)",
+  );
+});
+
+test("GitHub reply branding can replace the visible app name", () => {
+  const comment = formatAgentCommandGitHubComment(
+    "codex",
+    "Fix the failing test.",
+    false,
+    "Review Bot",
+  );
+
+  assert.match(comment, /\*\*Review Bot\*\* dispatched `codex`/);
+  assert.doesNotMatch(comment, /\*\*oh-my-pr\*\* dispatched/);
+  assert.doesNotMatch(comment, /Posted by/);
+});
+
+test("GitHub reply branding can remove the visible app name", () => {
+  const comment = formatAgentCommandGitHubComment(
+    "codex",
+    "Fix the failing test.",
+    true,
+    "   ",
+  );
+
+  assert.match(comment, /\ud83e\udd16 Dispatched `codex`/);
+  assert.doesNotMatch(comment, /oh-my-pr/);
+  assert.doesNotMatch(comment, /Posted by/);
+});
+
+test("GitHub reply branding uses the custom name in linked footers", () => {
+  assert.equal(
+    formatAppCommentFooter("Review Bot", true),
+    "Posted by [Review Bot](https://github.com/yungookim/oh-my-pr)",
+  );
+});

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -311,7 +311,7 @@ const TOOLS: Tool[] = [
       "Partially update oh-my-pr configuration. All fields are optional; only provided " +
       "fields are changed. Available fields: githubTokens, githubToken (legacy), codingAgent, maxTurns, " +
       "fallbackToNextCodingAgent, batchWindowMs, pollIntervalMs, maxChangesPerRun, autoResolveMergeConflicts, autoUpdateDocs, " +
-      "includeRepositoryLinksInGitHubComments, postGitHubProgressReplies, " +
+      "includeRepositoryLinksInGitHubComments, githubCommentAppName, postGitHubProgressReplies, " +
       "watchedRepos, trustedReviewers, ignoredBots.",
     inputSchema: {
       type: "object",
@@ -327,6 +327,7 @@ const TOOLS: Tool[] = [
         autoResolveMergeConflicts: { type: "boolean" },
         autoUpdateDocs: { type: "boolean" },
         includeRepositoryLinksInGitHubComments: { type: "boolean" },
+        githubCommentAppName: { type: "string" },
         postGitHubProgressReplies: { type: "boolean" },
         watchedRepos: { type: "array", items: { type: "string" } },
         trustedReviewers: { type: "array", items: { type: "string" } },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -426,6 +426,7 @@ describe("MemStorage", () => {
         config.includeRepositoryLinksInGitHubComments,
         DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments,
       );
+      assert.equal(config.githubCommentAppName, DEFAULT_CONFIG.githubCommentAppName);
       assert.equal(config.postGitHubProgressReplies, DEFAULT_CONFIG.postGitHubProgressReplies);
       assert.equal(config.autoHealCI, DEFAULT_CONFIG.autoHealCI);
       assert.equal(config.maxHealingAttemptsPerSession, DEFAULT_CONFIG.maxHealingAttemptsPerSession);
@@ -445,6 +446,7 @@ describe("MemStorage", () => {
       assert.equal(updated.fallbackToNextCodingAgent, false);
       assert.equal(updated.autoUpdateDocs, true);
       assert.equal(updated.includeRepositoryLinksInGitHubComments, true);
+      assert.equal(updated.githubCommentAppName, "oh-my-pr");
       assert.equal(updated.postGitHubProgressReplies, false);
       assert.equal(updated.autoCreateReleases, DEFAULT_CONFIG.autoCreateReleases);
       assert.equal(updated.autoHealCI, false);
@@ -454,6 +456,7 @@ describe("MemStorage", () => {
     it("returns the updated config", async () => {
       const updated = await storage.updateConfig({
         githubTokens: ["tok_123", "tok_456"],
+        githubCommentAppName: " Review Bot ",
         includeRepositoryLinksInGitHubComments: false,
         postGitHubProgressReplies: true,
         autoHealCI: true,
@@ -465,6 +468,7 @@ describe("MemStorage", () => {
       const fetched = await storage.getConfig();
       assert.deepEqual(updated, fetched);
       assert.deepEqual(fetched.githubTokens, ["tok_123", "tok_456"]);
+      assert.equal(fetched.githubCommentAppName, "Review Bot");
       assert.equal(fetched.postGitHubProgressReplies, true);
     });
   });

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -71,6 +71,7 @@ type ConfigRow = {
   auto_create_releases: number;
   auto_update_docs: number;
   include_repository_links_in_github_comments: number;
+  github_comment_app_name: string;
   post_github_progress_replies: number;
   auto_heal_ci: number;
   max_healing_attempts_per_session: number;
@@ -504,6 +505,7 @@ export class SqliteStorage implements IStorage {
         auto_create_releases INTEGER NOT NULL DEFAULT 0,
         auto_update_docs INTEGER NOT NULL DEFAULT 1,
         include_repository_links_in_github_comments INTEGER NOT NULL DEFAULT 1,
+        github_comment_app_name TEXT NOT NULL DEFAULT 'oh-my-pr',
         post_github_progress_replies INTEGER NOT NULL DEFAULT 0,
         auto_heal_ci INTEGER NOT NULL DEFAULT 0,
         max_healing_attempts_per_session INTEGER NOT NULL DEFAULT 3,
@@ -796,6 +798,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "include_repository_links_in_github_comments", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "github_comment_app_name", "TEXT NOT NULL DEFAULT 'oh-my-pr'");
     this.ensureColumn("config", "post_github_progress_replies", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_heal_ci", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "max_healing_attempts_per_session", "INTEGER NOT NULL DEFAULT 3");
@@ -867,6 +870,7 @@ export class SqliteStorage implements IStorage {
       includeRepositoryLinksInGitHubComments: Boolean(
         row.include_repository_links_in_github_comments ?? Number(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments),
       ),
+      githubCommentAppName: row.github_comment_app_name ?? DEFAULT_CONFIG.githubCommentAppName,
       postGitHubProgressReplies: Boolean(
         row.post_github_progress_replies ?? Number(DEFAULT_CONFIG.postGitHubProgressReplies),
       ),
@@ -910,6 +914,7 @@ export class SqliteStorage implements IStorage {
           auto_create_releases,
           auto_update_docs,
           include_repository_links_in_github_comments,
+          github_comment_app_name,
           post_github_progress_replies,
           auto_heal_ci,
           max_healing_attempts_per_session,
@@ -922,7 +927,7 @@ export class SqliteStorage implements IStorage {
           deployment_check_poll_interval_ms,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -937,6 +942,7 @@ export class SqliteStorage implements IStorage {
           auto_create_releases = excluded.auto_create_releases,
           auto_update_docs = excluded.auto_update_docs,
           include_repository_links_in_github_comments = excluded.include_repository_links_in_github_comments,
+          github_comment_app_name = excluded.github_comment_app_name,
           post_github_progress_replies = excluded.post_github_progress_replies,
           auto_heal_ci = excluded.auto_heal_ci,
           max_healing_attempts_per_session = excluded.max_healing_attempts_per_session,
@@ -964,6 +970,7 @@ export class SqliteStorage implements IStorage {
         Number(config.autoCreateReleases),
         Number(config.autoUpdateDocs),
         Number(config.includeRepositoryLinksInGitHubComments),
+        config.githubCommentAppName,
         Number(config.postGitHubProgressReplies),
         Number(config.autoHealCI),
         config.maxHealingAttemptsPerSession,
@@ -1564,7 +1571,8 @@ export class SqliteStorage implements IStorage {
     const row = this.get<ConfigRow>(`
       SELECT github_token, github_tokens_json, coding_agent, fallback_to_next_coding_agent, model, max_turns, batch_window_ms,
              poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
-             auto_update_docs, include_repository_links_in_github_comments, post_github_progress_replies,
+             auto_update_docs, include_repository_links_in_github_comments, github_comment_app_name,
+             post_github_progress_replies,
              auto_heal_ci, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -80,6 +80,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     autoCreateReleases: false,
     autoUpdateDocs: false,
     includeRepositoryLinksInGitHubComments: false,
+    githubCommentAppName: "Review Bot",
     postGitHubProgressReplies: true,
     autoHealCI: true,
     maxHealingAttemptsPerSession: 5,
@@ -212,6 +213,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(config.autoCreateReleases, false);
   assert.equal(config.autoUpdateDocs, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
+  assert.equal(config.githubCommentAppName, "Review Bot");
   assert.equal(config.postGitHubProgressReplies, true);
   assert.equal(config.autoHealCI, true);
   assert.equal(config.maxHealingAttemptsPerSession, 5);
@@ -309,6 +311,7 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
       autoCreateReleases: false,
       autoUpdateDocs: false,
       includeRepositoryLinksInGitHubComments: false,
+      githubCommentAppName: "Review Bot",
       autoHealCI: true,
       maxHealingAttemptsPerSession: 8,
       maxHealingAttemptsPerFingerprint: 7,

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -341,12 +341,16 @@ export function applyConfigUpdate(existing: Config, updates: Partial<Config>): C
   const normalizedGithubTokens = updatedGithubTokens
     .map((token) => token.trim())
     .filter(Boolean);
+  const githubCommentAppName = updates.githubCommentAppName === undefined
+    ? existing.githubCommentAppName
+    : updates.githubCommentAppName.trim();
 
   return configSchema.parse({
     ...existing,
     ...updates,
     githubTokens: normalizedGithubTokens,
     githubToken: undefined,
+    githubCommentAppName,
     watchedRepos: updates.watchedRepos ?? existing.watchedRepos,
     trustedReviewers: updates.trustedReviewers ?? existing.trustedReviewers,
     ignoredBots: updates.ignoredBots ?? existing.ignoredBots,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -449,6 +449,7 @@ export const configSchema = z.object({
   autoCreateReleases: z.boolean(),
   autoUpdateDocs: z.boolean(),
   includeRepositoryLinksInGitHubComments: z.boolean(),
+  githubCommentAppName: z.string(),
   postGitHubProgressReplies: z.boolean(),
   autoHealCI: z.boolean(),
   maxHealingAttemptsPerSession: z.number(),


### PR DESCRIPTION
## Summary
- add config-backed GitHub reply signature text, defaulting to oh-my-pr and allowing blank values to remove visible app branding
- route agent command comments, follow-up footers, status replies, and CI alerts through the configurable signature
- expose the setting in the dashboard settings page, MCP config schema, SQLite config storage, and tests

Closes #164

## Verification
- PASS: npm run check
- PASS: npm run lint
- PASS: node --import tsx --test server/githubReplyBranding.test.ts server/defaultConfig.test.ts server/storage.test.ts server/memoryStorage.test.ts server/appRuntime.test.ts server/github.test.ts
- PASS: node --import tsx --test server/babysitter.test.ts server/githubReplyBranding.test.ts
- FAIL: npm run test (unrelated local harness failure in server/agentRunner.test.ts: fake codex binary aborts because copied Node cannot load @rpath/libnode.141.dylib)
- FAIL: npm run test:all (same server/agentRunner.test.ts fake codex dylib failure)