### PR TITLE
[codex] fix Tauri link opening

### DIFF
--- a/client/src/lib/tauri.test.ts
+++ b/client/src/lib/tauri.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getTauriExternalLinkHref, handleTauriExternalLinkClick } from "./tauri";
+
+function createClickEvent() {
+  let prevented = false;
+
+  return {
+    event: {
+      button: 0,
+      defaultPrevented: false,
+      target: null,
+      preventDefault() {
+        prevented = true;
+      },
+    },
+    get prevented() {
+      return prevented;
+    },
+  };
+}
+
+test("getTauriExternalLinkHref returns external browser-safe URLs", () => {
+  assert.equal(
+    getTauriExternalLinkHref(
+      "https://github.com/yungookim/oh-my-pr/pull/1",
+      "http://localhost:5001/#/",
+    ),
+    "https://github.com/yungookim/oh-my-pr/pull/1",
+  );
+  assert.equal(
+    getTauriExternalLinkHref("mailto:maintainer@example.com", "http://localhost:5001/#/"),
+    "mailto:maintainer@example.com",
+  );
+});
+
+test("getTauriExternalLinkHref ignores same-origin app links", () => {
+  assert.equal(getTauriExternalLinkHref("/settings", "http://localhost:5001/#/"), null);
+  assert.equal(getTauriExternalLinkHref("http://localhost:5001/#/logs", "http://localhost:5001/#/"), null);
+});
+
+test("handleTauriExternalLinkClick opens external links through the provided opener", () => {
+  const click = createClickEvent();
+  const opened: string[] = [];
+
+  const handled = handleTauriExternalLinkClick(
+    click.event,
+    (href) => {
+      opened.push(href);
+    },
+    {
+      currentHref: "http://localhost:5001/#/",
+      findAnchor: () => ({
+        href: "https://github.com/yungookim/oh-my-pr/pull/1",
+        hasAttribute: () => false,
+      }),
+    },
+  );
+
+  assert.equal(handled, true);
+  assert.equal(click.prevented, true);
+  assert.deepEqual(opened, ["https://github.com/yungookim/oh-my-pr/pull/1"]);
+});
+
+test("handleTauriExternalLinkClick leaves internal links alone", () => {
+  const click = createClickEvent();
+  const opened: string[] = [];
+
+  const handled = handleTauriExternalLinkClick(
+    click.event,
+    (href) => {
+      opened.push(href);
+    },
+    {
+      currentHref: "http://localhost:5001/#/",
+      findAnchor: () => ({
+        href: "http://localhost:5001/#/settings",
+        hasAttribute: () => false,
+      }),
+    },
+  );
+
+  assert.equal(handled, false);
+  assert.equal(click.prevented, false);
+  assert.deepEqual(opened, []);
+});

--- a/client/src/lib/tauri.test.ts
+++ b/client/src/lib/tauri.test.ts
@@ -62,6 +62,36 @@ test("handleTauriExternalLinkClick opens external links through the provided ope
   assert.deepEqual(opened, ["https://github.com/yungookim/oh-my-pr/pull/1"]);
 });
 
