### PR TITLE
[codex] reduce feedback panel noise

### DIFF
--- a/client/src/lib/feedbackDisplay.test.ts
+++ b/client/src/lib/feedbackDisplay.test.ts
@@ -61,6 +61,28 @@ test("getFeedbackPreview strips inline HTML badges from bot comments", () => {
   );
 });
 
+test("getFeedbackPreview strips known HTML tags without corrupting angle brackets", () => {
+  const item = makeItem({
+    body: "<span>Medium</span>\nUse List<String> when x < y and y > z.",
+  });
+
+  assert.equal(
+    getFeedbackPreview(item),
+    "Use List<String> when x < y and y > z.",
+  );
+});
+
+test("getFeedbackPreview decodes HTML entities only once", () => {
+  const item = makeItem({
+    body: '<a href=""><img alt="&amp;lt;P2&amp;gt;" src="https://example.com/p2.svg"></a> Keep &amp;lt;script&amp;gt; escaped.',
+  });
+
+  assert.equal(
+    getFeedbackPreview(item),
+    "&lt;P2&gt; Keep &lt;script&gt; escaped.",
+  );
+});
+
 test("getFeedbackGroupSections groups attention, running, and done feedback in priority order", () => {
   const sections = getFeedbackGroupSections([
     makeItem({ id: "resolved", status: "resolved" }),

--- a/client/src/lib/feedbackDisplay.test.ts
+++ b/client/src/lib/feedbackDisplay.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FeedbackItem } from "@shared/schema";
+import {
+  formatFeedbackOverview,
+  getFeedbackGroupSections,
+  getFeedbackPreview,
+} from "./feedbackDisplay";
+
+function makeItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    id: "gh-review-comment-1",
+    author: "reviewer",
+    body: "Please rename this variable.",
+    bodyHtml: "<p>Please rename this variable.</p>",
+    replyKind: "review_thread",
+    sourceId: "1",
+    sourceNodeId: "PRRC_kwDO_example",
+    sourceUrl: "https://github.com/octo/example/pull/42#discussion_r1",
+    threadId: "PRRT_kwDO_example",
+    threadResolved: false,
+    auditToken: "codefactory-feedback:gh-review-comment-1",
+    file: "src/example.ts",
+    line: 12,
+    type: "review_comment",
+    createdAt: "2026-03-15T10:00:00.000Z",
+    decision: null,
+    decisionReason: null,
+    action: null,
+    status: "pending",
+    statusReason: null,
+    ...overrides,
+  };
+}
+
+test("getFeedbackPreview skips generic review headings and strips markdown noise", () => {
+  const item = makeItem({
+    body: [
+      "## Code Review",
+      "",
+      "**Medium**",
+      "",
+      "This returns `Element | null`; use an explicit cast before passing it to Tauri.",
+    ].join("\n"),
+  });
+
+  assert.equal(
+    getFeedbackPreview(item),
+    "This returns Element | null; use an explicit cast before passing it to Tauri.",
+  );
+});
+
+test("getFeedbackPreview strips inline HTML badges from bot comments", () => {
+  const item = makeItem({
+    body: '<a href=""><img alt="P2" src="https://example.com/p2.svg" align="top"></a> Silent failure swallows broken link open errors.',
+  });
+
+  assert.equal(
+    getFeedbackPreview(item),
+    "P2 Silent failure swallows broken link open errors.",
+  );
+});
+
+test("getFeedbackGroupSections groups attention, running, and done feedback in priority order", () => {
+  const sections = getFeedbackGroupSections([
+    makeItem({ id: "resolved", status: "resolved" }),
+    makeItem({ id: "running", status: "in_progress" }),
+    makeItem({ id: "failed", status: "failed" }),
+    makeItem({ id: "rejected", status: "rejected" }),
+  ]);
+
+  assert.deepEqual(
+    sections.map((section) => [section.key, section.items.map((item) => item.id)]),
+    [
+      ["attention", ["failed"]],
+      ["running", ["running"]],
+      ["done", ["resolved", "rejected"]],
+    ],
+  );
+});
+
+test("formatFeedbackOverview foregrounds the most important PR state", () => {
+  assert.equal(
+    formatFeedbackOverview([
+      makeItem({ id: "failed", status: "failed" }),
+      makeItem({ id: "running", status: "in_progress" }),
+      makeItem({ id: "rejected", status: "rejected" }),
+    ]),
+    "1 failed · 1 running · 1 done",
+  );
+});
+
+test("formatFeedbackOverview keeps running and done labels readable for plural counts", () => {
+  assert.equal(
+    formatFeedbackOverview([
+      makeItem({ id: "running-1", status: "in_progress" }),
+      makeItem({ id: "running-2", status: "queued" }),
+      makeItem({ id: "resolved", status: "resolved" }),
+      makeItem({ id: "rejected", status: "rejected" }),
+    ]),
+    "2 running · 2 done",
+  );
+});

--- a/client/src/lib/feedbackDisplay.ts
+++ b/client/src/lib/feedbackDisplay.ts
@@ -1,0 +1,177 @@
+import type { FeedbackItem, FeedbackStatus } from "@shared/schema";
+
+export type FeedbackGroupKey = "attention" | "running" | "done";
+
+export type FeedbackGroupSection = {
+  key: FeedbackGroupKey;
+  label: string;
+  summary: string;
+  defaultOpen: boolean;
+  items: FeedbackItem[];
+};
+
+const STATUS_ORDER: FeedbackStatus[] = [
+  "failed",
+  "warning",
+  "pending",
+  "flagged",
+  "in_progress",
+  "queued",
+  "resolved",
+  "rejected",
+];
+
+const STATUS_LABELS: Record<FeedbackStatus, { singular: string; plural?: string }> = {
+  pending: { singular: "pending", plural: "pending" },
+  queued: { singular: "queued", plural: "queued" },
+  in_progress: { singular: "running", plural: "running" },
+  resolved: { singular: "resolved", plural: "resolved" },
+  failed: { singular: "failed", plural: "failed" },
+  warning: { singular: "warning" },
+  rejected: { singular: "rejected", plural: "rejected" },
+  flagged: { singular: "flagged", plural: "flagged" },
+};
+
+const GENERIC_REVIEW_LINES = new Set([
+  "code review",
+  "high",
+  "medium",
+  "low",
+]);
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function countByStatus(items: FeedbackItem[]): Record<FeedbackStatus, number> {
+  return items.reduce((counts, item) => {
+    counts[item.status] += 1;
+    return counts;
+  }, {
+    pending: 0,
+    queued: 0,
+    in_progress: 0,
+    resolved: 0,
+    failed: 0,
+    warning: 0,
+    rejected: 0,
+    flagged: 0,
+  } satisfies Record<FeedbackStatus, number>);
+}
+
+function formatStatusParts(items: FeedbackItem[]): string {
+  const counts = countByStatus(items);
+  const parts = STATUS_ORDER
+    .filter((status) => counts[status] > 0)
+    .map((status) => {
+      const label = STATUS_LABELS[status];
+      return pluralize(counts[status], label.singular, label.plural);
+    });
+
+  return parts.join(" · ");
+}
+
+function cleanPreviewLine(line: string): string {
+  return line
+    .replace(/<img\b[^>]*\balt=(["'])(.*?)\1[^>]*>/gi, " $2 ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/[*_~>#]/g, "")
+    .replace(/^\s*[-+*]\s+/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function getFeedbackPreview(item: Pick<FeedbackItem, "body">, maxLength = 150): string {
+  const source = item.body
+    .replace(/```[\s\S]*?```/g, " ")
+    .split(/\n+/)
+    .map(cleanPreviewLine)
+    .find((line) => line.length > 0 && !GENERIC_REVIEW_LINES.has(line.toLowerCase()));
+
+  if (!source) {
+    return "No comment body";
+  }
+
+  if (source.length <= maxLength) {
+    return source;
+  }
+
+  return `${source.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function feedbackGroupForStatus(status: FeedbackStatus): FeedbackGroupKey {
+  if (status === "queued" || status === "in_progress") {
+    return "running";
+  }
+
+  if (status === "resolved" || status === "rejected") {
+    return "done";
+  }
+
+  return "attention";
+}
+
+export function getFeedbackGroupSections(items: FeedbackItem[]): FeedbackGroupSection[] {
+  const grouped: Record<FeedbackGroupKey, FeedbackItem[]> = {
+    attention: [],
+    running: [],
+    done: [],
+  };
+
+  for (const item of items) {
+    grouped[feedbackGroupForStatus(item.status)].push(item);
+  }
+
+  return [
+    {
+      key: "attention" as const,
+      label: "Needs attention",
+      summary: formatStatusParts(grouped.attention),
+      defaultOpen: true,
+      items: grouped.attention,
+    },
+    {
+      key: "running" as const,
+      label: "Running",
+      summary: formatStatusParts(grouped.running),
+      defaultOpen: true,
+      items: grouped.running,
+    },
+    {
+      key: "done" as const,
+      label: "Done",
+      summary: formatStatusParts(grouped.done),
+      defaultOpen: false,
+      items: grouped.done,
+    },
+  ].filter((section) => section.items.length > 0);
+}
+
+export function formatFeedbackOverview(items: FeedbackItem[]): string {
+  if (items.length === 0) {
+    return "no feedback";
+  }
+
+  const sections = getFeedbackGroupSections(items);
+  const parts = sections.map((section) => {
+    if (section.key === "attention") {
+      return section.summary || pluralize(section.items.length, "attention item");
+    }
+
+    if (section.key === "running") {
+      return pluralize(section.items.length, "running", "running");
+    }
+
+    return pluralize(section.items.length, "done", "done");
+  });
+
+  return parts.join(" · ");
+}

--- a/client/src/lib/feedbackDisplay.ts
+++ b/client/src/lib/feedbackDisplay.ts
@@ -39,6 +39,15 @@ const GENERIC_REVIEW_LINES = new Set([
   "low",
 ]);
 
+const PREVIEW_HTML_TAG_PATTERN = /<\/?(?:a|span|div|p|br|img)\b[^>]*>/gi;
+const PREVIEW_ENTITY_LABELS: Record<string, string> = {
+  quot: "\"",
+  "#39": "'",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+};
+
 function pluralize(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
 }
@@ -71,19 +80,23 @@ function formatStatusParts(items: FeedbackItem[]): string {
   return parts.join(" · ");
 }
 
+function decodePreviewEntities(value: string): string {
+  return value.replace(/&(quot|#39|amp|lt|gt);/g, (entity, label: string) => (
+    PREVIEW_ENTITY_LABELS[label] ?? entity
+  ));
+}
+
 function cleanPreviewLine(line: string): string {
-  return line
+  const withoutHtml = line
     .replace(/<img\b[^>]*\balt=(["'])(.*?)\1[^>]*>/gi, " $2 ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&quot;/g, "\"")
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
+    .replace(PREVIEW_HTML_TAG_PATTERN, " ");
+
+  return decodePreviewEntities(withoutHtml)
     .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .replace(/`([^`]+)`/g, "$1")
-    .replace(/[*_~>#]/g, "")
+    .replace(/^\s*>+\s?/, "")
+    .replace(/[*_~#]/g, "")
     .replace(/^\s*[-+*]\s+/, "")
     .replace(/\s+/g, " ")
     .trim();

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -19,10 +19,15 @@ import { toast } from "@/hooks/use-toast";
 import {
   formatFeedbackStatusLabel,
   getFeedbackStatusBadgeClass,
-  isFeedbackCollapsedByDefault,
   countActiveFeedbackStatuses,
   isPRReadyToMerge,
 } from "@/lib/feedbackStatus";
+import {
+  formatFeedbackOverview,
+  getFeedbackGroupSections,
+  getFeedbackPreview,
+  type FeedbackGroupSection as FeedbackGroupSectionView,
+} from "@/lib/feedbackDisplay";
 import {
   getHealingSessionView,
   selectRelevantHealingSession,
@@ -145,6 +150,39 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
       {formatFeedbackStatusLabel(status)}
     </span>
   );
+}
+
+const FEEDBACK_DECISIONS = ["accept", "reject", "flag"] as const;
+type FeedbackDecision = (typeof FEEDBACK_DECISIONS)[number];
+
+function formatFeedbackLocation(item: FeedbackItem): string {
+  if (item.file) {
+    return `${item.file}${item.line ? `:${item.line}` : ""}`;
+  }
+
+  if (item.type === "general_comment") {
+    return "General comment";
+  }
+
+  if (item.type === "review") {
+    return "Review";
+  }
+
+  return "Review comment";
+}
+
+function formatFeedbackMeta(item: FeedbackItem, createdAt: string | null): string {
+  const parts = [item.author];
+
+  if (createdAt) {
+    parts.push(createdAt);
+  }
+
+  if (item.decision) {
+    parts.push(`decision: ${item.decision}`);
+  }
+
+  return parts.join(" · ");
 }
 
 function WatchPausedIndicator() {
@@ -611,8 +649,9 @@ function FeedbackRow({
   readOnly?: boolean;
   globalDrainMode?: boolean;
 }) {
+  const [open, setOpen] = useState(false);
   const overrideMutation = useMutation({
-    mutationFn: async (decision: string) => {
+    mutationFn: async (decision: FeedbackDecision) => {
       const res = await apiRequest("PATCH", `/api/prs/${prId}/feedback/${item.id}`, { decision });
       return res.json();
     },
@@ -639,34 +678,40 @@ function FeedbackRow({
   });
 
   const createdAt = formatClock(item.createdAt);
-  const collapsedByDefault = isFeedbackCollapsedByDefault(item.status);
+  const location = formatFeedbackLocation(item);
+  const preview = getFeedbackPreview(item);
+  const meta = formatFeedbackMeta(item, createdAt);
   const prominentStatusReason = (item.status === "failed" || item.status === "warning") && item.statusReason
     ? item.statusReason
     : null;
+  const prominentStatusLabel = item.status === "warning" ? "Warning" : "Blocked";
 
   return (
-    <Collapsible.Root defaultOpen={!collapsedByDefault} className="border-b border-border">
-      <div className="px-4 py-3">
-        {/* Header row - always visible */}
+    <Collapsible.Root open={open} onOpenChange={setOpen} className="border-b border-border/80">
+      <div className="px-4 py-2.5">
         <div className="flex items-start gap-3">
           <div className="shrink-0 pt-0.5">
             <FeedbackStatusTag status={item.status} />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="mb-1 flex flex-wrap items-center gap-2">
-              <span className="font-medium">{item.author}</span>
-              {item.file && (
-                <span className="text-[11px] text-muted-foreground">
-                  {item.file}{item.line ? `:${item.line}` : ""}
-                </span>
-              )}
-              <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
-              {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
+            <div className="flex min-w-0 flex-col gap-0.5 lg:flex-row lg:items-baseline lg:gap-2">
+              <span className="min-w-0 truncate text-[12px] font-medium text-foreground/85 lg:max-w-[42%] lg:shrink-0">
+                {location}
+              </span>
+              <span className="min-w-0 truncate text-[12px] text-foreground/75" title={preview}>
+                "{preview}"
+              </span>
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title={meta}>
+              {meta}
             </div>
             {prominentStatusReason && (
-              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
-                <span className="font-medium uppercase tracking-wider">Failure reason:</span>{" "}
-                {prominentStatusReason}
+              <div
+                className="mt-1 flex min-w-0 items-center gap-1 border border-destructive/25 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive"
+                title={prominentStatusReason}
+              >
+                <span className="shrink-0 font-medium uppercase tracking-wider">{prominentStatusLabel}:</span>
+                <span className="min-w-0 truncate">{prominentStatusReason}</span>
               </div>
             )}
           </div>
@@ -688,32 +733,18 @@ function FeedbackRow({
               <button
                 type="button"
                 data-testid={`toggle-${item.id}`}
-                aria-label={`${collapsedByDefault ? "Show" : "Hide"} feedback details from ${item.author}`}
+                aria-label={`${open ? "Hide" : "Show"} feedback details from ${item.author}`}
                 title="Toggle feedback details"
                 className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
-                Details
+                {open ? "Hide" : "Open"}
               </button>
             </Collapsible.Trigger>
-            {!readOnly && ["accept", "reject", "flag"].map((decision) => (
-              <button
-                type="button"
-                key={decision}
-                onClick={() => overrideMutation.mutate(decision)}
-                data-testid={`override-${decision}-${item.id}`}
-                aria-label={`${decision} feedback from ${item.author}`}
-                className={`px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
-                  item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
-                }`}
-              >
-                {decision}
-              </button>
-            ))}
           </div>
         </div>
       </div>
       <Collapsible.Content>
-        <div className="px-4 pb-3">
+        <div className="px-4 pb-3 pl-[calc(1rem+4.5rem)]">
           {item.bodyHtml ? (
             <div
               className="feedback-markdown text-[12px] leading-relaxed"
@@ -734,9 +765,115 @@ function FeedbackRow({
               {item.decisionReason}
             </p>
           )}
+          {!readOnly && (
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-border/70 pt-2">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                Manual decision
+              </span>
+              <div className="flex flex-wrap items-center gap-1">
+                {FEEDBACK_DECISIONS.map((decision) => (
+                  <button
+                    type="button"
+                    key={decision}
+                    onClick={() => overrideMutation.mutate(decision)}
+                    disabled={overrideMutation.isPending}
+                    data-testid={`override-${decision}-${item.id}`}
+                    aria-label={`${decision} feedback from ${item.author}`}
+                    className={`px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30 ${
+                      item.decision === decision ? "bg-foreground text-background" : "border border-border text-muted-foreground"
+                    }`}
+                  >
+                    {decision}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </Collapsible.Content>
     </Collapsible.Root>
+  );
+}
+
+function FeedbackGroupSection({
+  section,
+  prId,
+  readOnly,
+  globalDrainMode,
+}: {
+  section: FeedbackGroupSectionView;
+  prId: string;
+  readOnly?: boolean;
+  globalDrainMode: boolean;
+}) {
+  const [open, setOpen] = useState(section.defaultOpen);
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen} className="border-b border-border last:border-b-0">
+      <div className="sticky top-0 z-[1] border-b border-border/80 bg-background/95 px-4 py-2">
+        <Collapsible.Trigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-3 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            aria-label={`${open ? "Collapse" : "Expand"} ${section.label.toLowerCase()} feedback`}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span aria-hidden="true" className="w-3 text-[10px] text-muted-foreground">
+                {open ? "▾" : "▸"}
+              </span>
+              <span className="text-[10px] uppercase tracking-wider text-foreground/80">
+                {section.label}
+              </span>
+              <span className="text-[11px] text-muted-foreground">
+                {section.items.length}
+              </span>
+            </span>
+            {section.summary && (
+              <span className="truncate text-[11px] text-muted-foreground">
+                {section.summary}
+              </span>
+            )}
+          </button>
+        </Collapsible.Trigger>
+      </div>
+      <Collapsible.Content>
+        {section.items.map((item) => (
+          <FeedbackRow
+            key={item.id}
+            item={item}
+            prId={prId}
+            readOnly={readOnly}
+            globalDrainMode={globalDrainMode}
+          />
+        ))}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+
+function FeedbackGroups({
+  items,
+  prId,
+  readOnly,
+  globalDrainMode,
+}: {
+  items: FeedbackItem[];
+  prId: string;
+  readOnly?: boolean;
+  globalDrainMode: boolean;
+}) {
+  return (
+    <>
+      {getFeedbackGroupSections(items).map((section) => (
+        <FeedbackGroupSection
+          key={section.key}
+          section={section}
+          prId={prId}
+          readOnly={readOnly}
+          globalDrainMode={globalDrainMode}
+        />
+      ))}
+    </>
   );
 }
 
@@ -1700,18 +1837,7 @@ export default function Dashboard() {
                     <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                       <span>status: {formatStatusLabel(selectedPR.status)}</span>
                       {!selectedPRWatchEnabled && <WatchPausedIndicator />}
-                      <span>{selectedPR.feedbackItems.length} items</span>
-                      {selectedPR.feedbackItems.length > 0 && (() => {
-                        const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
-                        return (
-                          <>
-                            {counts.queued > 0 && <span>{counts.queued} queued</span>}
-                            {counts.inProgress > 0 && <span>{counts.inProgress} in progress</span>}
-                            {counts.failed > 0 && <span>{counts.failed} failed</span>}
-                            {counts.warning > 0 && <span>{counts.warning} warnings</span>}
-                          </>
-                        );
-                      })()}
+                      <span>feedback: {formatFeedbackOverview(selectedPR.feedbackItems)}</span>
                       {selectedPR.testsPassed !== null && (
                         <span>tests: {selectedPR.testsPassed ? "pass" : "fail"}</span>
                       )}
@@ -1784,15 +1910,12 @@ export default function Dashboard() {
                       : "No feedback yet. Background watch is paused for this PR."}
                   </div>
                 ) : (
-                  selectedPR.feedbackItems.map((item) => (
-                    <FeedbackRow
-                      key={item.id}
-                      item={item}
-                      prId={selectedPR.id}
-                      readOnly={isArchived}
-                      globalDrainMode={globalDrainMode}
-                    />
-                  ))
+                  <FeedbackGroups
+                    items={selectedPR.feedbackItems}
+                    prId={selectedPR.id}
+                    readOnly={isArchived}
+                    globalDrainMode={globalDrainMode}
+                  />
                 )}
               </div>
             </>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -866,7 +866,7 @@ function FeedbackGroups({
     <>
       {getFeedbackGroupSections(items).map((section) => (
         <FeedbackGroupSection
-          key={section.key}
+          key={`${prId}-${section.key}`}
           section={section}
           prId={prId}
           readOnly={readOnly}


### PR DESCRIPTION
## Summary

- Group the dashboard feedback panel into attention, running, and done sections so unresolved work is visible first.
- Collapse noisy full comment bodies behind row-level details and show compact cleaned previews by default.
- Move manual accept/reject/flag decisions into expanded details while keeping retry actions visible for failed or warning feedback.
- Add focused display helpers and tests for preview cleaning, grouping, and PR-level feedback summaries.

## Why

The middle feedback panel was showing every review comment with full body, repeated metadata, and all decision controls at once. That made it hard to quickly understand which comments needed action versus which were already handled.

## Impact

Users can scan the feedback state faster: blocked items and active work stay prominent, completed feedback stays out of the way, and deeper comment content remains available on demand.

## Validation

- `npm run check`
- `npm run test:all`
- `npm run build`
- Live browser verification at `http://127.0.0.1:5002/#/`, including expanding a feedback row and confirming details/actions render correctly.