### PR TITLE
[codex] reduce onboarding workflow polling

### DIFF
--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -192,7 +192,12 @@ export function OnboardingPanel() {
 
   const { data: status, isLoading } = useQuery<OnboardingStatus>({
     queryKey: ["/api/onboarding/status"],
-    refetchInterval: 30000,
+    refetchInterval: (query) => {
+      const currentStatus = query.state.data as OnboardingStatus | undefined;
+      if (!currentStatus) return 120000;
+      return getOnboardingPanelState(currentStatus).hasIssues ? 120000 : false;
+    },
+    refetchOnWindowFocus: false,
   });
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -324,6 +324,108 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
   assert.equal(config.postGitHubProgressReplies, true);
 });
 
+test("runtime reuses onboarding status within the cache window", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["acme/widgets"] });
+  let statusChecks = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    checkOnboardingStatusFn: async (_config, watchedRepos) => {
+      statusChecks += 1;
+      return {
+        githubConnected: true,
+        githubUser: "octo",
+        repos: watchedRepos.map((repo) => ({
+          repo,
+          accessible: true,
+          codeReviews: { claude: false, codex: true, gemini: false },
+        })),
+      };
+    },
+  });
+
+  const first = await runtime.getOnboardingStatus();
+  const second = await runtime.getOnboardingStatus();
+
+  assert.equal(statusChecks, 1);
+  assert.deepEqual(second, first);
+});
+
+test("runtime refreshes onboarding status after config changes", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["acme/widgets"] });
+  let statusChecks = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    checkOnboardingStatusFn: async (_config, watchedRepos) => {
+      statusChecks += 1;
+      return {
+        githubConnected: true,
+        githubUser: "octo",
+        repos: watchedRepos.map((repo) => ({
+          repo,
+          accessible: true,
+          codeReviews: { claude: false, codex: statusChecks > 1, gemini: false },
+        })),
+      };
+    },
+  });
+
+  const before = await runtime.getOnboardingStatus();
+  await runtime.updateConfig({ maxTurns: 25 });
+  const after = await runtime.getOnboardingStatus();
+
+  assert.equal(statusChecks, 2);
+  assert.notDeepEqual(after, before);
+});
+
+test("runtime does not cache stale in-flight onboarding status after config changes", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["acme/widgets"] });
+  let statusChecks = 0;
+  let resolveFirst: (() => void) | null = null;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    checkOnboardingStatusFn: async (_config, watchedRepos) => {
+      statusChecks += 1;
+      const hasCodex = statusChecks > 1;
+      if (statusChecks === 1) {
+        await new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+
+      return {
+        githubConnected: true,
+        githubUser: "octo",
+        repos: watchedRepos.map((repo) => ({
+          repo,
+          accessible: true,
+          codeReviews: { claude: false, codex: hasCodex, gemini: false },
+        })),
+      };
+    },
+  });
+
+  const first = runtime.getOnboardingStatus();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(statusChecks, 1);
+
+  await runtime.updateConfig({ maxTurns: 25 });
+  resolveFirst?.();
+  await first;
+  const after = await runtime.getOnboardingStatus();
+
+  assert.equal(statusChecks, 2);
+  assert.equal(after.repos[0]?.codeReviews.codex, true);
+});
+
 test("runtime release adapter skips merged PRs without a merge commit SHA", () => {
   const summaries = mapMergedPullsToReleaseSummaries([
     {

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -353,6 +353,39 @@ test("runtime reuses onboarding status within the cache window", async () => {
   assert.deepEqual(second, first);
 });
 
+test("runtime treats missing githubTokens as empty for onboarding status cache keys", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["acme/widgets"] });
+  const getConfig = storage.getConfig.bind(storage);
+  storage.getConfig = async () => {
+    const config = await getConfig();
+    return { ...config, githubTokens: undefined as unknown as string[] };
+  };
+  let statusChecks = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    checkOnboardingStatusFn: async (_config, watchedRepos) => {
+      statusChecks += 1;
+      return {
+        githubConnected: true,
+        githubUser: "octo",
+        repos: watchedRepos.map((repo) => ({
+          repo,
+          accessible: true,
+          codeReviews: { claude: false, codex: true, gemini: false },
+        })),
+      };
+    },
+  });
+
+  const status = await runtime.getOnboardingStatus();
+
+  assert.equal(statusChecks, 1);
+  assert.equal(status.repos[0]?.repo, "acme/widgets");
+});
+
 test("runtime refreshes onboarding status after config changes", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ watchedRepos: ["acme/widgets"] });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -447,7 +447,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
   const buildOnboardingStatusCacheKey = (config: Config) => JSON.stringify({
     githubToken: fingerprintToken(config.githubToken),
-    githubTokens: config.githubTokens.map(fingerprintToken),
+    githubTokens: (config.githubTokens ?? []).map(fingerprintToken),
     watchedRepos: config.watchedRepos,
   });
 

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -47,6 +47,7 @@ import {
   listReleasesForRepo,
   listUnreleasedMergedPulls,
   type MergedPRSummary,
+  type OnboardingStatus,
   parsePRUrl,
   parseRepoSlug,
   resolveNextSemverTag,
@@ -72,6 +73,7 @@ export type AppRuntimeDependencies = {
   watcherScheduler?: WatcherScheduler;
   startBackgroundServices?: boolean;
   startWatcher?: boolean;
+  checkOnboardingStatusFn?: typeof checkOnboardingStatus;
 };
 
 export type RuntimeSnapshot = RuntimeState & {
@@ -293,6 +295,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   const storage = dependencies.storage ?? getDefaultStorage();
   const events = new EventEmitter();
   const backgroundJobQueue = dependencies.backgroundJobQueue ?? new BackgroundJobQueue(storage);
+  const checkOnboardingStatusFn = dependencies.checkOnboardingStatusFn ?? checkOnboardingStatus;
   // eslint-disable-next-line prefer-const -- circular dep: closure references this before it can be initialized
   let backgroundJobDispatcher!: BackgroundJobDispatcher;
 
@@ -429,6 +432,89 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   const startBackgroundServices = dependencies.startBackgroundServices ?? true;
   const startWatcher = dependencies.startWatcher ?? startBackgroundServices;
   let started = false;
+  let onboardingStatusCache: {
+    key: string;
+    value: OnboardingStatus;
+    refreshedAt: number;
+    expiresAt: number;
+  } | null = null;
+  let onboardingStatusInFlight: { key: string; promise: Promise<OnboardingStatus> } | null = null;
+  let onboardingStatusCacheGeneration = 0;
+
+  const fingerprintToken = (token: string | undefined) => token
+    ? `${token.length}:${token.slice(-4)}`
+    : "";
+
+  const buildOnboardingStatusCacheKey = (config: Config) => JSON.stringify({
+    githubToken: fingerprintToken(config.githubToken),
+    githubTokens: config.githubTokens.map(fingerprintToken),
+    watchedRepos: config.watchedRepos,
+  });
+
+  const invalidateOnboardingStatusCache = (reason: string) => {
+    if (!onboardingStatusCache && !onboardingStatusInFlight) {
+      return;
+    }
+
+    onboardingStatusCache = null;
+    onboardingStatusInFlight = null;
+    onboardingStatusCacheGeneration += 1;
+    log.debug({ reason }, "Onboarding status cache invalidated");
+  };
+
+  const getCachedOnboardingStatus = async (): Promise<OnboardingStatus> => {
+    const config = await storage.getConfig();
+    const key = buildOnboardingStatusCacheKey(config);
+    const now = Date.now();
+
+    if (onboardingStatusCache?.key === key && onboardingStatusCache.expiresAt > now) {
+      log.debug({
+        ageMs: now - onboardingStatusCache.refreshedAt,
+        cacheHit: true,
+        repoCount: config.watchedRepos.length,
+      }, "Onboarding status cache hit");
+      return onboardingStatusCache.value;
+    }
+
+    if (onboardingStatusInFlight?.key === key) {
+      log.debug({
+        cacheHit: true,
+        inFlight: true,
+        repoCount: config.watchedRepos.length,
+      }, "Onboarding status cache joined in-flight refresh");
+      return onboardingStatusInFlight.promise;
+    }
+
+    const startedAt = Date.now();
+    const cacheGeneration = onboardingStatusCacheGeneration;
+    const promise = checkOnboardingStatusFn(config, config.watchedRepos).then((status) => {
+      const refreshedAt = Date.now();
+      const stale = cacheGeneration !== onboardingStatusCacheGeneration;
+      if (!stale) {
+        onboardingStatusCache = {
+          key,
+          value: status,
+          refreshedAt,
+          expiresAt: refreshedAt + 10 * 60 * 1000,
+        };
+      }
+      log.debug({
+        cacheHit: false,
+        durationMs: refreshedAt - startedAt,
+        repoCount: config.watchedRepos.length,
+        stale,
+        ttlMs: 10 * 60 * 1000,
+      }, "Onboarding status cache refreshed");
+      return status;
+    }).finally(() => {
+      if (onboardingStatusInFlight?.promise === promise) {
+        onboardingStatusInFlight = null;
+      }
+    });
+
+    onboardingStatusInFlight = { key, promise };
+    return promise;
+  };
 
   const notifyChange = () => {
     events.emit("change");
@@ -883,6 +969,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         await storage.updateConfig({
           watchedRepos: [...config.watchedRepos, canonical].sort((a, b) => a.localeCompare(b)),
         });
+        invalidateOnboardingStatusCache("watched repo added");
       }
 
       void runWatcher();
@@ -994,6 +1081,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         await storage.updateConfig({
           watchedRepos: [...config.watchedRepos, repoSlug].sort((a, b) => a.localeCompare(b)),
         });
+        invalidateOnboardingStatusCache("pr repo added to watch list");
       }
 
       await queueBabysitWithAgent(pr, config.codingAgent);
@@ -1248,13 +1336,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async getOnboardingStatus() {
-      const config = await storage.getConfig();
-      return checkOnboardingStatus(config, config.watchedRepos);
+      return getCachedOnboardingStatus();
     },
 
     async installReviewWorkflow(repo, tool) {
       const config = await storage.getConfig();
-      return installCodeReviewWorkflow(config, repo, tool);
+      const result = await installCodeReviewWorkflow(config, repo, tool);
+      invalidateOnboardingStatusCache("review workflow installed");
+      return result;
     },
 
     async listHealingSessions() {
@@ -1282,6 +1371,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     async updateConfig(updates) {
       const updated = await storage.updateConfig(updates);
+      invalidateOnboardingStatusCache("config updated");
       if (startWatcher && started) {
         await refreshWatcherSchedule();
       }


### PR DESCRIPTION
## Summary

- Cache onboarding status checks inside the app runtime for 10 minutes using token fingerprints and watched repo state as the cache key.
- Deduplicate concurrent onboarding status refreshes and prevent stale in-flight results from repopulating cache after config/watchlist changes.
- Reduce the onboarding panel polling interval from 30 seconds to 120 seconds only while setup issues remain, and disable window-focus refetches.
- Add regression coverage for cache reuse, invalidation, and stale in-flight refresh handling.

## Root Cause

The onboarding panel polled `/api/onboarding/status` every 30 seconds. Each request called `checkOnboardingStatus`, which lists `.github/workflows` and reads workflow files for each watched repository. The last log scan showed high workflow-content request volume despite all calls succeeding.

## Validation

- `npm run check`
- `npm run test -- server/appRuntime.test.ts`
- `npm run build`
- `git diff --check origin/main...HEAD`

Earlier before the final rebase, `npm run test:all` also passed with 540 passing, 1 skipped, and 0 failed.
