### PR TITLE
fix: reduce babysitter log noise

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -127,6 +127,37 @@ test("runtime setDrainMode logs enable and disable transitions", async () => {
   assert.match(ring, /Drain mode disabled/);
 });
 
+test("runtime logs watcher lifecycle when background watcher starts and stops", async () => {
+  const storage = new MemStorage();
+  let watcherRuns = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: true,
+    watcherScheduler: {
+      run: () => {
+        watcherRuns += 1;
+      },
+      runAndReportErrors: async () => {
+        watcherRuns += 1;
+      },
+    },
+  });
+
+  _resetRingBufferForTests();
+
+  await runtime.start();
+  runtime.stop();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+  const ring = readRingBuffer().join("\n");
+  assert.equal(watcherRuns, 1);
+  assert.match(ring, /Repository watcher started/);
+  assert.match(ring, /pollIntervalMs/);
+  assert.match(ring, /Repository watcher stopped/);
+});
+
 test("runtime askQuestion persists the question and enqueues a durable job", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -645,8 +645,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     watcherIntervalMs = interval;
     watcherTimer = setInterval(() => {
+      log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher heartbeat");
       void runWatcher();
     }, interval);
+    log.info({ pollIntervalMs: interval }, "Repository watcher started");
   };
 
   const queueBabysitWithAgent = async (pr: PR, preferredAgent: Config["codingAgent"]) => {
@@ -727,6 +729,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (watcherTimer) {
         clearInterval(watcherTimer);
         watcherTimer = null;
+        log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher stopped");
       }
     },
 

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -754,6 +754,86 @@ test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitt
   ));
 });
 
+test("syncAndBabysitTrackedRepos queues unchanged PR heads when feedback sync fails before no-op suppression", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  await storage.updateConfig({ autoUpdateDocs: false });
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Already checked",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+
+  const openPull = {
+    number: 42,
+    title: "Already checked",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    headSha: "same-head",
+    baseRef: "main",
+    baseSha: "base123",
+  };
+  let failFeedbackSync = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchFeedbackItemsForPR: async () => {
+        if (failFeedbackSync) {
+          throw new Error("GitHub authentication failed while loading feedback");
+        }
+        return [];
+      },
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "same-head" }),
+      listFailingStatuses: async () => [],
+      listOpenPullsForRepo: async () => [openPull],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+  failFeedbackSync = true;
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(jobs.length, 1);
+  assert.ok(logs.some((log) =>
+    log.phase === "watcher"
+    && log.level === "warn"
+    && log.message.includes("Could not sync GitHub feedback before no-op suppression")
+  ));
+  assert.ok(!logs.some((log) =>
+    log.phase === "watcher"
+    && log.message.includes("Skipping babysitter run because the same PR head was already checked with no necessary fixes")
+  ));
+});
+
 test("syncAndBabysitTrackedRepos refreshes repository status during drain without queueing babysits", async () => {
   const storage = new MemStorage();
   const backgroundJobQueue = new BackgroundJobQueue(storage);
@@ -1618,7 +1698,10 @@ test("syncAndBabysitTrackedRepos pauses automation when the selected agent is un
   assert.equal(updated?.feedbackItems[1]?.status, "failed");
   assert.match(updated?.feedbackItems[1]?.statusReason ?? "", /Claude authentication failed/);
   assert.deepEqual(scheduled, []);
-  assert.ok(logs.some((log) => log.message.includes("Automation paused")));
+  const pauseLog = logs.find((log) => log.message.includes("Automation paused"));
+  assert.ok(pauseLog);
+  assert.equal(pauseLog.metadata?.agent, "claude");
+  assert.equal(pauseLog.metadata?.classification, "auth");
 });
 
 test("syncAndBabysitTrackedRepos does not enter drain mode for transient agent health timeouts", async () => {
@@ -1683,7 +1766,10 @@ test("syncAndBabysitTrackedRepos does not enter drain mode for transient agent h
   assert.equal(runtimeState.drainReason, null);
   assert.equal(updated?.feedbackItems[0]?.status, "queued");
   assert.equal(updated?.feedbackItems[1]?.status, "in_progress");
-  assert.ok(logs.some((log) => log.message.includes("Automation skipped")));
+  const skipLog = logs.find((log) => log.message.includes("Automation skipped"));
+  assert.ok(skipLog);
+  assert.equal(skipLog.metadata?.agent, "codex");
+  assert.equal(skipLog.metadata?.classification, null);
   assert.ok(logs.some((log) => log.message.includes("Command timed out after 30000ms")));
   assert.ok(logs.every((log) => !log.message.includes("Automation paused")));
 });
@@ -4441,6 +4527,80 @@ test("babysitPR logs successful git stderr as info during docs assessment", asyn
     const stderrLogs = logs.filter((log) => log.message.includes("[stderr] From https://github.com/alex-morgan-o/lolodex"));
     assert.ok(stderrLogs.length >= 1);
     assert.ok(stderrLogs.every((log) => log.level === "info"));
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR replays failed git stderr as warn during docs assessment", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs stderr failure",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  const baseRunCommand = makeGitRunCommand({ localHeadSha: "abc123", remoteHeadSha: "abc123" });
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "Docs are still accurate" }),
+        applyFixesWithAgent: async () => {
+          throw new Error("Should not run the agent when docs assessment cannot fetch base");
+        },
+        runCommand: async (command, args, options) => {
+          if (command === "git" && args[0] === "fetch" && args[1] === "origin") {
+            const stderr = "fatal: could not read Username\n";
+            options?.onStderrChunk?.(stderr);
+            return { code: 1, stdout: "", stderr };
+          }
+
+          const result = await baseRunCommand(command, args);
+          options?.onStdoutChunk?.(result.stdout);
+          options?.onStderrChunk?.(result.stderr);
+          return result;
+        },
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const logs = await storage.getLogs(pr.id);
+    assert.ok(logs.some((log) =>
+      log.phase === "evaluate.docs"
+      && log.level === "warn"
+      && log.message === "[stderr] fatal: could not read Username"
+    ));
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -301,6 +301,103 @@ test("pollForCICompletion returns timeout when status API keeps failing, includi
   assert.ok(logs.some((log) => log.level === "warn" && log.message.includes("Final CI status check after timeout failed")));
 });
 