+test("handleTauriExternalLinkClick logs rejected external open attempts", async (t) => {
+  const click = createClickEvent();
+  const warnings: unknown[][] = [];
+  const error = new Error("shell open failed");
+  const originalWarn = console.warn;
+  t.after(() => {
+    console.warn = originalWarn;
+  });
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  const handled = handleTauriExternalLinkClick(
+    click.event,
+    () => Promise.reject(error),
+    {
+      currentHref: "http://localhost:5001/#/",
+      findAnchor: () => ({
+        href: "https://github.com/yungookim/oh-my-pr/pull/1",
+        hasAttribute: () => false,
+      }),
+    },
+  );
+  await Promise.resolve();
+
+  assert.equal(handled, true);
+  assert.equal(click.prevented, true);
+  assert.deepEqual(warnings, [["Failed to open external link in Tauri", error]]);
+});
+
 test("handleTauriExternalLinkClick leaves internal links alone", () => {
   const click = createClickEvent();
   const opened: string[] = [];

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -77,7 +77,9 @@ export function handleTauriExternalLinkClick(
   }
 
   event.preventDefault();
-  void Promise.resolve(openExternal(href)).catch(() => {});
+  void Promise.resolve(openExternal(href)).catch((error: unknown) => {
+    console.warn("Failed to open external link in Tauri", error);
+  });
   return true;
 }
 

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -5,3 +5,100 @@
 export function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
+
+type ExternalLinkAnchor = {
+  href: string;
+  hasAttribute(name: string): boolean;
+};
+
+type ExternalLinkClickEvent = {
+  button: number;
+  defaultPrevented: boolean;
+  target: EventTarget | null;
+  preventDefault(): void;
+};
+
+type ExternalLinkHandlerOptions = {
+  currentHref?: string;
+  findAnchor?: (target: EventTarget | null) => ExternalLinkAnchor | null;
+};
+
+let removeExternalLinkHandler: (() => void) | null = null;
+
+export function getTauriExternalLinkHref(href: string, currentHref: string): string | null {
+  try {
+    const url = new URL(href, currentHref);
+
+    if (url.protocol === "mailto:" || url.protocol === "tel:") {
+      return url.href;
+    }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+
+    return url.origin === new URL(currentHref).origin ? null : url.href;
+  } catch {
+    return null;
+  }
+}
+
+function findAnchorFromTarget(target: EventTarget | null): HTMLAnchorElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  return target.closest("a[href]");
+}
+
+async function openExternalHref(href: string): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("plugin:shell|open", { path: href });
+}
+
+export function handleTauriExternalLinkClick(
+  event: ExternalLinkClickEvent,
+  openExternal: (href: string) => void | Promise<void>,
+  options: ExternalLinkHandlerOptions = {},
+): boolean {
+  if (event.defaultPrevented || event.button !== 0) {
+    return false;
+  }
+
+  const anchor = (options.findAnchor ?? findAnchorFromTarget)(event.target);
+  if (!anchor || anchor.hasAttribute("download")) {
+    return false;
+  }
+
+  const currentHref = options.currentHref ?? window.location.href;
+  const href = getTauriExternalLinkHref(anchor.href, currentHref);
+  if (!href) {
+    return false;
+  }
+
+  event.preventDefault();
+  void Promise.resolve(openExternal(href)).catch(() => {});
+  return true;
+}
+
+export function installTauriExternalLinkHandler(): () => void {
+  if (!isTauri() || typeof document === "undefined") {
+    return () => {};
+  }
+
+  if (removeExternalLinkHandler) {
+    return removeExternalLinkHandler;
+  }
+
+  const listener = (event: MouseEvent) => {
+    handleTauriExternalLinkClick(event, openExternalHref);
+  };
+
+  document.addEventListener("click", listener, true);
+  removeExternalLinkHandler = () => {
+    document.removeEventListener("click", listener, true);
+    removeExternalLinkHandler = null;
+  };
+
+  return removeExternalLinkHandler;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import { normalizeHashRouteSearch } from "./lib/hashRouteSearch";
+import { installTauriExternalLinkHandler } from "./lib/tauri";
 import "./index.css";
+
+installTauriExternalLinkHandler();
 
 // wouter's hash router expects the path in location.hash and the query in
 // location.search. Normalize deep links like #/logs?level=info before mount.


### PR DESCRIPTION
## Summary
- Add a Tauri-only document click handler that routes external links through `plugin:shell|open`.
- Keep same-origin app links inside the webview while opening `http(s)`, `mailto`, and `tel` targets with the system default app.
- Add focused regression coverage for external and internal link handling.

## Root Cause
The Tauri shell plugin and `shell:allow-open` permission were already configured, but the client never intercepted external anchor clicks to call the plugin. As a result, links stayed in the webview path instead of being handed off to the default browser.

## Verification
- `node --import tsx --test client/src/lib/tauri.test.ts`
- `npm run check`
- `npm run test:all` (521 pass, 1 skipped)
- `npm run build`
- `git diff --check`

## Note
Attempted the repo pre-commit `/simplify` check with `claude -p "/simplify client/src/lib/tauri.ts client/src/lib/tauri.test.ts client/src/main.tsx"`, but it produced no output for about two minutes and was terminated. It made no file changes.
