### PR TITLE
fix: harden babysitter log handling

### DIFF
--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -3,7 +3,7 @@ import { chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promi
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { applyFixesWithAgent, checkAgentHealth, detectAgentUnavailability, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand } from "./agentRunner";
+import { applyFixesWithAgent, checkAgentHealth, detectAgentUnavailability, evaluateFixNecessityWithAgent, resolveAgent, resolveCommandPath, runCommand, summarizeAgentCommandFailure } from "./agentRunner";
 
 test("runCommand reports a timeout even when the child exits 0 after SIGTERM", async () => {
   const result = await runCommand(
@@ -153,11 +153,27 @@ test("checkAgentHealth reports codex timeouts instead of stdin prelude", async (
     if (!result.ok) {
       assert.match(result.reason, /timed out after 30000ms/i);
       assert.doesNotMatch(result.reason, /Reading additional input from stdin/);
+      assert.equal(detectAgentUnavailability(result.reason), null);
     }
   } finally {
     process.env.PATH = originalPath;
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("summarizeAgentCommandFailure skips codex stdin prelude", () => {
+  const summary = summarizeAgentCommandFailure({
+    code: 124,
+    stdout: "",
+    stderr: [
+      "Reading additional input from stdin...",
+      "OpenAI Codex v0.128.0 (research preview)",
+      "Command timed out after 900000ms",
+    ].join("\n"),
+    timedOut: true,
+  });
+
+  assert.equal(summary, "Command timed out after 900000ms");
 });
 
 test("applyFixesWithAgent runs codex without deprecated full-auto flag", async () => {

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -47,6 +47,7 @@ const AGENT_HEALTH_ACTIONABLE_PATTERNS = [
   "failed",
   "error:",
 ];
+const STDIN_PRELUDE_PATTERN = /^reading additional input from stdin/i;
 
 const AGENT_CLI_MISSING_PATTERNS = [
   "cli is not installed",
@@ -208,7 +209,7 @@ export async function evaluateFixNecessityWithAgent(params: {
       );
 
       if (result.code !== 0) {
-        throw new Error(`codex evaluation failed (${result.code}): ${result.stderr || result.stdout}`);
+        throw new Error(`codex evaluation failed (${result.code}): ${summarizeAgentCommandFailure(result)}`);
       }
 
       let raw: string;
@@ -216,7 +217,7 @@ export async function evaluateFixNecessityWithAgent(params: {
         raw = await readFile(outputFile, "utf8");
       } catch (error) {
         if (isMissingFileError(error)) {
-          const suffix = result.stderr ? `: ${result.stderr}` : "";
+          const suffix = result.stderr || result.stdout ? `: ${summarizeAgentCommandFailure(result)}` : "";
           throw new Error(
             `codex evaluation completed without writing expected output file ${outputFile}${suffix}`,
             { cause: error },
@@ -346,15 +347,20 @@ function firstOutputLine(output: string): string | null {
 }
 
 function summarizeHealthFailure(result: CommandResult): string {
+  return summarizeAgentCommandFailure(result);
+}
+
+export function summarizeAgentCommandFailure(result: CommandResult): string {
   const lines = (result.stderr.trim() || result.stdout.trim() || "no output")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
   const actionable = lines.findLast((line) =>
     includesAnyPattern(line.toLowerCase(), AGENT_HEALTH_ACTIONABLE_PATTERNS)
-      && !/^reading additional input from stdin/i.test(line)
+      && !STDIN_PRELUDE_PATTERN.test(line)
   );
-  const raw = actionable ?? lines[0] ?? "no output";
+  const fallback = lines.find((line) => !STDIN_PRELUDE_PATTERN.test(line));
+  const raw = actionable ?? fallback ?? lines[0] ?? "no output";
   return raw.length > 220 ? `${raw.slice(0, 217).trimEnd()}...` : raw;
 }
 

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -47,7 +47,7 @@ const AGENT_HEALTH_ACTIONABLE_PATTERNS = [
   "failed",
   "error:",
 ];
-const STDIN_PRELUDE_PATTERN = /^reading additional input from stdin/i;
+export const STDIN_PRELUDE_PATTERN = /^reading additional input from stdin/i;
 
 const AGENT_CLI_MISSING_PATTERNS = [
   "cli is not installed",

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -796,7 +796,7 @@ test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures",
     branch: "feature/example",
     author: "octocat",
     url: "https://github.com/octo/example/pull/42",
-    status: "error",
+    status: "watching",
     feedbackItems: [],
     accepted: 0,
     rejected: 0,
@@ -861,14 +861,27 @@ test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures",
   };
 
   await babysitter.syncAndBabysitTrackedRepos();
+  await babysitter.syncAndBabysitTrackedRepos();
 
   const jobs = await storage.listBackgroundJobs({
     kind: "babysit_pr",
     targetId: pr.id,
   });
+  const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
+  const skipLogs = logs.filter((log) =>
+    log.phase === "watcher"
+    && log.message.includes("Dependency preflight previously failed")
+  );
   assert.equal(jobs.length, 0);
-  assert.ok(logs.some((log) => log.message.includes("Dependency preflight previously failed")));
+  assert.equal(updated?.status, "error");
+  assert.equal(skipLogs.length, 1);
+  assert.deepEqual(skipLogs[0]?.metadata, {
+    repo: "octo/example",
+    headSha: "head-same",
+    reason: "node_modules missing",
+    count: 1,
+  });
 });
 
 test("syncAndBabysitTrackedRepos skips terminal conflict repair failures for the same head and base", async () => {
@@ -4911,6 +4924,77 @@ test("resumeInterruptedRuns enqueues babysit_pr jobs when a background scheduler
   assert.equal(jobs[0].payload.preferredAgent, "codex");
 });
 
+test("babysitPR logs metadata when skipping a duplicate in-progress run", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Busy PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/busy",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  let releaseFetch!: () => void;
+  let markFetchStarted!: () => void;
+  const fetchStarted = new Promise<void>((resolve) => {
+    markFetchStarted = resolve;
+  });
+  const fetchReleased = new Promise<void>((resolve) => {
+    releaseFetch = resolve;
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchPullSummary: async () => {
+        markFetchStarted();
+        await fetchReleased;
+        return makePullSummary(pr);
+      },
+      listFailingStatuses: async () => [],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: false,
+        reason: "No code change needed",
+      }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  const firstRun = babysitter.babysitPR(pr.id, "codex");
+  await fetchStarted;
+  await babysitter.babysitPR(pr.id, "codex");
+  releaseFetch();
+  await firstRun;
+
+  const logs = await storage.getLogs(pr.id);
+  const skipLog = logs.find((log) =>
+    log.phase === "run"
+    && log.message.includes("another run is already in progress")
+  );
+
+  assert.equal(skipLog?.level, "warn");
+  assert.equal(skipLog?.metadata?.reason, "in_progress");
+  assert.equal(skipLog?.metadata?.activePreferredAgent, "codex");
+  assert.equal(skipLog?.metadata?.requestedPreferredAgent, "codex");
+  assert.equal(typeof skipLog?.metadata?.activeRunId, "string");
+  assert.equal(typeof skipLog?.metadata?.activeStartedAt, "string");
+  assert.equal(typeof skipLog?.metadata?.activeAgeMs, "number");
+});
+
 test("runQueuedBabysitPR rejects when evaluation auth fails after recording the run failure", async () => {
   const storage = new MemStorage();
   const existingItem = makeFeedbackItem();
@@ -5910,7 +5994,7 @@ test("babysitPR skips conflict resolution when PR is mergeable", async () => {
       }),
       applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
         onStdoutChunk?.("applied fix\n");
-        onStderrChunk?.("");
+        onStderrChunk?.(Array.from({ length: 125 }, (_, index) => `stderr line ${index + 1}`).join("\n") + "\n");
         return { code: 0, stdout: "applied fix\n", stderr: "" };
       },
       runCommand: async (command: string, args: string[], opts?: Record<string, unknown>) => {
@@ -5930,6 +6014,17 @@ test("babysitPR skips conflict resolution when PR is mergeable", async () => {
   assert.equal(mergeAttempted, false, "Should not attempt merge when PR is mergeable");
   assert.equal(updated?.status, "watching");
   assert.ok(!logs.some((log) => log.phase === "conflict"));
+  const stderrLogs = logs.filter((log) => log.phase === "agent" && log.metadata?.stream === "stderr");
+  assert.ok(stderrLogs.length > 0);
+  assert.ok(stderrLogs.every((log) => log.level === "info"));
+  assert.ok(stderrLogs.some((log) => log.message === "[stderr] stderr line 1"));
+  assert.ok(logs.some((log) =>
+    log.level === "info"
+    && log.phase === "agent"
+    && log.message.includes("output truncated after")
+    && log.metadata?.truncated === true
+  ));
+  assert.ok(!logs.some((log) => log.message.includes("stderr line 121")));
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -73,6 +73,7 @@ const DEPENDENCY_PREFLIGHT_FAILURE_KIND = "dependency_preflight";
 const CONFLICT_REPAIR_FAILURE_KIND = "merge_conflict_repair";
 const CONFLICT_REPAIR_RETRY_BUDGET = 2;
 const CODE_OWNER_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
+const AGENT_STREAM_LOG_LINE_LIMIT = 120;
 const APP_NAME = "oh-my-pr";
 const APP_REPOSITORY_URL = "https://github.com/yungookim/oh-my-pr";
 export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
@@ -1176,7 +1177,7 @@ function formatConciseFailureReason(message: string): string {
   const firstLine = detail
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find((line) => line.length > 0)
+    .find((line) => line.length > 0 && !/^Reading additional input from stdin/i.test(line))
     ?? "No failure details were reported";
   const singleLine = firstLine.replace(/\s+/g, " ");
   const capped = singleLine.length > 180 ? `${singleLine.slice(0, 177).trimEnd()}...` : singleLine;
@@ -1279,7 +1280,11 @@ function wait(ms: number): Promise<void> {
 
 export class PRBabysitter {
   private readonly storage: IStorage;
-  private readonly inProgress = new Set<string>();
+  private readonly inProgress = new Map<string, {
+    preferredAgent: CodingAgent;
+    runId: string;
+    startedAt: string;
+  }>();
   private readonly feedbackMutationLocks = new Map<string, Promise<void>>();
   private readonly github: GitHubService;
   private readonly runtime: BabysitterRuntime;
@@ -2040,15 +2045,24 @@ export class PRBabysitter {
           ? await this.findLatestDependencyPreflightFailure(local.id, pull.headSha)
           : null;
         if (priorDependencyFailure) {
-          await this.storage.addLog(local.id, "warn", "Dependency preflight previously failed for this PR head; skipping automatic babysitter run until the head changes", {
-            phase: "watcher",
-            metadata: {
-              repo: repoSlug,
-              headSha: pull.headSha,
-              reason: priorDependencyFailure.reason,
-              count: priorDependencyFailure.count,
-            },
-          });
+          const lastChecked = this.now().toISOString();
+          if (local.status !== "error") {
+            await this.storage.updatePR(local.id, {
+              status: "error",
+              lastChecked,
+            });
+            await this.storage.addLog(local.id, "warn", "Dependency preflight previously failed for this PR head; skipping automatic babysitter run until the head changes", {
+              phase: "watcher",
+              metadata: {
+                repo: repoSlug,
+                headSha: pull.headSha,
+                reason: priorDependencyFailure.reason,
+                count: priorDependencyFailure.count,
+              },
+            });
+          } else {
+            await this.storage.updatePR(local.id, { lastChecked });
+          }
           continue;
         }
 
@@ -2164,6 +2178,10 @@ export class PRBabysitter {
         phase: "verify.ci",
       });
     }
+    await queueLog(prId, "warn", `CI status did not settle after ${MAX_ATTEMPTS} poll attempt(s)`, {
+      phase: "verify.ci",
+      metadata: { attempts: MAX_ATTEMPTS, headSha },
+    });
     return { status: "timeout", failures: [] };
   }
 
@@ -2180,6 +2198,7 @@ export class PRBabysitter {
       rethrowOnFailure?: boolean;
     },
   ): Promise<void> {
+    const runId = options?.runId || randomUUID();
     const runtimeState = await this.storage.getRuntimeState();
     if (runtimeState.drainMode && !options?.allowDuringDrain) {
       const pr = await this.storage.getPR(prId);
@@ -2191,18 +2210,34 @@ export class PRBabysitter {
       return;
     }
 
-    if (this.inProgress.has(prId)) {
+    const activeRun = this.inProgress.get(prId);
+    if (activeRun) {
       const pr = await this.storage.getPR(prId);
       if (pr) {
+        const activeStartedAtMs = Date.parse(activeRun.startedAt);
+        const activeAgeMs = Number.isNaN(activeStartedAtMs)
+          ? null
+          : Math.max(0, this.now().getTime() - activeStartedAtMs);
         await this.storage.addLog(pr.id, "warn", "Babysitter run skipped because another run is already in progress", {
           phase: "run",
+          metadata: {
+            reason: "in_progress",
+            activeRunId: activeRun.runId,
+            activePreferredAgent: activeRun.preferredAgent,
+            activeStartedAt: activeRun.startedAt,
+            activeAgeMs,
+            requestedPreferredAgent: preferredAgent,
+          },
         });
       }
       return;
     }
 
-    this.inProgress.add(prId);
-    const runId = options?.runId || randomUUID();
+    this.inProgress.set(prId, {
+      runId,
+      preferredAgent,
+      startedAt: this.now().toISOString(),
+    });
     const auditWindowStartMs = Math.floor(Date.now() / 1000) * 1000 - 1000;
     let logQueue = Promise.resolve();
     const runCreatedAt = new Date().toISOString();
@@ -2533,8 +2568,8 @@ export class PRBabysitter {
         }
 
         const cwd = worktreePath;
-        const stdoutLogger = createChunkLogger(pr.id, "code-owner-fallback", "stdout", "info");
-        const stderrLogger = createChunkLogger(pr.id, "code-owner-fallback", "stderr", "warn");
+        const stdoutLogger = createChunkLogger(pr.id, "code-owner-fallback", "stdout", "info", AGENT_STREAM_LOG_LINE_LIMIT);
+        const stderrLogger = createChunkLogger(pr.id, "code-owner-fallback", "stderr", "info", AGENT_STREAM_LOG_LINE_LIMIT);
 
         try {
           await queueLog(pr.id, "info", `Launching ${agent} code-owner fallback after default run failure`, {
@@ -2543,7 +2578,7 @@ export class PRBabysitter {
               agent,
               cwd,
               timeoutMs: CODE_OWNER_FALLBACK_TIMEOUT_MS,
-              prompt,
+              promptChars: prompt.length,
             },
           });
 
@@ -3648,8 +3683,8 @@ export class PRBabysitter {
                 throw new TerminalBabysitterError(reason);
               }
 
-              const conflictStdout = createChunkLogger(pr.id, "conflict.agent", "stdout", "info");
-              const conflictStderr = createChunkLogger(pr.id, "conflict.agent", "stderr", "warn");
+              const conflictStdout = createChunkLogger(pr.id, "conflict.agent", "stdout", "info", AGENT_STREAM_LOG_LINE_LIMIT);
+              const conflictStderr = createChunkLogger(pr.id, "conflict.agent", "stderr", "info", AGENT_STREAM_LOG_LINE_LIMIT);
               const githubTokenForConflict = await this.github.resolveGitHubAuthToken(config);
               const conflictAgentEnv = githubTokenForConflict
                 ? {
@@ -3668,7 +3703,7 @@ export class PRBabysitter {
 
               await queueLog(pr.id, "info", `Launching ${agent} to resolve merge conflicts`, {
                 phase: "conflict.agent",
-                metadata: { agent, prompt: conflictPrompt },
+                metadata: { agent, promptChars: conflictPrompt.length },
               });
 
               await postAgentCommandComment(agent, conflictPrompt);
@@ -3784,8 +3819,8 @@ export class PRBabysitter {
           }
 
           if (shouldRunForcedReplay || effectiveCommentTasks.length > 0 || statusTasks.length > 0 || hasDocsTask) {
-            const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info");
-            const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "warn");
+            const agentStdout = createChunkLogger(pr.id, "agent", "stdout", "info", AGENT_STREAM_LOG_LINE_LIMIT);
+            const agentStderr = createChunkLogger(pr.id, "agent", "stderr", "info", AGENT_STREAM_LOG_LINE_LIMIT);
             const githubToken = await this.github.resolveGitHubAuthToken(config);
             const agentEnv = githubToken
               ? {
@@ -3812,7 +3847,7 @@ export class PRBabysitter {
 
             await queueLog(pr.id, "info", `Launching ${agent} in autonomous mode`, {
               phase: "agent",
-              metadata: { githubAuth: Boolean(githubToken), prompt: fixPrompt },
+              metadata: { githubAuth: Boolean(githubToken), promptChars: fixPrompt.length },
             });
             await updateRunRecord({
               phase: "run.agent-running",

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -11,6 +11,7 @@ import {
   isAgentUnavailableError,
   resolveAgent,
   runCommand,
+  STDIN_PRELUDE_PATTERN,
   summarizeCommandResult,
   type AgentHealthResult,
   type CodingAgent,
@@ -1177,7 +1178,7 @@ function formatConciseFailureReason(message: string): string {
   const firstLine = detail
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find((line) => line.length > 0 && !/^Reading additional input from stdin/i.test(line))
+    .find((line) => line.length > 0 && !STDIN_PRELUDE_PATTERN.test(line))
     ?? "No failure details were reported";
   const singleLine = firstLine.replace(/\s+/g, " ");
   const capped = singleLine.length > 180 ? `${singleLine.slice(0, 177).trimEnd()}...` : singleLine;


### PR DESCRIPTION
## Summary
- summarize Codex command failures without the stdin prelude so timeouts and permission errors stay actionable
- cap agent stderr/stdout log capture and downgrade routine agent stderr to info while preserving failure summaries
- quiet repeated same-head dependency-preflight skips once the PR is marked error, enrich duplicate-run skip metadata, and log CI settle timeouts

## Verification
- node --test --import tsx server/agentRunner.test.ts
- node --test --import tsx server/babysitter.test.ts --test-name-pattern "dependency preflight|duplicate in-progress|mergeable|code-owner fallback"
- npm run check
- node --test --import tsx server/*.test.ts
- npm run build
- git diff --check

Note: attempted the repo-required claude /simplify pre-commit pass, but the local claude CLI produced no output for roughly two minutes and was stopped.