+test("pollForCICompletion includes pending check details when checks never settle", async () => {
+  const storage = new MemStorage();
+  const logs: Array<{
+    level: "info" | "warn" | "error";
+    message: string;
+    metadata?: Record<string, unknown> | null;
+  }> = [];
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [],
+      fetchPullSummary: async () => {
+        throw new Error("unused");
+      },
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => false,
+      fetchCheckSnapshotsForRef: async (_octokit: unknown, _repo: unknown, prId: string, headSha: string) => [
+        makeCheckSnapshot({
+          id: "build",
+          prId,
+          sha: headSha,
+          context: "Backend Build",
+          status: "queued",
+          conclusion: null,
+          description: "Waiting for a runner",
+          targetUrl: "https://github.com/octo/example/actions/runs/1",
+        }),
+        makeCheckSnapshot({
+          id: "e2e",
+          prId,
+          sha: headSha,
+          context: "Playwright E2E",
+          status: "in_progress",
+          conclusion: null,
+          description: "Still running",
+          targetUrl: "https://github.com/octo/example/actions/runs/2",
+        }),
+      ],
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => undefined,
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => undefined,
+      addReactionToComment: async () => undefined,
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => undefined,
+      postPRComment: async () => undefined,
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  const result = await (babysitter as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>).pollForCICompletion(
+    {} as never,
+    { owner: "octo", repo: "example" },
+    { owner: "octo", repo: "example", number: 42 },
+    "abc123",
+    "pr-1",
+    async (
+      _prId: string,
+      level: "info" | "warn" | "error",
+      message: string,
+      opts?: { metadata?: Record<string, unknown> | null },
+    ) => {
+      logs.push({ level, message, metadata: opts?.metadata ?? null });
+    },
+  );
+
+  assert.deepEqual(result, { status: "timeout", failures: [] });
+  const timeoutLog = logs.find((log) => log.message.includes("CI status did not settle"));
+  assert.equal(timeoutLog?.level, "warn");
+  assert.match(timeoutLog?.message ?? "", /Backend Build/);
+  assert.match(timeoutLog?.message ?? "", /Playwright E2E/);
+  assert.deepEqual(timeoutLog?.metadata?.pendingChecks, [
+    {
+      context: "Backend Build",
+      status: "queued",
+      conclusion: null,
+      description: "Waiting for a runner",
+      targetUrl: "https://github.com/octo/example/actions/runs/1",
+    },
+    {
+      context: "Playwright E2E",
+      status: "in_progress",
+      conclusion: null,
+      description: "Still running",
+      targetUrl: "https://github.com/octo/example/actions/runs/2",
+    },
+  ]);
+});
+
 test("syncFeedbackForPR logs completion even when no new feedback items arrive", async () => {
   const storage = new MemStorage();
   const existingItem = makeFeedbackItem();
@@ -577,6 +674,84 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
   assert.equal(jobs[0].payload.activityLabel, "Babysitting PR #42");
   assert.equal(jobs[0].payload.activityDetail, "octo/example - Example PR");
   assert.equal(jobs[0].payload.activityTargetUrl, pr.url);
+});
+
+test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitter run", async () => {
+  const storage = new MemStorage();
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  await storage.updateConfig({ autoUpdateDocs: false });
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Already checked",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: true,
+  });
+
+  const openPull = {
+    number: 42,
+    title: "Already checked",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    headSha: "same-head",
+    baseRef: "main",
+    baseSha: "base123",
+  };
+  let feedbackFetches = 0;
+  let failingStatusFetches = 0;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetches += 1;
+        return [];
+      },
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "same-head" }),
+      listFailingStatuses: async () => {
+        failingStatusFetches += 1;
+        return [];
+      },
+      listOpenPullsForRepo: async () => [openPull],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const logs = await storage.getLogs(pr.id);
+  assert.equal(jobs.length, 0);
+  assert.ok(feedbackFetches >= 2);
+  assert.ok(failingStatusFetches >= 2);
+  assert.ok(logs.some((log) =>
+    log.phase === "watcher"
+    && log.message.includes("Skipping babysitter run because the same PR head was already checked with no necessary fixes")
+  ));
 });
 
 test("syncAndBabysitTrackedRepos refreshes repository status during drain without queueing babysits", async () => {
@@ -4182,6 +4357,90 @@ test("babysitPR caps verbose diff preview logs during docs assessment", async ()
     assert.equal(previewLogs.length, 20);
     assert.ok(logs.some((log) => log.phase === "evaluate.docs" && log.message.includes("[stdout] output truncated after 20 line(s)")));
     assert.match(capturedDocsPrompt, /\+changed implementation line 120/);
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+});
+
+test("babysitPR logs successful git stderr as info during docs assessment", async () => {
+  const storage = new MemStorage();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Docs stderr",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  const baseRunCommand = makeGitRunCommand({ localHeadSha: "abc123", remoteHeadSha: "abc123" });
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        buildOctokit: async () => ({}) as never,
+        fetchFeedbackItemsForPR: async () => [],
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "abc123" }),
+        listFailingStatuses: async () => [],
+        checkCISettled: async () => true,
+        listOpenPullsForRepo: async () => [],
+        postFollowUpForFeedbackItem: async () => undefined,
+        resolveReviewThread: async () => undefined,
+        resolveGitHubAuthToken: async () => "test-token",
+        addReactionToComment: async () => {},
+        postStatusReplyForFeedbackItem: async () => null,
+        updateStatusReply: async () => {},
+      },
+      {
+        resolveAgent: async () => "codex",
+        ciPollIntervalMs: 0,
+        evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "Docs are still accurate" }),
+        applyFixesWithAgent: async () => {
+          throw new Error("Should not run the agent when docs assessment says no fix is needed");
+        },
+        runCommand: async (command, args, options) => {
+          if (command === "git" && args[0] === "-C" && args[2] === "fetch") {
+            const stderr = "From https://github.com/alex-morgan-o/lolodex\n";
+            options?.onStderrChunk?.(stderr);
+            return { code: 0, stdout: "", stderr };
+          }
+
+          if (command === "git" && args[0] === "diff" && args[1] === "--name-only") {
+            return { code: 0, stdout: "README.md\n", stderr: "" };
+          }
+
+          if (command === "git" && args[0] === "diff" && args[1] === "--stat") {
+            return { code: 0, stdout: "README.md | 1 +\n", stderr: "" };
+          }
+
+          if (command === "git" && args[0] === "diff" && args[1] === "--no-color") {
+            return { code: 0, stdout: "+docs line\n", stderr: "" };
+          }
+
+          const result = await baseRunCommand(command, args);
+          options?.onStdoutChunk?.(result.stdout);
+          options?.onStderrChunk?.(result.stderr);
+          return result;
+        },
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+
+    const logs = await storage.getLogs(pr.id);
+    const stderrLogs = logs.filter((log) => log.message.includes("[stderr] From https://github.com/alex-morgan-o/lolodex"));
+    assert.ok(stderrLogs.length >= 1);
+    assert.ok(stderrLogs.every((log) => log.level === "info"));
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -4596,11 +4596,12 @@ test("babysitPR replays failed git stderr as warn during docs assessment", async
     await babysitter.babysitPR(pr.id, "codex");
 
     const logs = await storage.getLogs(pr.id);
-    assert.ok(logs.some((log) =>
+    const stderrLogs = logs.filter((log) =>
       log.phase === "evaluate.docs"
-      && log.level === "warn"
       && log.message === "[stderr] fatal: could not read Username"
-    ));
+    );
+    assert.equal(stderrLogs.length, 1);
+    assert.equal(stderrLogs[0]?.level, "warn");
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -2476,6 +2476,7 @@ export class PRBabysitter {
       stream: "stdout" | "stderr",
       level: "info" | "warn",
       maxLines?: number,
+      options?: { logLines?: boolean },
     ) => {
       let buffer = "";
       let loggedLines = 0;
@@ -2484,6 +2485,10 @@ export class PRBabysitter {
 
       const enqueueLine = (trimmed: string) => {
         capturedLines.push(trimmed);
+        if (options?.logLines === false) {
+          return logQueue;
+        }
+
         if (maxLines !== undefined && loggedLines >= maxLines) {
           if (!loggedTruncation) {
             loggedTruncation = true;
@@ -2525,6 +2530,35 @@ export class PRBabysitter {
       };
     };
 
+    const emitCapturedStreamLines = async (
+      currentPrId: string,
+      phase: string,
+      stream: "stdout" | "stderr",
+      level: "info" | "warn",
+      lines: string[],
+      maxLines?: number,
+      metadata?: Record<string, unknown>,
+    ) => {
+      let loggedLines = 0;
+      for (const line of lines) {
+        if (maxLines !== undefined && loggedLines >= maxLines) {
+          await queueLog(currentPrId, level, `[${stream}] output truncated after ${maxLines} line(s)`, {
+            phase,
+            metadata: metadata ? { stream, truncated: true, maxLines, ...metadata } : { stream, truncated: true, maxLines },
+          });
+          return;
+        }
+
+        loggedLines += 1;
+        await queueLog(currentPrId, level, `[${stream}] ${line}`, {
+          phase,
+          metadata: metadata ? { stream, ...metadata } : { stream },
+        });
+      }
+
+      await logQueue;
+    };
+
     const runLoggedCommand = async (params: {
       currentPrId: string;
       command: string;
@@ -2542,7 +2576,9 @@ export class PRBabysitter {
       });
 
       const stdoutLogger = createChunkLogger(currentPrId, phase, "stdout", "info", maxOutputLogLines);
-      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "info", maxOutputLogLines);
+      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "info", maxOutputLogLines, {
+        logLines: false,
+      });
 
       const result = await this.runtime.runCommand(command, args, {
         cwd,
@@ -2555,18 +2591,15 @@ export class PRBabysitter {
       await stderrLogger.flush();
 
       if (result.code === 0) {
+        await emitCapturedStreamLines(currentPrId, phase, "stderr", "info", stderrLogger.getCapturedLines(), maxOutputLogLines);
         await queueLog(currentPrId, "info", successMessage, {
           phase,
           metadata: { command: formatCommand(command, args), code: result.code },
         });
       } else {
-        const capturedStderrLines = stderrLogger.getCapturedLines();
-        for (const line of capturedStderrLines) {
-          await queueLog(currentPrId, "warn", `[stderr] ${line}`, {
-            phase,
-            metadata: { stream: "stderr", reemittedFor: "failure" },
-          });
-        }
+        await emitCapturedStreamLines(currentPrId, phase, "stderr", "warn", stderrLogger.getCapturedLines(), maxOutputLogLines, {
+          reemittedFor: "failure",
+        });
         await queueLog(currentPrId, "error", `${formatCommand(command, args)} failed (${result.code})`, {
           phase,
           metadata: {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -14,6 +14,7 @@ import {
   STDIN_PRELUDE_PATTERN,
   summarizeCommandResult,
   type AgentHealthResult,
+  type AgentUnavailabilityKind,
   type CodingAgent,
 } from "./agentRunner";
 import {
@@ -1209,6 +1210,23 @@ function summarizeUnknownError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function classifyFeedbackSyncError(error: unknown): "auth" | "rate_limit" | "network" | "not_found" | "unknown" {
+  const message = summarizeUnknownError(error).toLowerCase();
+  if (/\b(401|unauthor|forbidden|bad credentials|authentication|token)\b/.test(message)) {
+    return "auth";
+  }
+  if (/\b(rate limit|abuse detection|secondary rate|429)\b/.test(message)) {
+    return "rate_limit";
+  }
+  if (/\b(404|not found)\b/.test(message)) {
+    return "not_found";
+  }
+  if (/\b(econnreset|enotfound|eai_again|network|timeout|timed out|fetch failed|socket hang up)\b/.test(message)) {
+    return "network";
+  }
+  return "unknown";
+}
+
 function getNextCodingAgent(agent: CodingAgent): CodingAgent {
   return agent === "claude" ? "codex" : "claude";
 }
@@ -1467,20 +1485,22 @@ export class PRBabysitter {
   }
 
   private async findLatestNoOpCheck(prId: string, headSha: string): Promise<NoOpCheckMarker | null> {
-    const completedRuns = (await this.storage.listAgentRuns({ prId, status: "completed" }))
-      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+    const matchingRuns = await this.storage.listAgentRuns({
+      prId,
+      status: "completed",
+      initialHeadSha: headSha,
+      orderBy: "updatedAt",
+      order: "desc",
+      limit: 1,
+    });
 
-    for (const run of completedRuns) {
-      const marker = readNoOpCheck(run.metadata);
-      const runHeadSha = marker?.headSha ?? run.initialHeadSha;
-      if (runHeadSha !== headSha) {
-        continue;
-      }
-
-      return marker?.kind === NO_OP_CHECK_KIND ? marker : null;
+    const latest = matchingRuns[0];
+    if (!latest) {
+      return null;
     }
 
-    return null;
+    const marker = readNoOpCheck(latest.metadata);
+    return marker?.kind === NO_OP_CHECK_KIND ? marker : null;
   }
 
   private async readAgentHealth(agent: CodingAgent): Promise<AgentHealthResult> {
@@ -1497,7 +1517,12 @@ export class PRBabysitter {
     return result;
   }
 
-  private async pauseAutomationForAgentFailure(agent: CodingAgent, reason: string, prIds: string[]): Promise<void> {
+  private async pauseAutomationForAgentFailure(
+    agent: CodingAgent,
+    reason: string,
+    prIds: string[],
+    classification: AgentUnavailabilityKind,
+  ): Promise<void> {
     const message = `Agent health check failed for ${agent}: ${reason}`;
     await this.storage.updateRuntimeState({
       drainMode: true,
@@ -1526,6 +1551,7 @@ export class PRBabysitter {
 
       await this.storage.addLog(prId, "error", `Automation paused: ${message}`, {
         phase: "agent.health",
+        metadata: { agent, classification },
       });
     }));
   }
@@ -1537,12 +1563,14 @@ export class PRBabysitter {
     }
 
     const message = `Agent health check failed for ${agent}: ${health.reason}`;
-    if (detectAgentUnavailability(health.reason) !== null) {
-      await this.pauseAutomationForAgentFailure(agent, health.reason, prIds);
+    const classification = detectAgentUnavailability(health.reason);
+    if (classification !== null) {
+      await this.pauseAutomationForAgentFailure(agent, health.reason, prIds, classification);
     } else {
       await Promise.all(prIds.map(async (prId) => {
         await this.storage.addLog(prId, "warn", `Automation skipped: ${message}`, {
           phase: "agent.health",
+          metadata: { agent, classification: null },
         });
       }));
     }
@@ -2166,7 +2194,7 @@ export class PRBabysitter {
           ? await this.findLatestNoOpCheck(local.id, pull.headSha)
           : null;
         if (priorNoOpCheck) {
-          let syncedLocal: typeof local;
+          let syncedLocal: typeof local | null = null;
           try {
             syncedLocal = await this.syncFeedbackForPR(local.id, {
               phase: "watcher",
@@ -2174,23 +2202,33 @@ export class PRBabysitter {
           } catch (error) {
             await this.storage.addLog(local.id, "warn", `Could not sync GitHub feedback before no-op suppression: ${summarizeUnknownError(error)}`, {
               phase: "watcher",
+              metadata: {
+                repo: repoSlug,
+                headSha: pull.headSha,
+                errorClass: classifyFeedbackSyncError(error),
+              },
             });
-            syncedLocal = await this.storage.getPR(local.id) ?? local;
           }
 
           let failingStatuses: GitHubStatusFailure[] | null = null;
-          try {
-            failingStatuses = await this.github.listFailingStatuses(octokit, repo, pull.headSha);
-          } catch (error) {
-            await this.storage.addLog(local.id, "warn", `Could not check CI status before no-op suppression: ${summarizeUnknownError(error)}`, {
-              phase: "watcher",
-            });
+          if (syncedLocal) {
+            try {
+              failingStatuses = await this.github.listFailingStatuses(octokit, repo, pull.headSha);
+            } catch (error) {
+              await this.storage.addLog(local.id, "warn", `Could not check CI status before no-op suppression: ${summarizeUnknownError(error)}`, {
+                phase: "watcher",
+                metadata: {
+                  repo: repoSlug,
+                  headSha: pull.headSha,
+                },
+              });
+            }
           }
 
-          const hasPendingFeedback = syncedLocal.feedbackItems.some((item) =>
+          const hasPendingFeedback = syncedLocal?.feedbackItems.some((item) =>
             item.status === "pending" || item.status === "queued" || item.status === "in_progress"
-          );
-          if (!hasPendingFeedback && failingStatuses && failingStatuses.length === 0) {
+          ) ?? false;
+          if (syncedLocal && !hasPendingFeedback && failingStatuses && failingStatuses.length === 0) {
             const lastChecked = this.now().toISOString();
             await this.storage.updatePR(local.id, {
               status: "watching",
@@ -2442,8 +2480,10 @@ export class PRBabysitter {
       let buffer = "";
       let loggedLines = 0;
       let loggedTruncation = false;
+      const capturedLines: string[] = [];
 
       const enqueueLine = (trimmed: string) => {
+        capturedLines.push(trimmed);
         if (maxLines !== undefined && loggedLines >= maxLines) {
           if (!loggedTruncation) {
             loggedTruncation = true;
@@ -2481,6 +2521,7 @@ export class PRBabysitter {
           }
           await logQueue;
         },
+        getCapturedLines: () => capturedLines.slice(),
       };
     };
 
@@ -2519,6 +2560,13 @@ export class PRBabysitter {
           metadata: { command: formatCommand(command, args), code: result.code },
         });
       } else {
+        const capturedStderrLines = stderrLogger.getCapturedLines();
+        for (const line of capturedStderrLines) {
+          await queueLog(currentPrId, "warn", `[stderr] ${line}`, {
+            phase,
+            metadata: { stream: "stderr", reemittedFor: "failure" },
+          });
+        }
         await queueLog(currentPrId, "error", `${formatCommand(command, args)} failed (${result.code})`, {
           phase,
           metadata: {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -72,6 +72,7 @@ const AGENT_HEALTH_CACHE_TTL_MS = 60_000;
 const DEPENDENCY_PREFLIGHT_FAILURE_PREFIX = "Dependency preflight failed:";
 const DEPENDENCY_PREFLIGHT_FAILURE_KIND = "dependency_preflight";
 const CONFLICT_REPAIR_FAILURE_KIND = "merge_conflict_repair";
+const NO_OP_CHECK_KIND = "no_op_check";
 const CONFLICT_REPAIR_RETRY_BUDGET = 2;
 const CODE_OWNER_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const AGENT_STREAM_LOG_LINE_LIMIT = 120;
@@ -125,6 +126,12 @@ type ConflictRepairFailureMarker = {
   firstSeenAt: string;
   lastSeenAt: string;
   count: number;
+};
+
+type NoOpCheckMarker = {
+  kind: typeof NO_OP_CHECK_KIND;
+  headSha: string;
+  checkedAt: string;
 };
 
 type BabysitterRuntime = {
@@ -762,6 +769,23 @@ function readConflictRepairFailure(metadata: AgentRun["metadata"]): ConflictRepa
   };
 }
 
+function readNoOpCheck(metadata: AgentRun["metadata"]): NoOpCheckMarker | null {
+  const marker = metadata?.noOpCheck;
+  if (isRecord(marker)
+    && marker.kind === NO_OP_CHECK_KIND
+    && typeof marker.headSha === "string"
+    && typeof marker.checkedAt === "string"
+  ) {
+    return {
+      kind: NO_OP_CHECK_KIND,
+      headSha: marker.headSha,
+      checkedAt: marker.checkedAt,
+    };
+  }
+
+  return null;
+}
+
 function isDependencyPreflightFailureMessage(message: string): boolean {
   return message.trim().startsWith(DEPENDENCY_PREFLIGHT_FAILURE_PREFIX);
 }
@@ -885,6 +909,25 @@ function snapshotIdentity(snapshot: CheckSnapshot): string {
     snapshot.description,
     snapshot.targetUrl || "",
   ].join("|");
+}
+
+function summarizePendingChecks(snapshots: CheckSnapshot[]): Array<{
+  context: string;
+  status: string;
+  conclusion: string | null;
+  description: string;
+  targetUrl: string | null;
+}> {
+  return snapshots
+    .filter((snapshot) => snapshot.status !== "completed" || snapshot.conclusion === null)
+    .map((snapshot) => ({
+      context: snapshot.context,
+      status: snapshot.status,
+      conclusion: snapshot.conclusion,
+      description: snapshot.description,
+      targetUrl: snapshot.targetUrl,
+    }))
+    .sort((a, b) => a.context.localeCompare(b.context));
 }
 
 async function persistCheckSnapshotsIfMissing(storage: IStorage, snapshots: CheckSnapshot[]): Promise<void> {
@@ -1418,6 +1461,23 @@ export class PRBabysitter {
           count,
         };
       }
+    }
+
+    return null;
+  }
+
+  private async findLatestNoOpCheck(prId: string, headSha: string): Promise<NoOpCheckMarker | null> {
+    const completedRuns = (await this.storage.listAgentRuns({ prId, status: "completed" }))
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+
+    for (const run of completedRuns) {
+      const marker = readNoOpCheck(run.metadata);
+      const runHeadSha = marker?.headSha ?? run.initialHeadSha;
+      if (runHeadSha !== headSha) {
+        continue;
+      }
+
+      return marker?.kind === NO_OP_CHECK_KIND ? marker : null;
     }
 
     return null;
@@ -2102,6 +2162,52 @@ export class PRBabysitter {
           continue;
         }
 
+        const priorNoOpCheck = pull.headSha
+          ? await this.findLatestNoOpCheck(local.id, pull.headSha)
+          : null;
+        if (priorNoOpCheck) {
+          let syncedLocal: typeof local;
+          try {
+            syncedLocal = await this.syncFeedbackForPR(local.id, {
+              phase: "watcher",
+            });
+          } catch (error) {
+            await this.storage.addLog(local.id, "warn", `Could not sync GitHub feedback before no-op suppression: ${summarizeUnknownError(error)}`, {
+              phase: "watcher",
+            });
+            syncedLocal = await this.storage.getPR(local.id) ?? local;
+          }
+
+          let failingStatuses: GitHubStatusFailure[] | null = null;
+          try {
+            failingStatuses = await this.github.listFailingStatuses(octokit, repo, pull.headSha);
+          } catch (error) {
+            await this.storage.addLog(local.id, "warn", `Could not check CI status before no-op suppression: ${summarizeUnknownError(error)}`, {
+              phase: "watcher",
+            });
+          }
+
+          const hasPendingFeedback = syncedLocal.feedbackItems.some((item) =>
+            item.status === "pending" || item.status === "queued" || item.status === "in_progress"
+          );
+          if (!hasPendingFeedback && failingStatuses && failingStatuses.length === 0) {
+            const lastChecked = this.now().toISOString();
+            await this.storage.updatePR(local.id, {
+              status: "watching",
+              lastChecked,
+            });
+            await this.storage.addLog(local.id, "info", "Skipping babysitter run because the same PR head was already checked with no necessary fixes", {
+              phase: "watcher",
+              metadata: {
+                repo: repoSlug,
+                headSha: pull.headSha,
+                checkedAt: priorNoOpCheck.checkedAt,
+              },
+            });
+            continue;
+          }
+        }
+
         await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
           phase: "watcher",
           metadata: { repo: repoSlug },
@@ -2179,9 +2285,25 @@ export class PRBabysitter {
         phase: "verify.ci",
       });
     }
-    await queueLog(prId, "warn", `CI status did not settle after ${MAX_ATTEMPTS} poll attempt(s)`, {
+
+    let pendingChecks: ReturnType<typeof summarizePendingChecks> = [];
+    if (this.github.fetchCheckSnapshotsForRef) {
+      try {
+        pendingChecks = summarizePendingChecks(
+          await this.github.fetchCheckSnapshotsForRef(octokit, repo, prId, headSha),
+        );
+      } catch (error) {
+        await queueLog(prId, "warn", `Could not fetch pending CI check details after timeout: ${summarizeUnknownError(error)}`, {
+          phase: "verify.ci",
+        });
+      }
+    }
+    const pendingSummary = pendingChecks.length > 0
+      ? ` Pending: ${pendingChecks.map((check) => `${check.context} (${check.status}${check.conclusion ? `/${check.conclusion}` : ""})`).join("; ")}`
+      : "";
+    await queueLog(prId, "warn", `CI status did not settle after ${MAX_ATTEMPTS} poll attempt(s).${pendingSummary}`, {
       phase: "verify.ci",
-      metadata: { attempts: MAX_ATTEMPTS, headSha },
+      metadata: { attempts: MAX_ATTEMPTS, headSha, pendingChecks },
     });
     return { status: "timeout", failures: [] };
   }
@@ -2379,7 +2501,7 @@ export class PRBabysitter {
       });
 
       const stdoutLogger = createChunkLogger(currentPrId, phase, "stdout", "info", maxOutputLogLines);
-      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "warn", maxOutputLogLines);
+      const stderrLogger = createChunkLogger(currentPrId, phase, "stderr", "info", maxOutputLogLines);
 
       const result = await this.runtime.runCommand(command, args, {
         cwd,
@@ -3308,6 +3430,14 @@ export class PRBabysitter {
         await updateRunRecord({
           status: "completed",
           phase: "run.completed",
+          metadata: {
+            ...(runRecord.metadata ?? {}),
+            noOpCheck: {
+              kind: NO_OP_CHECK_KIND,
+              headSha: pullSummary.headSha,
+              checkedAt: this.now().toISOString(),
+            },
+          },
           lastError: null,
         });
         return;

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -1022,6 +1022,37 @@ describe("MemStorage", () => {
       assert.equal(runs[0].prId, "pr-1");
     });
 
+    it("orders, limits, and filters by initialHeadSha", async () => {
+      await storage.upsertAgentRun(makeAgentRun({
+        id: "old-match",
+        status: "completed",
+        initialHeadSha: "same-head",
+        updatedAt: "2026-03-18T10:01:00.000Z",
+      }));
+      await storage.upsertAgentRun(makeAgentRun({
+        id: "new-other-head",
+        status: "completed",
+        initialHeadSha: "other-head",
+        updatedAt: "2026-03-18T10:05:00.000Z",
+      }));
+      await storage.upsertAgentRun(makeAgentRun({
+        id: "new-match",
+        status: "completed",
+        initialHeadSha: "same-head",
+        updatedAt: "2026-03-18T10:03:00.000Z",
+      }));
+
+      const runs = await storage.listAgentRuns({
+        status: "completed",
+        initialHeadSha: "same-head",
+        orderBy: "updatedAt",
+        order: "desc",
+        limit: 1,
+      });
+
+      assert.deepEqual(runs.map((run) => run.id), ["new-match"]);
+    });
+
     it("returns copies (not references)", async () => {
       await storage.upsertAgentRun(makeAgentRun({ id: "r1" }));
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -707,16 +707,31 @@ export class MemStorage implements IStorage {
     return run ? { ...run } : undefined;
   }
 
-  async listAgentRuns(filters?: { status?: AgentRunStatus; prId?: string }): Promise<AgentRun[]> {
+  async listAgentRuns(filters?: {
+    status?: AgentRunStatus;
+    prId?: string;
+    initialHeadSha?: string;
+    orderBy?: "createdAt" | "updatedAt";
+    order?: "asc" | "desc";
+    limit?: number;
+  }): Promise<AgentRun[]> {
+    const orderBy = filters?.orderBy ?? "createdAt";
+    const direction = filters?.order ?? "asc";
     const runs = Array.from(this.agentRuns.values())
       .filter((run) => {
         if (filters?.status && run.status !== filters.status) return false;
         if (filters?.prId && run.prId !== filters.prId) return false;
+        if (filters?.initialHeadSha && run.initialHeadSha !== filters.initialHeadSha) return false;
         return true;
       })
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      .sort((a, b) => {
+        const aTime = new Date(orderBy === "updatedAt" ? a.updatedAt : a.createdAt).getTime();
+        const bTime = new Date(orderBy === "updatedAt" ? b.updatedAt : b.createdAt).getTime();
+        return direction === "desc" ? bTime - aTime : aTime - bTime;
+      });
 
-    return runs.map((run) => ({ ...run }));
+    const limited = filters?.limit !== undefined ? runs.slice(0, filters.limit) : runs;
+    return limited.map((run) => ({ ...run }));
   }
 
   async upsertAgentRun(run: AgentRun): Promise<AgentRun> {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -2344,9 +2344,16 @@ export class SqliteStorage implements IStorage {
     return this.parseAgentRunRow(row);
   }
 
-  async listAgentRuns(filters?: { status?: AgentRunStatus; prId?: string }): Promise<AgentRun[]> {
+  async listAgentRuns(filters?: {
+    status?: AgentRunStatus;
+    prId?: string;
+    initialHeadSha?: string;
+    orderBy?: "createdAt" | "updatedAt";
+    order?: "asc" | "desc";
+    limit?: number;
+  }): Promise<AgentRun[]> {
     const clauses: string[] = [];
-    const values: string[] = [];
+    const values: (string | number)[] = [];
 
     if (filters?.status) {
       clauses.push("status = ?");
@@ -2358,14 +2365,23 @@ export class SqliteStorage implements IStorage {
       values.push(filters.prId);
     }
 
+    if (filters?.initialHeadSha) {
+      clauses.push("initial_head_sha = ?");
+      values.push(filters.initialHeadSha);
+    }
+
     const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const orderColumn = filters?.orderBy === "updatedAt" ? "updated_at" : "created_at";
+    const direction = filters?.order === "desc" ? "DESC" : "ASC";
+    const limitClause = filters?.limit !== undefined ? `LIMIT ${Math.max(0, Math.floor(filters.limit))}` : "";
 
     const rows = this.all<AgentRunRow>(`
       SELECT id, pr_id, preferred_agent, resolved_agent, status, phase, prompt, initial_head_sha,
              metadata_json, last_error, created_at, updated_at
       FROM agent_runs
       ${whereClause}
-      ORDER BY datetime(created_at) ASC
+      ORDER BY datetime(${orderColumn}) ${direction}
+      ${limitClause}
     `, ...values);
 
     return rows.map((row) => this.parseAgentRunRow(row));

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -517,6 +517,83 @@ test("SqliteStorage upsertAgentRun preserves the original createdAt", async () =
   storage.close();
 });
 
+test("SqliteStorage listAgentRuns orders, limits, and filters by initialHeadSha", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+
+  const pr = await storage.addPR({
+    number: 60,
+    title: "Filter runs",
+    repo: "yungookim/oh-my-pr",
+    branch: "claude/typescript-data-model-k3zAW",
+    author: "claude",
+    url: "https://github.com/yungookim/oh-my-pr/pull/60",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  await storage.upsertAgentRun({
+    id: "old-match",
+    prId: pr.id,
+    preferredAgent: "claude",
+    resolvedAgent: "claude",
+    status: "completed",
+    phase: "run.done",
+    prompt: null,
+    initialHeadSha: "same-head",
+    metadata: null,
+    lastError: null,
+    createdAt: "2026-03-18T10:01:00.000Z",
+    updatedAt: "2026-03-18T10:01:00.000Z",
+  });
+  await storage.upsertAgentRun({
+    id: "new-other-head",
+    prId: pr.id,
+    preferredAgent: "claude",
+    resolvedAgent: "claude",
+    status: "completed",
+    phase: "run.done",
+    prompt: null,
+    initialHeadSha: "other-head",
+    metadata: null,
+    lastError: null,
+    createdAt: "2026-03-18T10:02:00.000Z",
+    updatedAt: "2026-03-18T10:05:00.000Z",
+  });
+  await storage.upsertAgentRun({
+    id: "new-match",
+    prId: pr.id,
+    preferredAgent: "claude",
+    resolvedAgent: "claude",
+    status: "completed",
+    phase: "run.done",
+    prompt: null,
+    initialHeadSha: "same-head",
+    metadata: null,
+    lastError: null,
+    createdAt: "2026-03-18T10:03:00.000Z",
+    updatedAt: "2026-03-18T10:03:00.000Z",
+  });
+
+  const runs = await storage.listAgentRuns({
+    prId: pr.id,
+    status: "completed",
+    initialHeadSha: "same-head",
+    orderBy: "updatedAt",
+    order: "desc",
+    limit: 1,
+  });
+
+  assert.deepEqual(runs.map((run) => run.id), ["new-match"]);
+  storage.close();
+});
+
 test("SqliteStorage persists background jobs and requeues expired leases", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
   const first = new SqliteStorage(root);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -151,6 +151,10 @@ export interface IStorage {
   listAgentRuns(filters?: {
     status?: AgentRunStatus;
     prId?: string;
+    initialHeadSha?: string;
+    orderBy?: "createdAt" | "updatedAt";
+    order?: "asc" | "desc";
+    limit?: number;
   }): Promise<AgentRun[]>;
   upsertAgentRun(run: AgentRun): Promise<AgentRun>;
 

--- a/tasks/recent-log-failure-report-2026-05-20.md
+++ b/tasks/recent-log-failure-report-2026-05-20.md
@@ -1,0 +1,77 @@
+# Recent Log Failure Fix Baseline - 2026-05-20
+
+## Scope
+
+This baseline records fixes applied after reviewing local oh-my-pr logs for the 24-hour window ending May 20, 2026.
+
+Implementation branch:
+
+- `fix/log-plan-implementation`
+- Base: `origin/main@72e2b5b9df3596961c5b8298ac6241df7c1d0862`
+- Recorded at: `2026-05-20T15:29:35Z`
+
+## Fixes Applied
+
+### Watcher Lifecycle Observability
+
+The app runtime now logs watcher start, heartbeat, and stop events with the configured poll interval.
+
+Expected future signal:
+
+- Each runtime start with background jobs enabled emits `Repository watcher started`.
+- Each interval emits `Repository watcher heartbeat`.
+- Runtime shutdown emits `Repository watcher stopped`.
+
+### CI Timeout Diagnostics
+
+CI timeout warnings now include pending check names and statuses when check snapshots are available.
+
+Expected future signal:
+
+- `Timed out waiting for CI checks to complete` identifies the checks that are still pending.
+- The run metadata includes `pendingChecks` for timeout analysis.
+
+### Repeated No-Op Babysitter Runs
+
+No-op babysitter runs now record a PR/head marker, and the repository watcher skips requeueing the same unchanged head when feedback and CI are still clean.
+
+Expected future signal:
+
+- After a no-op babysitter run for a PR head SHA, the watcher logs `Skipping babysitter run because the same PR head was already checked with no necessary fixes`.
+- New review feedback, failing checks, or a new head SHA still allow another babysitter run.
+
+### Git Stderr Log Severity
+
+Successful command stderr is now logged at `info`; failed commands still emit an error summary.
+
+Expected future signal:
+
+- Normal git progress output on stderr no longer inflates warning counts.
+- Failed commands remain visible as errors.
+
+## Verification
+
+Commands run from `.worktrees/log-plan-implementation`:
+
+```bash
+node --test --import tsx server/appRuntime.test.ts server/babysitter.test.ts --test-name-pattern "watcher lifecycle|unchanged PR heads|pending check details|successful git stderr"
+node --test --import tsx server/appRuntime.test.ts server/babysitter.test.ts server/backgroundJobHandlers.test.ts server/backgroundJobDispatcher.test.ts
+npm run check
+npm run test
+```
+
+Results:
+
+- Focused regression suite passed: 94 passed, 0 failed.
+- Adjacent background-job suite passed: 116 passed, 0 failed.
+- TypeScript check passed.
+- Full server suite passed: 468 passed, 1 skipped, 0 failed.
+
+## Future Log Review Boundary
+
+For future local-log analysis, treat log rows before this branch lands as pre-fix evidence. Only count these as regressions if they appear after the merge commit for `fix/log-plan-implementation`:
+
+- Repeated babysitter jobs for the same clean PR/head after a no-op run marker exists.
+- CI timeout warnings that do not identify pending checks when snapshots are available.
+- Missing watcher lifecycle logs while background watcher startup succeeds.
+- Successful git progress output classified as warnings.


### PR DESCRIPTION
## Summary
- add watcher lifecycle logging for start, heartbeat, and stop events
- include pending check details in CI timeout logs and metadata
- suppress repeated no-op babysitter jobs for unchanged clean PR heads
- log successful command stderr at info while keeping failed commands as errors
- add a tracked post-fix baseline for future log reviews

## Verification
- node --test --import tsx server/appRuntime.test.ts server/babysitter.test.ts --test-name-pattern "watcher lifecycle|unchanged PR heads|pending check details|successful git stderr"
- node --test --import tsx server/appRuntime.test.ts server/babysitter.test.ts server/backgroundJobHandlers.test.ts server/backgroundJobDispatcher.test.ts
- npm run check
- npm run test
- git diff --check