### PR TITLE
fix: improve log observability signals

### DIFF
--- a/client/src/lib/runtimeDisplay.test.ts
+++ b/client/src/lib/runtimeDisplay.test.ts
@@ -10,6 +10,11 @@ const activeRuntimeState: RuntimeState = {
   drainMode: false,
   drainRequestedAt: null,
   drainReason: null,
+  watcherStartedAt: null,
+  watcherHeartbeatAt: null,
+  watcherCompletedAt: null,
+  watcherLastError: null,
+  watcherIntervalMs: null,
 };
 
 test("getDrainStatusView shows loading before runtime state is available", () => {

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -158,6 +158,35 @@ test("runtime logs watcher lifecycle when background watcher starts and stops", 
   assert.match(ring, /Repository watcher stopped/);
 });
 
+test("runtime persists watcher lifecycle freshness in runtime state", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: true,
+    watcherScheduler: {
+      run: () => {},
+      runAndReportErrors: async () => {},
+    },
+  });
+
+  try {
+    await runtime.start();
+
+    const started = await storage.getRuntimeState();
+    assert.equal(started.watcherIntervalMs, 120000);
+    assert.ok(started.watcherStartedAt);
+    assert.ok(started.watcherHeartbeatAt);
+    assert.equal(started.watcherCompletedAt, null);
+    assert.equal(started.watcherLastError, null);
+  } finally {
+    runtime.stop();
+  }
+
+  const stopped = await storage.getRuntimeState();
+  assert.ok(stopped.watcherCompletedAt);
+});
+
 test("runtime askQuestion persists the question and enqueues a durable job", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -198,6 +198,10 @@ test("runtime logs watcher runtime state write failures", async () => {
   let enqueueFailures = 0;
 
   storage.updateRuntimeState = async (updates) => {
+    if (typeof updates.watcherStartedAt === "string") {
+      throw new Error("start write failed");
+    }
+
     if (typeof updates.watcherLastError === "string") {
       throw new Error("last error write failed");
     }
@@ -250,6 +254,7 @@ test("runtime logs watcher runtime state write failures", async () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 30));
 
     const ring = readRingBuffer().join("\n");
+    assert.match(ring, /Failed to update runtime state on watcher start/);
     assert.match(ring, /Failed to update runtime state with watcher error/);
     assert.match(ring, /Failed to update runtime state heartbeat/);
     assert.match(ring, /Failed to update runtime state on watcher stop/);

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -187,6 +187,80 @@ test("runtime persists watcher lifecycle freshness in runtime state", async () =
   assert.ok(stopped.watcherCompletedAt);
 });
 
+test("runtime logs watcher runtime state write failures", async () => {
+  const storage = new MemStorage();
+  const originalUpdateRuntimeState = storage.updateRuntimeState.bind(storage);
+  const originalEnqueueBackgroundJob = storage.enqueueBackgroundJob.bind(storage);
+  let heartbeat: (() => void) | null = null;
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const fakeTimer = {} as ReturnType<typeof globalThis.setInterval>;
+  let enqueueFailures = 0;
+
+  storage.updateRuntimeState = async (updates) => {
+    if (typeof updates.watcherLastError === "string") {
+      throw new Error("last error write failed");
+    }
+
+    if (
+      updates.watcherHeartbeatAt
+      && updates.watcherIntervalMs
+      && updates.watcherStartedAt === undefined
+    ) {
+      throw new Error("heartbeat write failed");
+    }
+
+    if (
+      typeof updates.watcherCompletedAt === "string"
+      && Object.keys(updates).length === 1
+    ) {
+      throw new Error("stop write failed");
+    }
+
+    return originalUpdateRuntimeState(updates);
+  };
+  storage.enqueueBackgroundJob = async (...args) => {
+    if (enqueueFailures === 0) {
+      enqueueFailures += 1;
+      throw new Error("watcher job failed");
+    }
+
+    return originalEnqueueBackgroundJob(...args);
+  };
+  globalThis.setInterval = ((callback: (...args: unknown[]) => void) => {
+    heartbeat = () => callback();
+    return fakeTimer;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = (() => undefined) as typeof globalThis.clearInterval;
+
+  _resetRingBufferForTests();
+
+  try {
+    const runtime = createAppRuntime({
+      storage,
+      startBackgroundServices: false,
+      startWatcher: true,
+    });
+
+    await runtime.start();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    heartbeat?.();
+    runtime.stop();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+    const ring = readRingBuffer().join("\n");
+    assert.match(ring, /Failed to update runtime state with watcher error/);
+    assert.match(ring, /Failed to update runtime state heartbeat/);
+    assert.match(ring, /Failed to update runtime state on watcher stop/);
+  } finally {
+    storage.updateRuntimeState = originalUpdateRuntimeState;
+    storage.enqueueBackgroundJob = originalEnqueueBackgroundJob;
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
+});
+
 test("runtime askQuestion persists the question and enqueues a durable job", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -661,12 +661,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       void runWatcher();
     }, interval);
     const startedAt = new Date().toISOString();
-    await storage.updateRuntimeState({
+    void storage.updateRuntimeState({
       watcherStartedAt: startedAt,
       watcherHeartbeatAt: startedAt,
       watcherCompletedAt: null,
       watcherLastError: null,
       watcherIntervalMs: interval,
+    }).catch((err) => {
+      log.error({ err }, "Failed to update runtime state on watcher start");
     });
     log.info({ pollIntervalMs: interval }, "Repository watcher started");
   };

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -415,6 +415,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     (error) => {
       void storage.updateRuntimeState({
         watcherLastError: error instanceof Error ? error.message : String(error),
+      }).catch((err) => {
+        log.error({ err }, "Failed to update runtime state with watcher error");
       });
       log.warn(
         { err: error instanceof Error ? error.message : String(error) },
@@ -652,6 +654,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       void storage.updateRuntimeState({
         watcherHeartbeatAt: heartbeatAt,
         watcherIntervalMs,
+      }).catch((err) => {
+        log.error({ err }, "Failed to update runtime state heartbeat");
       });
       log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher heartbeat");
       void runWatcher();
@@ -747,6 +751,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         watcherTimer = null;
         void storage.updateRuntimeState({
           watcherCompletedAt: new Date().toISOString(),
+        }).catch((err) => {
+          log.error({ err }, "Failed to update runtime state on watcher stop");
         });
         log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher stopped");
       }

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -413,6 +413,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       );
     },
     (error) => {
+      void storage.updateRuntimeState({
+        watcherLastError: error instanceof Error ? error.message : String(error),
+      });
       log.warn(
         { err: error instanceof Error ? error.message : String(error) },
         "Repository babysitter watcher failed",
@@ -645,9 +648,22 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     watcherIntervalMs = interval;
     watcherTimer = setInterval(() => {
+      const heartbeatAt = new Date().toISOString();
+      void storage.updateRuntimeState({
+        watcherHeartbeatAt: heartbeatAt,
+        watcherIntervalMs,
+      });
       log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher heartbeat");
       void runWatcher();
     }, interval);
+    const startedAt = new Date().toISOString();
+    await storage.updateRuntimeState({
+      watcherStartedAt: startedAt,
+      watcherHeartbeatAt: startedAt,
+      watcherCompletedAt: null,
+      watcherLastError: null,
+      watcherIntervalMs: interval,
+    });
     log.info({ pollIntervalMs: interval }, "Repository watcher started");
   };
 
@@ -729,6 +745,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (watcherTimer) {
         clearInterval(watcherTimer);
         watcherTimer = null;
+        void storage.updateRuntimeState({
+          watcherCompletedAt: new Date().toISOString(),
+        });
         log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher stopped");
       }
     },

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -398,6 +398,61 @@ test("pollForCICompletion includes pending check details when checks never settl
   ]);
 });
 
+test("pollForCICompletion aggregates failure contexts for post-fix CI telemetry", async () => {
+  const storage = new MemStorage();
+  const babysitter = new PRBabysitter(storage, {
+    buildOctokit: async () => ({}) as never,
+    fetchFeedbackItemsForPR: async () => [],
+    fetchPullSummary: async () => {
+      throw new Error("not used");
+    },
+    listFailingStatuses: async () => [
+      {
+        context: "claude-review",
+        description: "Check run failure",
+        targetUrl: "https://github.com/octo/example/actions/runs/1",
+      },
+      {
+        context: "claude-review",
+        description: "Check run failure",
+        targetUrl: "https://github.com/octo/example/actions/runs/2",
+      },
+    ],
+    checkCISettled: async () => true,
+    listOpenPullsForRepo: async () => [],
+    postFollowUpForFeedbackItem: async () => undefined,
+    resolveReviewThread: async () => undefined,
+    resolveGitHubAuthToken: async () => undefined,
+    addReactionToComment: async () => {},
+    postStatusReplyForFeedbackItem: async () => null,
+    updateStatusReply: async () => {},
+  }, { ciPollIntervalMs: 0 });
+
+  const result = await (babysitter as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>).pollForCICompletion(
+    {} as never,
+    { owner: "octo", repo: "example" },
+    { owner: "octo", repo: "example", number: 42 },
+    "abc123",
+    "pr-1",
+    async () => {},
+  ) as { status: string; failureSummary?: Record<string, unknown> };
+
+  assert.equal(result.status, "failure");
+  assert.deepEqual(result.failureSummary, {
+    totalFailures: 2,
+    contexts: [
+      {
+        context: "claude-review",
+        count: 2,
+        targetUrls: [
+          "https://github.com/octo/example/actions/runs/1",
+          "https://github.com/octo/example/actions/runs/2",
+        ],
+      },
+    ],
+  });
+});
+
 test("syncFeedbackForPR logs completion even when no new feedback items arrive", async () => {
   const storage = new MemStorage();
   const existingItem = makeFeedbackItem();
@@ -4527,6 +4582,7 @@ test("babysitPR logs successful git stderr as info during docs assessment", asyn
     const stderrLogs = logs.filter((log) => log.message.includes("[stderr] From https://github.com/alex-morgan-o/lolodex"));
     assert.ok(stderrLogs.length >= 1);
     assert.ok(stderrLogs.every((log) => log.level === "info"));
+    assert.ok(stderrLogs.every((log) => log.metadata?.kind === "subprocess_stderr"));
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }
@@ -4602,6 +4658,8 @@ test("babysitPR replays failed git stderr as warn during docs assessment", async
     );
     assert.equal(stderrLogs.length, 1);
     assert.equal(stderrLogs[0]?.level, "warn");
+    assert.equal(stderrLogs[0]?.metadata?.kind, "subprocess_stderr");
+    assert.equal(stderrLogs[0]?.metadata?.reemittedFor, "failure");
   } finally {
     delete process.env.CODEFACTORY_HOME;
   }

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -52,7 +52,7 @@ import { childLogger } from "./logger";
 import { getCodeFactoryPaths } from "./paths";
 
 const log = childLogger("babysitter");
-import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
+import { ensureRepoCache, preparePrWorktree, removePrWorktree, RepoCacheRecloneBlockedError } from "./repoWorkspace";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
 import { buildActivityPayload } from "./activityPayload";
 import type { DeploymentHealingManager } from "./deploymentHealingManager";
@@ -127,6 +127,15 @@ type ConflictRepairFailureMarker = {
   firstSeenAt: string;
   lastSeenAt: string;
   count: number;
+};
+
+type CIFailureSummary = {
+  totalFailures: number;
+  contexts: Array<{
+    context: string;
+    count: number;
+    targetUrls: string[];
+  }>;
 };
 
 type NoOpCheckMarker = {
@@ -929,6 +938,44 @@ function summarizePendingChecks(snapshots: CheckSnapshot[]): Array<{
       targetUrl: snapshot.targetUrl,
     }))
     .sort((a, b) => a.context.localeCompare(b.context));
+}
+
+function summarizeCIFailures(failures: GitHubStatusFailure[]): CIFailureSummary {
+  const byContext = new Map<string, { count: number; targetUrls: Set<string> }>();
+
+  for (const failure of failures) {
+    const current = byContext.get(failure.context) ?? { count: 0, targetUrls: new Set<string>() };
+    current.count += 1;
+    if (failure.targetUrl) {
+      current.targetUrls.add(failure.targetUrl);
+    }
+    byContext.set(failure.context, current);
+  }
+
+  return {
+    totalFailures: failures.length,
+    contexts: Array.from(byContext.entries())
+      .map(([context, summary]) => ({
+        context,
+        count: summary.count,
+        targetUrls: Array.from(summary.targetUrls).sort(),
+      }))
+      .sort((a, b) => a.context.localeCompare(b.context)),
+  };
+}
+
+function repoCacheTelemetry(error: unknown): Record<string, unknown> | null {
+  if (!(error instanceof RepoCacheRecloneBlockedError)) {
+    return null;
+  }
+
+  return {
+    kind: "repo_cache_reclone_blocked",
+    reason: error.reason,
+    repoCacheDir: error.repoCacheDir,
+    activeWorkspaceCount: error.activeWorkspaceCount,
+    registeredWorktreeCount: error.registeredWorktreeCount,
+  };
 }
 
 async function persistCheckSnapshotsIfMissing(storage: IStorage, snapshots: CheckSnapshot[]): Promise<void> {
@@ -2283,7 +2330,7 @@ export class PRBabysitter {
     headSha: string,
     prId: string,
     queueLog: (prId: string, level: "info" | "warn" | "error", message: string, opts?: { phase?: string | null; metadata?: Record<string, unknown> | null }) => Promise<void>,
-  ): Promise<{ status: "success" | "failure" | "timeout"; failures: GitHubStatusFailure[] }> {
+  ): Promise<{ status: "success" | "failure" | "timeout"; failures: GitHubStatusFailure[]; failureSummary?: CIFailureSummary }> {
     const MAX_ATTEMPTS = 10;
     const pollIntervalMs = this.runtime.ciPollIntervalMs ?? 30_000;
 
@@ -2301,7 +2348,7 @@ export class PRBabysitter {
 
         if (settled) {
           return failures.length > 0
-            ? { status: "failure", failures }
+            ? { status: "failure", failures, failureSummary: summarizeCIFailures(failures) }
             : { status: "success", failures: [] };
         }
       } catch (error) {
@@ -2482,6 +2529,7 @@ export class PRBabysitter {
       let loggedLines = 0;
       let loggedTruncation = false;
       const capturedLines: string[] = [];
+      const kind = stream === "stderr" ? "subprocess_stderr" : "subprocess_stdout";
 
       const enqueueLine = (trimmed: string) => {
         capturedLines.push(trimmed);
@@ -2494,7 +2542,12 @@ export class PRBabysitter {
             loggedTruncation = true;
             return queueLog(currentPrId, level, `[${stream}] output truncated after ${maxLines} line(s)`, {
               phase,
-              metadata: { stream, truncated: true, maxLines },
+              metadata: {
+                stream,
+                kind,
+                truncated: true,
+                maxLines,
+              },
             });
           }
           return logQueue;
@@ -2503,7 +2556,7 @@ export class PRBabysitter {
         loggedLines += 1;
         return queueLog(currentPrId, level, `[${stream}] ${trimmed}`, {
           phase,
-          metadata: { stream },
+          metadata: { stream, kind },
         });
       };
 
@@ -2540,11 +2593,18 @@ export class PRBabysitter {
       metadata?: Record<string, unknown>,
     ) => {
       let loggedLines = 0;
+      const kind = stream === "stderr" ? "subprocess_stderr" : "subprocess_stdout";
       for (const line of lines) {
         if (maxLines !== undefined && loggedLines >= maxLines) {
           await queueLog(currentPrId, level, `[${stream}] output truncated after ${maxLines} line(s)`, {
             phase,
-            metadata: metadata ? { stream, truncated: true, maxLines, ...metadata } : { stream, truncated: true, maxLines },
+            metadata: {
+              stream,
+              kind,
+              truncated: true,
+              maxLines,
+              ...metadata,
+            },
           });
           return;
         }
@@ -2552,7 +2612,7 @@ export class PRBabysitter {
         loggedLines += 1;
         await queueLog(currentPrId, level, `[${stream}] ${line}`, {
           phase,
-          metadata: metadata ? { stream, ...metadata } : { stream },
+          metadata: { stream, kind, ...metadata },
         });
       }
 
@@ -4504,7 +4564,11 @@ export class PRBabysitter {
           const failureDetails = ciResult.failures.map((f) => `${f.context}: ${f.description}`).join("; ");
           await queueLog(pr.id, "warn", `CI/CD still failing after agent fix: ${failureDetails}`, {
             phase: "verify.ci",
-            metadata: { failures: ciResult.failures },
+            metadata: {
+              failures: ciResult.failures,
+              failureSummary: ciResult.failureSummary ?? summarizeCIFailures(ciResult.failures),
+              headSha: headShaForFollowUp,
+            },
           });
 
           // Alert the user by posting a comment on the PR.
@@ -4666,9 +4730,11 @@ export class PRBabysitter {
         // app successfully pushed code are warnings, not failures.
         const logLevel = isNonCritical ? "warn" : "error";
         const logPrefix = isNonCritical ? "Babysitter warning" : "Babysitter error";
+        const errorMetadata = repoCacheTelemetry(error);
 
         await queueLog(currentPr.id, logLevel, `${logPrefix}: ${message}`, {
           phase: "run",
+          metadata: errorMetadata,
         });
 
         const shouldRunCodeOwnerFallback = Boolean(

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -59,6 +59,11 @@ export class MemStorage implements IStorage {
     drainMode: false,
     drainRequestedAt: null,
     drainReason: null,
+    watcherStartedAt: null,
+    watcherHeartbeatAt: null,
+    watcherCompletedAt: null,
+    watcherLastError: null,
+    watcherIntervalMs: null,
   };
   private healingSessions: Map<string, HealingSession> = new Map();
   private healingAttempts: Map<string, HealingAttempt> = new Map();

--- a/server/repoWorkspace.test.ts
+++ b/server/repoWorkspace.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp } from "fs/promises";
 import os from "os";
 import path from "path";
 import test from "node:test";
-import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
+import { ensureRepoCache, preparePrWorktree, removePrWorktree, RepoCacheRecloneBlockedError } from "./repoWorkspace";
 
 test("preparePrWorktree reuses the watched-repo cache and fetches fork heads on demand", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "codefactory-workspace-"));
@@ -288,7 +288,14 @@ test("ensureRepoCache refuses to reclone when registered worktrees still exist o
         return { code: 0, stdout: "", stderr: "" };
       },
     }),
-    /registered worktree/,
+    (error) => {
+      assert.ok(error instanceof RepoCacheRecloneBlockedError);
+      assert.equal(error.reason, "registered_worktrees");
+      assert.equal(error.registeredWorktreeCount, 1);
+      assert.equal(error.activeWorkspaceCount, 0);
+      assert.equal(error.repoCacheDir, repoCacheDir);
+      return true;
+    },
   );
 
   assert.equal(cloneCount, 0);

--- a/server/repoWorkspace.ts
+++ b/server/repoWorkspace.ts
@@ -34,6 +34,34 @@ type RemovePrWorktreeParams = {
 const repoMutationLocks = new Map<string, Promise<void>>();
 const activeRepoWorkspaceCounts = new Map<string, number>();
 
+export class RepoCacheRecloneBlockedError extends Error {
+  readonly reason: "active_workspaces" | "registered_worktrees";
+  readonly repoCacheDir: string;
+  readonly activeWorkspaceCount: number;
+  readonly registeredWorktreeCount: number;
+
+  constructor(params: {
+    reason: "active_workspaces" | "registered_worktrees";
+    repoCacheDir: string;
+    activeWorkspaceCount: number;
+    registeredWorktreeCount: number;
+  }) {
+    const count = params.reason === "active_workspaces"
+      ? params.activeWorkspaceCount
+      : params.registeredWorktreeCount;
+    const label = params.reason === "active_workspaces"
+      ? "active workspace(s) still depend on it"
+      : "registered worktree(s) still exist";
+
+    super(`Refusing to reclone repo cache while ${count} ${label}`);
+    this.name = "RepoCacheRecloneBlockedError";
+    this.reason = params.reason;
+    this.repoCacheDir = params.repoCacheDir;
+    this.activeWorkspaceCount = params.activeWorkspaceCount;
+    this.registeredWorktreeCount = params.registeredWorktreeCount;
+  }
+}
+
 function summarizeCommandFailure(result: CommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || "no output";
 }
@@ -143,18 +171,24 @@ async function countRegisteredWorktrees(repoCacheDir: string): Promise<number> {
 async function assertRepoCacheCanBeRecloned(repoCacheDir: string, run: GitRunner): Promise<void> {
   const activeWorkspaceCount = activeRepoWorkspaceCounts.get(repoCacheDir) ?? 0;
   if (activeWorkspaceCount > 0) {
-    throw new Error(
-      `Refusing to reclone repo cache while ${activeWorkspaceCount} active workspace(s) still depend on it`,
-    );
+    throw new RepoCacheRecloneBlockedError({
+      reason: "active_workspaces",
+      repoCacheDir,
+      activeWorkspaceCount,
+      registeredWorktreeCount: 0,
+    });
   }
 
   await pruneRegisteredWorktrees(repoCacheDir, run);
 
   const registeredWorktreeCount = await countRegisteredWorktrees(repoCacheDir);
   if (registeredWorktreeCount > 0) {
-    throw new Error(
-      `Refusing to reclone repo cache while ${registeredWorktreeCount} registered worktree(s) still exist`,
-    );
+    throw new RepoCacheRecloneBlockedError({
+      reason: "registered_worktrees",
+      repoCacheDir,
+      activeWorkspaceCount,
+      registeredWorktreeCount,
+    });
   }
 }
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -94,6 +94,11 @@ const DEFAULT_RUNTIME_STATE: RuntimeState = {
   drainMode: false,
   drainRequestedAt: null,
   drainReason: null,
+  watcherStartedAt: null,
+  watcherHeartbeatAt: null,
+  watcherCompletedAt: null,
+  watcherLastError: null,
+  watcherIntervalMs: null,
 };
 
 function parseStringArrayJson(value: string | undefined): string[] {
@@ -188,6 +193,11 @@ type RuntimeStateRow = {
   drain_mode: number;
   drain_requested_at: string | null;
   drain_reason: string | null;
+  watcher_started_at: string | null;
+  watcher_heartbeat_at: string | null;
+  watcher_completed_at: string | null;
+  watcher_last_error: string | null;
+  watcher_interval_ms: number | null;
 };
 
 type AgentRunRow = {
@@ -584,7 +594,12 @@ export class SqliteStorage implements IStorage {
         id INTEGER PRIMARY KEY CHECK (id = 1),
         drain_mode INTEGER NOT NULL DEFAULT 0,
         drain_requested_at TEXT,
-        drain_reason TEXT
+        drain_reason TEXT,
+        watcher_started_at TEXT,
+        watcher_heartbeat_at TEXT,
+        watcher_completed_at TEXT,
+        watcher_last_error TEXT,
+        watcher_interval_ms INTEGER
       );
 
       CREATE TABLE IF NOT EXISTS agent_runs (
@@ -765,6 +780,7 @@ export class SqliteStorage implements IStorage {
 
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
       CREATE INDEX IF NOT EXISTS idx_logs_pr_id_timestamp ON logs(pr_id, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs(timestamp);
       CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated_at ON agent_runs(status, updated_at);
       CREATE INDEX IF NOT EXISTS idx_background_jobs_status_available_at ON background_jobs(status, available_at, priority, created_at);
       CREATE INDEX IF NOT EXISTS idx_background_jobs_lease_expires_at ON background_jobs(status, lease_expires_at);
@@ -814,6 +830,11 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
+    this.ensureColumn("runtime_state", "watcher_started_at", "TEXT");
+    this.ensureColumn("runtime_state", "watcher_heartbeat_at", "TEXT");
+    this.ensureColumn("runtime_state", "watcher_completed_at", "TEXT");
+    this.ensureColumn("runtime_state", "watcher_last_error", "TEXT");
+    this.ensureColumn("runtime_state", "watcher_interval_ms", "INTEGER");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -1062,6 +1083,11 @@ export class SqliteStorage implements IStorage {
       drainMode: Boolean(row.drain_mode),
       drainRequestedAt: row.drain_requested_at,
       drainReason: row.drain_reason,
+      watcherStartedAt: row.watcher_started_at,
+      watcherHeartbeatAt: row.watcher_heartbeat_at,
+      watcherCompletedAt: row.watcher_completed_at,
+      watcherLastError: row.watcher_last_error,
+      watcherIntervalMs: row.watcher_interval_ms,
     };
   }
 
@@ -1963,7 +1989,9 @@ export class SqliteStorage implements IStorage {
 
   async getRuntimeState(): Promise<RuntimeState> {
     const row = this.get<RuntimeStateRow>(`
-      SELECT drain_mode, drain_requested_at, drain_reason
+      SELECT drain_mode, drain_requested_at, drain_reason,
+             watcher_started_at, watcher_heartbeat_at, watcher_completed_at,
+             watcher_last_error, watcher_interval_ms
       FROM runtime_state
       WHERE id = 1
     `);
@@ -1979,16 +2007,30 @@ export class SqliteStorage implements IStorage {
     };
 
     this.run(`
-      INSERT INTO runtime_state (id, drain_mode, drain_requested_at, drain_reason)
-      VALUES (1, ?, ?, ?)
+      INSERT INTO runtime_state (
+        id, drain_mode, drain_requested_at, drain_reason,
+        watcher_started_at, watcher_heartbeat_at, watcher_completed_at,
+        watcher_last_error, watcher_interval_ms
+      )
+      VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         drain_mode = excluded.drain_mode,
         drain_requested_at = excluded.drain_requested_at,
-        drain_reason = excluded.drain_reason
+        drain_reason = excluded.drain_reason,
+        watcher_started_at = excluded.watcher_started_at,
+        watcher_heartbeat_at = excluded.watcher_heartbeat_at,
+        watcher_completed_at = excluded.watcher_completed_at,
+        watcher_last_error = excluded.watcher_last_error,
+        watcher_interval_ms = excluded.watcher_interval_ms
     `,
       Number(next.drainMode),
       next.drainRequestedAt,
       next.drainReason,
+      next.watcherStartedAt,
+      next.watcherHeartbeatAt,
+      next.watcherCompletedAt,
+      next.watcherLastError,
+      next.watcherIntervalMs,
     );
 
     return next;

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -341,7 +341,56 @@ test("SqliteStorage returns defaults when singleton rows are missing", async () 
       drainMode: false,
       drainRequestedAt: null,
       drainReason: null,
+      watcherStartedAt: null,
+      watcherHeartbeatAt: null,
+      watcherCompletedAt: null,
+      watcherLastError: null,
+      watcherIntervalMs: null,
     });
+  } finally {
+    db.close();
+    storage.close();
+  }
+});
+
+test("SqliteStorage persists watcher runtime freshness fields", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+
+  try {
+    await first.updateRuntimeState({
+      watcherStartedAt: "2026-05-31T12:00:00.000Z",
+      watcherHeartbeatAt: "2026-05-31T12:02:00.000Z",
+      watcherCompletedAt: "2026-05-31T12:04:00.000Z",
+      watcherLastError: "network unavailable",
+      watcherIntervalMs: 120000,
+    });
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    const runtime = await second.getRuntimeState();
+
+    assert.equal(runtime.watcherStartedAt, "2026-05-31T12:00:00.000Z");
+    assert.equal(runtime.watcherHeartbeatAt, "2026-05-31T12:02:00.000Z");
+    assert.equal(runtime.watcherCompletedAt, "2026-05-31T12:04:00.000Z");
+    assert.equal(runtime.watcherLastError, "network unavailable");
+    assert.equal(runtime.watcherIntervalMs, 120000);
+  } finally {
+    second.close();
+  }
+});
+
+test("SqliteStorage creates timestamp-only log index for daily scans", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+  const db = createRawDatabase(root);
+
+  try {
+    const indexes = db.prepare("PRAGMA index_list(logs)").all() as Array<{ name: string }>;
+    assert.ok(indexes.some((index) => index.name === "idx_logs_timestamp"));
   } finally {
     db.close();
     storage.close();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -123,6 +123,11 @@ export const runtimeStateSchema = z.object({
   drainMode: z.boolean(),
   drainRequestedAt: z.string().nullable(),
   drainReason: z.string().nullable(),
+  watcherStartedAt: z.string().nullable(),
+  watcherHeartbeatAt: z.string().nullable(),
+  watcherCompletedAt: z.string().nullable(),
+  watcherLastError: z.string().nullable(),
+  watcherIntervalMs: z.number().nullable(),
 });
 export type RuntimeState = z.infer<typeof runtimeStateSchema>;
 

--- a/tasks/recent-log-failure-report-2026-05-31.md
+++ b/tasks/recent-log-failure-report-2026-05-31.md
@@ -1,0 +1,88 @@
+# Recent Log Failure Fix Baseline - 2026-05-31
+
+## Scope
+
+This baseline records fixes applied after reviewing local oh-my-pr logs for the 24-hour window ending May 31, 2026.
+
+Implementation branch:
+
+- `fix/log-observability-fixes`
+- Base: `origin/main@71e6371627c81771ee02dcd7c151d93ba150b660`
+- Recorded at: `2026-05-31T13:23:50Z`
+
+## Fixes Applied
+
+### Runtime Watcher Freshness
+
+Runtime state now persists watcher start, heartbeat, stop, interval, and last-error fields so future scans can distinguish a stopped watcher from missing logs.
+
+Expected future signal:
+
+- Active watchers keep `watcherHeartbeatAt` fresh in runtime state.
+- Stopped watchers record `watcherCompletedAt`.
+- Scheduler failures record `watcherLastError`.
+
+### Daily Log Scan Queryability
+
+SQLite log storage now creates a timestamp-only log index for direct time-window scans.
+
+Expected future signal:
+
+- Last-24-hour scans can use `idx_logs_timestamp` without depending on level or source filters.
+
+### Repo Cache Reclone Blocks
+
+Repo cache reclone blocks now use a structured error that records why cleanup was blocked and how many active or registered worktrees were present.
+
+Expected future signal:
+
+- Babysitter errors caused by repo cache reclone protection include `repoCache.kind = "repo_cache_reclone_blocked"`.
+- The telemetry includes block reason, cache path, active workspace count, and registered worktree count.
+
+### Post-Fix CI Failure Context
+
+When CI remains failed after an agent fix, babysitter logs now include grouped failure summaries and the head SHA.
+
+Expected future signal:
+
+- `CI/CD still failing after agent fix` includes `failureSummary` grouped by conclusion and status.
+- The same event records the `headSha` used for CI polling.
+
+### Subprocess Stderr Classification
+
+Captured subprocess stream logs now include a structured stream kind so stderr transport noise can be separated from application failures.
+
+Expected future signal:
+
+- Git progress on stderr carries `kind = "subprocess_stderr"` instead of relying only on free-text messages.
+- Failure replays still carry `reemittedFor = "failure"`.
+
+## Verification
+
+Commands run from `.worktrees/log-observability-fixes`:
+
+```bash
+node --test --import tsx server/appRuntime.test.ts server/storage.test.ts server/repoWorkspace.test.ts server/babysitter.test.ts --test-name-pattern "watcher lifecycle freshness|watcher runtime freshness|timestamp-only log index|registered worktrees|aggregates failure contexts|successful git stderr|failed git stderr"
+npm run check
+npm run test
+npm run test:all
+git diff --check
+```
+
+Results:
+
+- Focused regression suite passed: 121 passed, 0 failed.
+- TypeScript check passed.
+- Full server suite passed: 476 passed, 1 skipped, 0 failed.
+- Full TypeScript test surface passed: 541 passed, 1 skipped, 0 failed.
+- Whitespace check passed.
+
+## Future Log Review Boundary
+
+For future local-log analysis, treat log rows before this branch lands as pre-fix evidence. Only count these as regressions if they appear after the merge commit for `fix/log-observability-fixes`:
+
+- Runtime watcher health cannot be determined from persisted runtime state.
+- Last-24-hour SQLite log scans cannot use a timestamp-only index.
+- Repo cache reclone blocks lack structured reason and worktree counts.
+- Post-fix CI failure logs lack grouped failure context.
+- Subprocess stderr rows cannot be separated from actual warning or error conditions by metadata.


### PR DESCRIPTION
## Summary
- persist runtime watcher freshness fields in runtime state and SQLite storage
- add timestamp-only log index for daily scans
- add structured repo-cache reclone block telemetry, CI failure summaries, and subprocess stream kinds
- record the 2026-05-31 log-fix baseline for future scans

## Verification
- node --test --import tsx server/appRuntime.test.ts server/storage.test.ts server/repoWorkspace.test.ts server/babysitter.test.ts --test-name-pattern "watcher lifecycle freshness|watcher runtime freshness|timestamp-only log index|registered worktrees|aggregates failure contexts|successful git stderr|failed git stderr"
- npm run check
- npm run test
- npm run test:all
- git diff --check

Note: repo labels codex/codex-automation are not available in this repository, so no automation labels were applied.