### PR TITLE
[codex] Show update instructions in banner

### DIFF
--- a/client/src/components/UpdateBanner.tsx
+++ b/client/src/components/UpdateBanner.tsx
@@ -5,6 +5,7 @@ import {
   APP_UPDATE_SESSION_STORAGE_KEY,
   formatAppVersionLabel,
   getAppUpdateDismissKey,
+  getAppUpdateInstructionSteps,
   shouldShowAppUpdateBanner,
 } from "@/lib/updateAlert";
 
@@ -30,17 +31,34 @@ export function UpdateBanner() {
     return null;
   }
 
+  const updateInstructionSteps = getAppUpdateInstructionSteps();
+
   return (
     <div className="shrink-0 border-b border-warning-border bg-warning-muted">
-      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-3 text-[12px]">
-          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
-          <span className="font-medium uppercase tracking-wider text-warning-foreground">
-            Update available
-          </span>
-          <span className="text-foreground/75">
-            {`oh-my-pr ${formatAppVersionLabel(status.latestVersion)} is available. You're on ${formatAppVersionLabel(status.currentVersion)}.`}
-          </span>
+      <div className="grid gap-2 px-4 py-2 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+        <div className="min-w-0 space-y-1.5">
+          <div className="flex min-w-0 flex-wrap items-center gap-3 text-[12px]">
+            <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
+            <span className="font-medium uppercase tracking-wider text-warning-foreground">
+              Update available
+            </span>
+            <span className="text-foreground/75">
+              {`oh-my-pr ${formatAppVersionLabel(status.latestVersion)} is available. You're on ${formatAppVersionLabel(status.currentVersion)}.`}
+            </span>
+          </div>
+          <ol className="flex flex-wrap gap-x-4 gap-y-1 pl-4 text-[11px] text-foreground/70">
+            {updateInstructionSteps.map((step) => (
+              <li key={`${step.text}:${step.command ?? ""}`} className="list-decimal pl-0.5">
+                {step.command ? (
+                  <>
+                    {step.text} <code className="font-mono text-foreground">{step.command}</code>.
+                  </>
+                ) : (
+                  step.text
+                )}
+              </li>
+            ))}
+          </ol>
         </div>
         <div className="flex items-center gap-3 text-[11px]">
           <a

--- a/client/src/components/UpdateBanner.tsx
+++ b/client/src/components/UpdateBanner.tsx
@@ -46,9 +46,9 @@ export function UpdateBanner() {
               {`oh-my-pr ${formatAppVersionLabel(status.latestVersion)} is available. You're on ${formatAppVersionLabel(status.currentVersion)}.`}
             </span>
           </div>
-          <ol className="flex flex-wrap gap-x-4 gap-y-1 pl-4 text-[11px] text-foreground/70">
+          <ol className="list-decimal space-y-1 pl-5 text-[11px] text-foreground/70">
             {updateInstructionSteps.map((step) => (
-              <li key={`${step.text}:${step.command ?? ""}`} className="list-decimal pl-0.5">
+              <li key={`${step.text}:${step.command ?? ""}`} className="pl-0.5">
                 {step.command ? (
                   <>
                     {step.text} <code className="font-mono text-foreground">{step.command}</code>.

--- a/client/src/lib/updateAlert.test.ts
+++ b/client/src/lib/updateAlert.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { AppUpdateStatus } from "@shared/schema";
 import {
+  APP_UPDATE_INSTALL_COMMAND,
   formatAppVersionLabel,
   getAppUpdateDismissKey,
+  getAppUpdateInstructionSteps,
   shouldShowAppUpdateBanner,
 } from "./updateAlert";
 
@@ -35,4 +37,13 @@ test("shouldShowAppUpdateBanner stays hidden when no update is available", () =>
     }, null),
     false,
   );
+});
+
+test("getAppUpdateInstructionSteps describes the npm update flow", () => {
+  assert.equal(APP_UPDATE_INSTALL_COMMAND, "npm install -g oh-my-pr@latest");
+  assert.deepEqual(getAppUpdateInstructionSteps(), [
+    { text: "Stop the running oh-my-pr process." },
+    { text: "Run", command: "npm install -g oh-my-pr@latest" },
+    { text: "Start oh-my-pr again." },
+  ]);
 });

--- a/client/src/lib/updateAlert.ts
+++ b/client/src/lib/updateAlert.ts
@@ -1,6 +1,20 @@
 import type { AppUpdateStatus } from "@shared/schema";
 
 export const APP_UPDATE_SESSION_STORAGE_KEY = "app-update-dismissed";
+export const APP_UPDATE_INSTALL_COMMAND = "npm install -g oh-my-pr@latest";
+
+export type AppUpdateInstructionStep = {
+  text: string;
+  command?: string;
+};
+
+export function getAppUpdateInstructionSteps(): AppUpdateInstructionStep[] {
+  return [
+    { text: "Stop the running oh-my-pr process." },
+    { text: "Run", command: APP_UPDATE_INSTALL_COMMAND },
+    { text: "Start oh-my-pr again." },
+  ];
+}
 
 export function formatAppVersionLabel(version: string): string {
   return version.startsWith("v") ? version : `v${version}`;

--- a/client/src/lib/updateBannerSurface.test.ts
+++ b/client/src/lib/updateBannerSurface.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import * as ts from "typescript";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(testDir, "../../..");
+
+function walk(sourceFile: ts.SourceFile, callback: (node: ts.Node) => void) {
+  const visit = (node: ts.Node) => {
+    callback(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
+function getClassName(sourceFile: ts.SourceFile, node: ts.JsxOpeningElement) {
+  const classAttribute = node.attributes.properties.find(
+    (property): property is ts.JsxAttribute =>
+      ts.isJsxAttribute(property) && property.name.getText(sourceFile) === "className",
+  );
+
+  if (!classAttribute?.initializer || !ts.isStringLiteral(classAttribute.initializer)) {
+    return undefined;
+  }
+
+  return classAttribute.initializer.text;
+}
+
+async function parseUpdateBanner() {
+  const relativePath = "client/src/components/UpdateBanner.tsx";
+  const source = await readFile(path.join(projectRoot, relativePath), "utf-8");
+  return ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+test("UpdateBanner styles update steps as a numbered ordered list", async () => {
+  const sourceFile = await parseUpdateBanner();
+  let orderedListClassName: string | undefined;
+  const listItemClassNames: string[] = [];
+
+  walk(sourceFile, (node) => {
+    if (!ts.isJsxOpeningElement(node)) {
+      return;
+    }
+
+    const tagName = node.tagName.getText(sourceFile);
+    if (tagName === "ol") {
+      orderedListClassName = getClassName(sourceFile, node);
+    }
+    if (tagName === "li") {
+      const className = getClassName(sourceFile, node);
+      if (className) {
+        listItemClassNames.push(className);
+      }
+    }
+  });
+
+  assert.ok(orderedListClassName, "Expected UpdateBanner to render an ordered list");
+
+  const orderedListClasses = orderedListClassName.split(/\s+/);
+  assert.ok(
+    orderedListClasses.includes("list-decimal"),
+    "Expected list-decimal on the ordered list so browser markers render",
+  );
+  assert.ok(
+    !orderedListClasses.includes("flex") && !orderedListClasses.includes("flex-wrap"),
+    "Expected the ordered list not to use flex classes that suppress browser markers",
+  );
+  assert.ok(
+    listItemClassNames.every((className) => !className.split(/\s+/).includes("list-decimal")),
+    "Expected decimal marker styling to live on the ordered list parent",
+  );
+});

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -295,7 +295,13 @@ oh-my-pr --no-log-file
 <p>On builds where <code>APP_VERSION</code> is a stable semver string, the dashboard calls
 <code>GET /api/app-update</code> and compares the running version to the latest stable
 GitHub release for <code>yungookim/oh-my-pr</code>. When a newer release exists, the
-dashboard shows an update banner with a link to the matching release page.</p>
+dashboard shows an update banner with a link to the matching release page and
+step-by-step npm update instructions:</p>
+<ol>
+<li>Stop the running <code>oh-my-pr</code> process.</li>
+<li>Run <code>npm install -g oh-my-pr@latest</code>.</li>
+<li>Start <code>oh-my-pr</code> again.</li>
+</ol>
 <p>Selecting <code>dismiss for now</code> stores a release-scoped key in browser
 <code>sessionStorage</code>, so the banner stays hidden only for the current browser
 session and only for that specific <code>latestVersion</code>. Opening a new browser

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -104,7 +104,12 @@ Runtime drain mode also blocks manual release creation and release retries until
 On builds where `APP_VERSION` is a stable semver string, the dashboard calls
 `GET /api/app-update` and compares the running version to the latest stable
 GitHub release for `yungookim/oh-my-pr`. When a newer release exists, the
-dashboard shows an update banner with a link to the matching release page.
+dashboard shows an update banner with a link to the matching release page and
+step-by-step npm update instructions:
+
+1. Stop the running `oh-my-pr` process.
+2. Run `npm install -g oh-my-pr@latest`.
+3. Start `oh-my-pr` again.
 
 Selecting `dismiss for now` stores a release-scoped key in browser
 `sessionStorage`, so the banner stays hidden only for the current browser


### PR DESCRIPTION
## Summary

- Add step-by-step npm update instructions to the existing app update banner
- Centralize the update command and steps in the update alert helper
- Document the banner's npm update flow in public configuration docs

## Verification

- `npx tsx --test client/src/lib/updateAlert.test.ts`
- `npm run test:all`
- `npm run check`
- `npm run build`
- `npx tsx --test server/packagedBundle.test.ts`
- `npm run lint`

## Note

The repo-required Claude `/simplify` pass was attempted, but the CLI process produced no output and hung until it was terminated. The diff was unchanged after that attempt.
