### PR TITLE
[codex] add anonymous usage tracking

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -22,6 +22,7 @@
    - [Feedback items](#feedback-items)
    - [PR Q&A](#pr-qa)
    - [Logs](#logs)
+   - [Usage](#usage)
    - [CI healing sessions](#ci-healing-sessions)
    - [Deployment healing sessions](#deployment-healing-sessions)
    - [Configuration](#configuration)
@@ -598,6 +599,50 @@ buffering.
 
 ---
 
+### Usage
+
+Usage endpoints expose anonymous local aggregate counters. They return only
+daily dates and counts for app opens, tracked PRs, merged PRs, and fixes made;
+they do not include repo names, PR URLs, GitHub users, feedback text, or an
+event stream. The dashboard uses the same data for the Settings usage panel and
+the `/usage` page.
+
+#### `GET /api/usage`
+
+Read the current usage summary.
+
+**Response** `200` — [UsageSummary object](#usagesummary)
+
+**Example** `200`
+```json
+{
+  "totals": {
+    "appOpenCount": 3,
+    "trackedPrCount": 5,
+    "mergedPrCount": 2,
+    "fixesMadeCount": 4
+  },
+  "daily": [
+    {
+      "date": "2026-06-07",
+      "appOpenCount": 3,
+      "trackedPrCount": 5,
+      "mergedPrCount": 2,
+      "fixesMadeCount": 4
+    }
+  ]
+}
+```
+
+#### `POST /api/usage/app-open`
+
+Increment the anonymous app-open counter for the current UTC date and return the
+updated usage summary. The dashboard calls this once when the app shell mounts.
+
+**Response** `200` — [UsageSummary object](#usagesummary)
+
+---
+
 ### CI healing sessions
 
 #### `GET /api/healing-sessions`
@@ -1002,6 +1047,26 @@ Install the oh-my-pr code-review GitHub Actions workflow on a repository.
   phase: string | null;
   message: string;
   metadata: Record<string, unknown> | null;
+}
+```
+
+### UsageSummary
+
+```typescript
+{
+  totals: {
+    appOpenCount: number;
+    trackedPrCount: number;
+    mergedPrCount: number;
+    fixesMadeCount: number;
+  };
+  daily: Array<{
+    date: string;              // UTC date, YYYY-MM-DD
+    appOpenCount: number;
+    trackedPrCount: number;
+    mergedPrCount: number;
+    fixesMadeCount: number;
+  }>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ Then:
 - Pushes verified fixes back to the PR branch
 - Can automatically create a GitHub release when a merged PR is important enough to justify a version bump
 - Keeps logs, run history, and PR state on your machine
+- Shows anonymous local usage totals for app opens, tracked PRs, merged PRs, and fixes made
 - Exposes the same system through a dashboard, local API, and MCP server
 
 ## Technical Details
 
 ### Local-First
 
-oh-my-pr runs on your machine and works with your local agent CLI. Repository caches (`repos/`), worktrees (`worktrees/`), logs (`log/`), and app state (`state.sqlite`) live under `~/.oh-my-pr` by default. Set `OH_MY_PR_HOME` if you want a different location.
+oh-my-pr runs on your machine and works with your local agent CLI. Repository caches (`repos/`), worktrees (`worktrees/`), logs (`log/`), and app state (`state.sqlite`) live under `~/.oh-my-pr` by default. Set `OH_MY_PR_HOME` if you want a different location. Anonymous usage counters are stored in the same local app state and contain only dates and counts, not repo names, PR URLs, or user identity.
 
 ### Isolation
 
@@ -102,6 +103,7 @@ Watched repositories default to `My PRs only`. You can switch a repo to `My PRs 
 oh-my-pr can be used in a few ways:
 
 - web dashboard: `oh-my-pr`
+- usage dashboard: `http://localhost:5001/usage`
 - server logs page: `http://localhost:5001/logs`
 - MCP server: `oh-my-pr mcp`
 - local REST API: see [LOCAL_API.md](LOCAL_API.md)

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from "react";
 import { Switch, Route, Router } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";
-import { queryClient } from "./lib/queryClient";
+import { apiRequest, queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/toaster";
@@ -10,8 +11,11 @@ import Settings from "@/pages/settings";
 import Changelogs from "@/pages/changelogs";
 import Releases from "@/pages/releases";
 import Logs from "@/pages/logs";
+import Usage from "@/pages/usage";
 import NotFound from "@/pages/not-found";
 import { WebLoginGate } from "@/components/WebLoginGate";
+
+let appOpenRecorded = false;
 
 function AppRouter() {
   return (
@@ -21,12 +25,26 @@ function AppRouter() {
       <Route path="/changelogs" component={Changelogs} />
       <Route path="/releases" component={Releases} />
       <Route path="/logs" component={Logs} />
+      <Route path="/usage" component={Usage} />
       <Route component={NotFound} />
     </Switch>
   );
 }
 
 function App() {
+  useEffect(() => {
+    if (appOpenRecorded) {
+      return;
+    }
+
+    appOpenRecorded = true;
+    void apiRequest("POST", "/api/usage/app-open")
+      .then(() => queryClient.invalidateQueries({ queryKey: ["/api/usage"] }))
+      .catch(() => {
+        appOpenRecorded = false;
+      });
+  }, []);
+
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <QueryClientProvider client={queryClient}>

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -263,8 +263,10 @@ test("full app QA route matrix is wired through the hash router", async () => {
     { label: "changelogs", path: "/changelogs", component: "Changelogs" },
     { label: "releases", path: "/releases", component: "Releases" },
     { label: "logs", path: "/logs", component: "Logs" },
+    { label: "usage", path: "/usage", component: "Usage" },
     { label: "not found fallback", component: "NotFound" },
   ]);
+  assertHasApiRequest(sourceFile, "app open usage mutation", "POST", "/api/usage/app-open");
 });
 
 test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows wired", async () => {
@@ -338,10 +340,13 @@ test("settings keeps the QA-tested configuration, token, and runtime controls wi
 
   assertHasQueryKey(sourceFile, "settings config query", "/api/config");
   assertHasQueryKey(sourceFile, "runtime query", "/api/runtime");
+  assertHasQueryKey(sourceFile, "usage query", "/api/usage");
   assertHasApiRequest(sourceFile, "config mutation", "PATCH", "/api/config");
   assertHasApiRequest(sourceFile, "drain mutation", "POST", "/api/runtime/drain");
 
   assertHasJsxAttribute(sourceFile, "id", "coding agent selector", "settings-coding-agent");
+  assertHasTestId(sourceFile, "usage panel", "settings-usage-panel");
+  assertHasJsxAttribute(sourceFile, "href", "usage details link", "/usage");
   for (const [label, testId] of [
     ["fallback toggle", "checkbox-fallback-to-next-coding-agent"],
     ["auto resolve conflicts toggle", "checkbox-auto-resolve-conflicts"],
@@ -353,6 +358,20 @@ test("settings keeps the QA-tested configuration, token, and runtime controls wi
     assertHasTestId(sourceFile, label, testId);
   }
   assertHasExpression(sourceFile, "ordered GitHub tokens", /\bgithubTokens\b/);
+});
+
+test("usage route keeps anonymous usage charts wired", async () => {
+  const { sourceFile } = await parseProjectFile("client/src/pages/usage.tsx");
+
+  assertHasQueryKey(sourceFile, "usage query", "/api/usage");
+  for (const [label, testId] of [
+    ["usage page", "usage-page"],
+    ["usage totals", "usage-totals"],
+    ["usage charts", "usage-charts"],
+  ] satisfies SourceExpectation[]) {
+    assertHasTestId(sourceFile, label, testId);
+  }
+  assertHasStringValue(sourceFile, "anonymous usage copy", "Anonymous. Stored locally.");
 });
 
 test("logs route keeps the QA-tested filtering, streaming, copy, and download surface wired", async () => {

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
-import type { Config, RuntimeState } from "@shared/schema";
+import type { Config, RuntimeState, UsageCounterKey, UsageSummary } from "@shared/schema";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import { Link } from "wouter";
@@ -10,9 +10,23 @@ import {
   getDrainStatusView,
 } from "@/lib/runtimeDisplay";
 
+const USAGE_METRICS: Array<{ key: UsageCounterKey; label: string }> = [
+  { key: "appOpenCount", label: "app opens" },
+  { key: "trackedPrCount", label: "PRs tracked" },
+  { key: "mergedPrCount", label: "merged" },
+  { key: "fixesMadeCount", label: "fixes made" },
+];
+
+function formatUsageNumber(value: number | undefined): string {
+  return (value ?? 0).toLocaleString();
+}
+
 export default function Settings() {
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],
+  });
+  const { data: usage } = useQuery<UsageSummary>({
+    queryKey: ["/api/usage"],
   });
 
   const [newGithubToken, setNewGithubToken] = useState("");
@@ -97,6 +111,44 @@ export default function Settings() {
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto flex max-w-2xl flex-col gap-8">
+
+          {/* Usage */}
+          <section>
+            <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Usage
+            </h2>
+            <div
+              className="flex flex-col gap-4 rounded border border-border p-4"
+              data-testid="settings-usage-panel"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm">Anonymous local usage</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Counts only. No repo names, PR URLs, or user identity.
+                  </div>
+                </div>
+                <Link
+                  href="/usage"
+                  className="shrink-0 border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                >
+                  details
+                </Link>
+              </div>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {USAGE_METRICS.map((metric) => (
+                  <div key={metric.key} className="border border-border px-2 py-2">
+                    <div className="font-mono text-lg leading-none">
+                      {formatUsageNumber(usage?.totals[metric.key])}
+                    </div>
+                    <div className="mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                      {metric.label}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
 
           {/* Agent */}
           <section>

--- a/client/src/pages/usage.tsx
+++ b/client/src/pages/usage.tsx
@@ -1,0 +1,188 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { UpdateBanner } from "@/components/UpdateBanner";
+import type { UsageCounterKey, UsageDailyBucket, UsageSummary } from "@shared/schema";
+
+const USAGE_METRICS: Array<{
+  key: UsageCounterKey;
+  label: string;
+  description: string;
+  barClassName: string;
+}> = [
+  {
+    key: "appOpenCount",
+    label: "App opens",
+    description: "Dashboard sessions started from the app shell.",
+    barClassName: "bg-chart-1",
+  },
+  {
+    key: "trackedPrCount",
+    label: "PRs tracked",
+    description: "Pull requests registered for oh-my-pr to watch.",
+    barClassName: "bg-chart-2",
+  },
+  {
+    key: "mergedPrCount",
+    label: "Merged",
+    description: "Tracked PRs observed as merged.",
+    barClassName: "bg-chart-3",
+  },
+  {
+    key: "fixesMadeCount",
+    label: "Fixes made",
+    description: "Verified branch updates or deployment fix PRs.",
+    barClassName: "bg-chart-4",
+  },
+];
+
+function formatNumber(value: number | undefined): string {
+  return (value ?? 0).toLocaleString();
+}
+
+function compactDate(date: string): string {
+  return date.slice(5);
+}
+
+function metricMax(daily: UsageDailyBucket[], key: UsageCounterKey): number {
+  return Math.max(1, ...daily.map((bucket) => bucket[key]));
+}
+
+export default function Usage() {
+  const { data: usage, isLoading } = useQuery<UsageSummary>({
+    queryKey: ["/api/usage"],
+  });
+  const daily = usage?.daily.slice(-30) ?? [];
+
+  return (
+    <div className="flex min-h-screen flex-col" data-testid="usage-page">
+      <UpdateBanner />
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-label="Usage">
+            <rect x="1" y="1" width="14" height="14" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M4 11V7M8 11V4M12 11V6" stroke="currentColor" strokeWidth="1" />
+          </svg>
+          <span className="text-sm font-medium tracking-tight">oh-my-pr</span>
+          <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+            usage
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/settings"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            settings
+          </Link>
+          <Link
+            href="/"
+            className="text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            &larr; back to dashboard
+          </Link>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6">
+          <div>
+            <h1 className="text-base font-medium">Usage</h1>
+            <p className="mt-1 text-[12px] text-muted-foreground">
+              Anonymous. Stored locally.
+            </p>
+          </div>
+
+          <section data-testid="usage-totals">
+            <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Totals
+            </h2>
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+              {USAGE_METRICS.map((metric) => (
+                <div key={metric.key} className="border border-border px-3 py-3">
+                  <div className="font-mono text-2xl leading-none">
+                    {formatNumber(usage?.totals[metric.key])}
+                  </div>
+                  <div className="mt-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                    {metric.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section data-testid="usage-charts">
+            <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Last 30 Recorded Days
+            </h2>
+            {isLoading ? (
+              <div className="border border-border px-4 py-8 text-center text-[12px] text-muted-foreground">
+                Loading usage…
+              </div>
+            ) : daily.length === 0 ? (
+              <div className="border border-border px-4 py-8 text-center">
+                <p className="text-sm text-muted-foreground">No usage recorded yet.</p>
+              </div>
+            ) : (
+              <div className="grid gap-3 lg:grid-cols-2">
+                {USAGE_METRICS.map((metric) => (
+                  <UsageChart
+                    key={metric.key}
+                    metric={metric}
+                    daily={daily}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UsageChart({
+  metric,
+  daily,
+}: {
+  metric: (typeof USAGE_METRICS)[number];
+  daily: UsageDailyBucket[];
+}) {
+  const max = metricMax(daily, metric.key);
+
+  return (
+    <div className="border border-border p-3">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm">{metric.label}</div>
+          <div className="text-[11px] text-muted-foreground">{metric.description}</div>
+        </div>
+        <div className="font-mono text-sm">
+          {formatNumber(daily.reduce((sum, bucket) => sum + bucket[metric.key], 0))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {daily.map((bucket) => {
+          const value = bucket[metric.key];
+          const width = `${Math.max(value > 0 ? 4 : 0, (value / max) * 100)}%`;
+
+          return (
+            <div key={`${metric.key}-${bucket.date}`} className="grid grid-cols-[3.2rem_1fr_2.4rem] items-center gap-2">
+              <div className="font-mono text-[10px] text-muted-foreground">
+                {compactDate(bucket.date)}
+              </div>
+              <div className="h-2 border border-border bg-muted/40">
+                <div
+                  className={`h-full ${metric.barClassName}`}
+                  style={{ width }}
+                />
+              </div>
+              <div className="text-right font-mono text-[10px] text-muted-foreground">
+                {formatNumber(value)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/docs/plans/2026-06-07-anonymous-usage-tracking.md
+++ b/docs/plans/2026-06-07-anonymous-usage-tracking.md
@@ -1,0 +1,73 @@
+# Anonymous Usage Tracking Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add anonymous local usage totals and a simple over-time usage page for app opens, tracked PRs, merged PRs, and fixes made by oh-my-pr.
+
+**Architecture:** Store aggregate usage totals and daily usage buckets locally in the app storage layer. Expose them through thin runtime and route methods, then render Settings usage totals plus a `/usage` page with simple charts. Store only counts and dates; do not persist repo names, PR URLs, user IDs, or event streams.
+
+**Tech Stack:** TypeScript, Zod shared schemas, Express routes, MemStorage, SQLite, React Query, Wouter, Tailwind.
+
+---
+
+### Task 1: Shared Contract And Storage Tests
+
+**Files:**
+- Modify: `shared/schema.ts`
+- Modify: `server/storage.ts`
+- Modify: `server/memoryStorage.test.ts`
+- Modify: `server/storage.test.ts`
+
+**Steps:**
+1. Add a `usageCounterKeyEnum`, `usageCountersSchema`, `usageDailyBucketSchema`, and `usageSummarySchema`.
+2. Add `getUsageSummary()` and `incrementUsageCounter(counter, amount?, occurredAt?)` to `IStorage`.
+3. Write failing memory and SQLite tests that increment counters across two dates and assert totals plus daily buckets.
+4. Implement the smallest storage changes that make those tests pass.
+
+### Task 2: Runtime And API
+
+**Files:**
+- Modify: `server/appRuntime.ts`
+- Modify: `server/routes.ts`
+- Modify: `server/routes.test.ts`
+
+**Steps:**
+1. Add runtime methods for usage read and app-open tracking.
+2. Add `GET /api/usage` and `POST /api/usage/app-open`.
+3. Write failing route tests that assert the API exposes only anonymous aggregate fields.
+4. Implement route and runtime methods.
+
+### Task 3: Product Hooks
+
+**Files:**
+- Modify: `server/appRuntime.ts`
+- Modify: `server/babysitter.ts`
+- Modify: `server/backgroundJobHandlers.ts`
+- Modify: relevant server tests
+
+**Steps:**
+1. Increment tracked PRs when a new PR record is created.
+2. Increment merged PRs when a tracked PR is observed as merged and archived.
+3. Increment fixes made when babysitter pushes a new fix commit or deployment healing submits a fix PR.
+4. Add focused regression tests for each hook.
+
+### Task 4: Settings And Usage Page
+
+**Files:**
+- Modify: `client/src/App.tsx`
+- Modify: `client/src/pages/settings.tsx`
+- Create: `client/src/pages/usage.tsx`
+- Modify: `client/src/lib/fullAppQaSurface.test.ts`
+
+**Steps:**
+1. Record app open once from the mounted app shell.
+2. Add a compact Settings usage section linking to `/usage`.
+3. Add a simple `/usage` page with totals and daily bar charts.
+4. Add full-app surface assertions for the settings query/link and usage route.
+
+### Verification
+
+Run:
+- `npm run test -- server/memoryStorage.test.ts server/storage.test.ts server/routes.test.ts`
+- `npm run test:all`
+- `npm run check`

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -227,6 +227,16 @@
 <pre><code>~/.oh-my-pr/state.sqlite
 </code></pre>
 <p>No external database is required. This is ideal for single-user setups.</p>
+<h2>Usage Tracking</h2>
+<p>oh-my-pr keeps a small anonymous usage summary locally so operators can understand how much the babysitter is being used. It records only daily counts for:</p>
+<ul>
+<li>app opens</li>
+<li>PRs tracked</li>
+<li>tracked PRs observed as merged</li>
+<li>fixes made by babysitter runs or deployment-healing fix PRs</li>
+</ul>
+<p>Usage tracking does not store repo names, PR URLs, GitHub users, feedback text, or an event stream. The counters are stored in the local app database, in the <code>usage_daily</code> table when using SQLite, and are not sent to GitHub or an external analytics service.</p>
+<p>View usage totals from the dashboard settings page or open <code>/usage</code> for totals and the last 30 recorded days. The local API also exposes <code>GET /api/usage</code>; the dashboard records an app open once per mounted app shell through <code>POST /api/usage/app-open</code>.</p>
 <h2>Activity Logs</h2>
 <p>oh-my-pr writes daily activity logs to:</p>
 <pre><code>~/.oh-my-pr/log/
@@ -247,6 +257,7 @@ oh-my-pr --no-log-file
 <ul>
 <li><strong>GitHub token management</strong> — Add, remove, and reorder saved tokens before falling back to <code>GITHUB_TOKEN</code> or <code>gh auth</code>.</li>
 <li><strong>Agent selection</strong> — Choose whether autonomous runs use Claude Code or OpenAI Codex. Enabling <strong>Fallback to next coding agent</strong> lets oh-my-pr switch to the other local CLI when the selected agent cannot start, cannot authenticate, or fails a health check; code-owner fallback runs use the same resolved agent.</li>
+<li><strong>Usage</strong> — Review anonymous local totals for app opens, tracked PRs, merged PRs, and fixes made, with a link to the <code>/usage</code> page for daily charts.</li>
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
 <li><strong>Runtime drain mode</strong> — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return <code>409</code> instead of queueing new agent work.</li>
 <li><strong>Ignored bots</strong> — Add or remove bot logins whose comments and reviews should be ignored.</li>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -31,6 +31,19 @@ By default, oh-my-pr stores all state in a local SQLite database:
 
 No external database is required. This is ideal for single-user setups.
 
+## Usage Tracking
+
+oh-my-pr keeps a small anonymous usage summary locally so operators can understand how much the babysitter is being used. It records only daily counts for:
+
+- app opens
+- PRs tracked
+- tracked PRs observed as merged
+- fixes made by babysitter runs or deployment-healing fix PRs
+
+Usage tracking does not store repo names, PR URLs, GitHub users, feedback text, or an event stream. The counters are stored in the local app database, in the `usage_daily` table when using SQLite, and are not sent to GitHub or an external analytics service.
+
+View usage totals from the dashboard settings page or open `/usage` for totals and the last 30 recorded days. The local API also exposes `GET /api/usage`; the dashboard records an app open once per mounted app shell through `POST /api/usage/app-open`.
+
 ## Activity Logs
 
 oh-my-pr writes daily activity logs to:
@@ -62,6 +75,7 @@ The settings page in the dashboard provides a UI for:
 
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex. Enabling **Fallback to next coding agent** lets oh-my-pr switch to the other local CLI when the selected agent cannot start, cannot authenticate, or fails a health check; code-owner fallback runs use the same resolved agent.
+- **Usage** — Review anonymous local totals for app opens, tracked PRs, merged PRs, and fixes made, with a link to the `/usage` page for daily charts.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **Runtime drain mode** — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
 - **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -13,6 +13,7 @@ import type {
   ReleaseRun,
   RuntimeState,
   SocialChangelog,
+  UsageSummary,
   WatchedRepo,
 } from "@shared/schema";
 import { z } from "zod";
@@ -121,6 +122,8 @@ export type AppRuntime = {
   getHealingSession(id: string): Promise<HealingSession>;
   listDeploymentHealingSessions(repo?: string): Promise<DeploymentHealingSession[]>;
   getDeploymentHealingSession(id: string): Promise<DeploymentHealingSession>;
+  getUsageSummary(): Promise<UsageSummary>;
+  recordAppOpen(): Promise<UsageSummary>;
   getConfig(): Promise<Config>;
   updateConfig(updates: Partial<Config>): Promise<Config>;
   listSocialChangelogs(): Promise<SocialChangelog[]>;
@@ -1274,6 +1277,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         await storage.getDeploymentHealingSession(id),
         "Deployment healing session not found",
       );
+    },
+
+    async getUsageSummary() {
+      return storage.getUsageSummary();
+    },
+
+    async recordAppOpen() {
+      return storage.incrementUsageCounter("appOpenCount");
     },
 
     async getConfig() {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -556,7 +556,9 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
 
   const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
+  const usage = await storage.getUsageSummary();
   assert.equal(updated?.status, "archived");
+  assert.equal(usage.totals.mergedPrCount, 1);
   assert.equal(queued.length, 1);
   assert.equal(queued[0]?.triggerMergeSha, "merge123");
   assert.ok(logs.some((log) => log.message.includes("queued release evaluation")));
@@ -7555,6 +7557,8 @@ test("babysitPR marks a healing session healed when the repair push turns CI gre
   assert.equal(attempts[0]?.outputSha, "heal456");
 
   const updated = await storage.getPR(pr.id);
+  const usage = await storage.getUsageSummary();
+  assert.equal(usage.totals.fixesMadeCount, 1);
   assert.equal(updated?.testsPassed, true);
 });
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -2050,6 +2050,14 @@ export class PRBabysitter {
           });
 
           const repoAutoCreateReleases = repoSettingsByRepo.get(repoSlug)?.autoCreateReleases ?? false;
+          if (closeState?.merged) {
+            await this.storage.incrementUsageCounter(
+              "mergedPrCount",
+              1,
+              closeState.mergedAt || closeState.closedAt || new Date().toISOString(),
+            );
+          }
+
           if (!automationBlocked && closeState?.merged && this.releaseManager && config.autoCreateReleases) {
             if (!repoAutoCreateReleases) {
               await this.storage.addLog(pr.id, "info", `PR #${pr.number} was merged, but auto-release is disabled for ${repoSlug}`, {
@@ -4335,6 +4343,9 @@ export class PRBabysitter {
           }
 
           branchMoved = remoteHeadSha !== pullSummary.headSha;
+          if (branchMoved) {
+            await this.storage.incrementUsageCounter("fixesMadeCount");
+          }
 
           if (statusTasks.length > 0 && !branchMoved) {
             throw new Error("Agent did not update the PR head branch for accepted failing status tasks");
@@ -4498,6 +4509,9 @@ export class PRBabysitter {
             latestFingerprint: healingAttemptResult.targetFingerprints[0] ?? healingSession.latestFingerprint,
           });
           branchMoved = healingAttemptResult.verification.pushedNewSha;
+          if (branchMoved) {
+            await this.storage.incrementUsageCounter("fixesMadeCount");
+          }
           headShaForFollowUp = healingAttemptResult.verification.remoteHeadSha;
           remoteNameForLogs = healingAttemptResult.remoteName;
         } else {

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -389,6 +389,74 @@ test("heal_deployment handler passes an authenticated clone URL to deployment re
   );
 });
 
+test("heal_deployment handler increments fixes made when a fix PR is submitted", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    deploymentCheckDelayMs: 0,
+    deploymentCheckTimeoutMs: 1,
+    deploymentCheckPollIntervalMs: 0,
+  });
+
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "heal_deployment",
+    "acme/widgets:merge-sha",
+    "heal_deployment:acme/widgets:merge-sha",
+    {
+      repo: "acme/widgets",
+      platform: "railway",
+      mergeSha: "merge-sha",
+      triggerPrNumber: 42,
+      triggerPrTitle: "feat: add widget",
+      triggerPrUrl: "https://github.com/acme/widgets/pull/42",
+      baseBranch: "main",
+    },
+  );
+
+  const handlers = createBackgroundJobHandlers({
+    storage,
+    deploymentHealingManager: {
+      ensureSession: async () => ({ id: "session-1" }),
+      transitionTo: async (sessionId, state, updates) => ({ id: sessionId, state, ...updates }) as never,
+    } as unknown as DeploymentHealingManager,
+    deps: {
+      buildOctokitFn: async () => ({
+        pulls: {
+          create: async () => ({
+            data: {
+              number: 43,
+              html_url: "https://github.com/acme/widgets/pull/43",
+            },
+          }),
+        },
+      }) as never,
+      createAdapterFn: () => ({
+        platform: "railway",
+        getDeploymentStatus: async () => ({
+          state: "error",
+          deploymentId: "dep_123",
+          url: null,
+          error: "deployment failed",
+        }),
+        getDeploymentLogs: async () => "deployment failed",
+      }),
+      resolveGitHubAuthTokenFn: async () => null,
+      runDeploymentHealingRepairFn: async () => ({
+        accepted: true,
+        rejectionReason: null,
+        summary: "Fixed the deployment config",
+        fixBranch: "deploy-fix/railway-1",
+        agentResult: { code: 0, stdout: "", stderr: "" },
+      }),
+    },
+  });
+
+  await handlers.heal_deployment!(job);
+
+  const usage = await storage.getUsageSummary();
+  assert.equal(usage.totals.fixesMadeCount, 1);
+});
+
 test("process_release_run handler delegates to ReleaseManager for active rows", async () => {
   const storage = new MemStorage();
   const releaseRun = await storage.createReleaseRun({

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -257,6 +257,7 @@ export function createBackgroundJobHandlers(params: {
             fixPrNumber: prResult.data.number,
             fixPrUrl: prResult.data.html_url,
           });
+          await storage.incrementUsageCounter("fixesMadeCount");
         } catch (error) {
           await manager.transitionTo(session.id, "escalated", {
             error: error instanceof Error ? error.message : String(error),

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -455,6 +455,25 @@ describe("MemStorage", () => {
         },
       ]);
     });
+
+    it("falls back to the current UTC date for invalid usage timestamps", async () => {
+      const validFallbackDates = new Set([
+        new Date().toISOString().slice(0, 10),
+      ]);
+
+      const usage = await storage.incrementUsageCounter("appOpenCount", 1, "not-a-date");
+      validFallbackDates.add(new Date().toISOString().slice(0, 10));
+
+      assert.deepEqual(usage.totals, {
+        appOpenCount: 1,
+        trackedPrCount: 0,
+        mergedPrCount: 0,
+        fixesMadeCount: 0,
+      });
+      assert.equal(usage.daily.length, 1);
+      assert.equal(validFallbackDates.has(usage.daily[0]?.date ?? ""), true);
+      assert.equal(usage.daily[0]?.appOpenCount, 1);
+    });
   });
 
   // ── Config ───────────────────────────────────────────────

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -150,6 +150,14 @@ describe("MemStorage", () => {
       assert.equal(pr.status, "watching");
       assert.equal(pr.watchEnabled, true);
     });
+
+    it("increments tracked PR usage when a PR is created", async () => {
+      await storage.addPR(makePRInput());
+
+      const usage = await storage.getUsageSummary();
+
+      assert.equal(usage.totals.trackedPrCount, 1);
+    });
   });
 
   describe("getPR", () => {
@@ -409,6 +417,43 @@ describe("MemStorage", () => {
       // getLogs returns the last 200 of those => indices 801..1000 => messages "Log 801".."Log 1000"
       assert.equal(logs[0].message, "Log 801");
       assert.equal(logs[199].message, "Log 1000");
+    });
+  });
+
+  // ── Usage ───────────────────────────────────────────────
+
+  describe("usage counters", () => {
+    it("increments anonymous totals and daily buckets by UTC date", async () => {
+      await storage.incrementUsageCounter("appOpenCount", 1, "2026-06-07T12:00:00.000Z");
+      await storage.incrementUsageCounter("appOpenCount", 2, "2026-06-07T23:59:59.000Z");
+      await storage.incrementUsageCounter("trackedPrCount", 1, "2026-06-07T14:00:00.000Z");
+      await storage.incrementUsageCounter("mergedPrCount", 1, "2026-06-08T00:00:00.000Z");
+      await storage.incrementUsageCounter("fixesMadeCount", 1, "2026-06-08T01:00:00.000Z");
+
+      const usage = await storage.getUsageSummary();
+
+      assert.deepEqual(usage.totals, {
+        appOpenCount: 3,
+        trackedPrCount: 1,
+        mergedPrCount: 1,
+        fixesMadeCount: 1,
+      });
+      assert.deepEqual(usage.daily, [
+        {
+          date: "2026-06-07",
+          appOpenCount: 3,
+          trackedPrCount: 1,
+          mergedPrCount: 0,
+          fixesMadeCount: 0,
+        },
+        {
+          date: "2026-06-08",
+          appOpenCount: 0,
+          trackedPrCount: 0,
+          mergedPrCount: 1,
+          fixesMadeCount: 1,
+        },
+      ]);
     });
   });
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -21,6 +21,10 @@ import type {
   ReleaseRunStatus,
   RuntimeState,
   SocialChangelog,
+  UsageCounterKey,
+  UsageCounters,
+  UsageDailyBucket,
+  UsageSummary,
   WatchedRepo,
 } from "@shared/schema";
 import {
@@ -51,6 +55,13 @@ import type { IStorage } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
 export class MemStorage implements IStorage {
+  private static readonly usageCounterKeys: UsageCounterKey[] = [
+    "appOpenCount",
+    "trackedPrCount",
+    "mergedPrCount",
+    "fixesMadeCount",
+  ];
+
   private prs: Map<string, PR> = new Map();
   private questions: Map<string, PRQuestion> = new Map();
   private logs: LogEntry[] = [];
@@ -75,6 +86,23 @@ export class MemStorage implements IStorage {
   private backgroundJobs: Map<string, BackgroundJob> = new Map();
   private deploymentHealingSessions: Map<string, DeploymentHealingSession> = new Map();
   private repoSettings: Map<string, WatchedRepo> = new Map();
+  private usageDailyBuckets: Map<string, UsageDailyBucket> = new Map();
+
+  private createEmptyUsageCounters(): UsageCounters {
+    return {
+      appOpenCount: 0,
+      trackedPrCount: 0,
+      mergedPrCount: 0,
+      fixesMadeCount: 0,
+    };
+  }
+
+  private createEmptyUsageDailyBucket(date: string): UsageDailyBucket {
+    return {
+      date,
+      ...this.createEmptyUsageCounters(),
+    };
+  }
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -139,6 +167,7 @@ export class MemStorage implements IStorage {
   async addPR(pr: NewPR): Promise<PR> {
     const full = createPR(pr);
     this.prs.set(full.id, full);
+    await this.incrementUsageCounter("trackedPrCount", 1, full.addedAt);
     return full;
   }
 
@@ -206,6 +235,44 @@ export class MemStorage implements IStorage {
     }
 
     this.logs = [];
+  }
+
+  async getUsageSummary(): Promise<UsageSummary> {
+    const totals = this.createEmptyUsageCounters();
+    const daily = Array.from(this.usageDailyBuckets.values())
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((bucket) => ({ ...bucket }));
+
+    for (const bucket of daily) {
+      for (const key of MemStorage.usageCounterKeys) {
+        totals[key] += bucket[key];
+      }
+    }
+
+    return {
+      totals,
+      daily,
+    };
+  }
+
+  async incrementUsageCounter(
+    counter: UsageCounterKey,
+    amount = 1,
+    occurredAt = new Date().toISOString(),
+  ): Promise<UsageSummary> {
+    const increment = Math.trunc(amount);
+    if (increment <= 0) {
+      return this.getUsageSummary();
+    }
+
+    const date = new Date(occurredAt).toISOString().slice(0, 10);
+    const bucket = this.usageDailyBuckets.get(date) ?? this.createEmptyUsageDailyBucket(date);
+    this.usageDailyBuckets.set(date, {
+      ...bucket,
+      [counter]: bucket[counter] + increment,
+    });
+
+    return this.getUsageSummary();
   }
 
   async getConfig(): Promise<Config> {

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -265,7 +265,12 @@ export class MemStorage implements IStorage {
       return this.getUsageSummary();
     }
 
-    const date = new Date(occurredAt).toISOString().slice(0, 10);
+    let date: string;
+    try {
+      date = new Date(occurredAt).toISOString().slice(0, 10);
+    } catch {
+      date = new Date().toISOString().slice(0, 10);
+    }
     const bucket = this.usageDailyBuckets.get(date) ?? this.createEmptyUsageDailyBucket(date);
     this.usageDailyBuckets.set(date, {
       ...bucket,

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -217,6 +217,71 @@ test("PATCH /api/config accepts legacy single githubToken updates", async () => 
   }
 });
 
+test("GET /api/usage exposes only anonymous aggregate usage", async () => {
+  const harness = await createHarness();
+
+  try {
+    await harness.storage.incrementUsageCounter("appOpenCount", 1, "2026-06-07T12:00:00.000Z");
+    await harness.storage.incrementUsageCounter("trackedPrCount", 2, "2026-06-07T13:00:00.000Z");
+    await harness.storage.incrementUsageCounter("fixesMadeCount", 1, "2026-06-08T01:00:00.000Z");
+
+    const response = await fetch(`${harness.baseUrl}/api/usage`);
+    assert.equal(response.status, 200);
+
+    const usage = await response.json() as Record<string, unknown>;
+    assert.deepEqual(usage, {
+      totals: {
+        appOpenCount: 1,
+        trackedPrCount: 2,
+        mergedPrCount: 0,
+        fixesMadeCount: 1,
+      },
+      daily: [
+        {
+          date: "2026-06-07",
+          appOpenCount: 1,
+          trackedPrCount: 2,
+          mergedPrCount: 0,
+          fixesMadeCount: 0,
+        },
+        {
+          date: "2026-06-08",
+          appOpenCount: 0,
+          trackedPrCount: 0,
+          mergedPrCount: 0,
+          fixesMadeCount: 1,
+        },
+      ],
+    });
+    assert.equal("repo" in usage, false);
+    assert.equal("url" in usage, false);
+    assert.equal("userId" in usage, false);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("POST /api/usage/app-open increments anonymous app open usage", async () => {
+  const harness = await createHarness();
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/usage/app-open`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 200);
+    const usage = await response.json() as {
+      totals: { appOpenCount: number };
+      daily: Array<{ appOpenCount: number }>;
+    };
+    assert.equal(usage.totals.appOpenCount, 1);
+    assert.equal(usage.daily.length, 1);
+    assert.equal(usage.daily[0]?.appOpenCount, 1);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/prs/:id/questions enqueues a durable answer_pr_question job", async () => {
   const harness = await createHarness();
   const pr = await seedPR(harness.storage);

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -261,6 +261,25 @@ test("GET /api/usage exposes only anonymous aggregate usage", async () => {
   }
 });
 
+test("GET /api/usage returns an app-aware error when usage summary fails", async () => {
+  const harness = await createHarness();
+
+  try {
+    harness.storage.getUsageSummary = async () => {
+      throw new Error("usage summary unavailable");
+    };
+
+    const response = await fetch(`${harness.baseUrl}/api/usage`);
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), {
+      error: "usage summary unavailable",
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/usage/app-open increments anonymous app open usage", async () => {
   const harness = await createHarness();
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -455,7 +455,11 @@ export async function registerRoutes(
   });
 
   app.get("/api/usage", async (_req, res) => {
-    res.json(usageSummarySchema.parse(await runtime.getUsageSummary()));
+    try {
+      res.json(usageSummarySchema.parse(await runtime.getUsageSummary()));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
   });
 
   app.post("/api/usage/app-open", async (_req, res) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express, Response } from "express";
 import type { Server } from "http";
 import { z } from "zod";
-import { configSchema } from "@shared/schema";
+import { configSchema, usageSummarySchema } from "@shared/schema";
 import type { Config } from "@shared/schema";
 import {
   createAppRuntime,
@@ -452,6 +452,18 @@ export async function registerRoutes(
 
   app.get("/api/config", async (_req, res) => {
     res.json(maskConfig(await runtime.getConfig()));
+  });
+
+  app.get("/api/usage", async (_req, res) => {
+    res.json(usageSummarySchema.parse(await runtime.getUsageSummary()));
+  });
+
+  app.post("/api/usage/app-open", async (_req, res) => {
+    try {
+      res.json(usageSummarySchema.parse(await runtime.recordAppOpen()));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
   });
 
   app.get("/api/app-update", async (_req, res) => {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1684,7 +1684,12 @@ export class SqliteStorage implements IStorage {
       return this.getUsageSummary();
     }
 
-    const date = new Date(occurredAt).toISOString().slice(0, 10);
+    let date: string;
+    try {
+      date = new Date(occurredAt).toISOString().slice(0, 10);
+    } catch {
+      date = new Date().toISOString().slice(0, 10);
+    }
     const column = this.usageCounterColumn(counter);
     this.run(`
       INSERT INTO usage_daily (date, ${column})

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -27,6 +27,10 @@ import type {
   ReleaseRunStatus,
   RuntimeState,
   SocialChangelog,
+  UsageCounterKey,
+  UsageCounters,
+  UsageDailyBucket,
+  UsageSummary,
   WatchedRepo,
 } from "@shared/schema";
 import {
@@ -200,6 +204,14 @@ type RuntimeStateRow = {
   watcher_interval_ms: number | null;
 };
 
+type UsageDailyRow = {
+  date: string;
+  app_open_count: number;
+  tracked_pr_count: number;
+  merged_pr_count: number;
+  fixes_made_count: number;
+};
+
 type AgentRunRow = {
   id: string;
   pr_id: string;
@@ -365,6 +377,13 @@ type DeploymentHealingSessionRow = {
 };
 
 export class SqliteStorage implements IStorage {
+  private static readonly usageCounterKeys: UsageCounterKey[] = [
+    "appOpenCount",
+    "trackedPrCount",
+    "mergedPrCount",
+    "fixesMadeCount",
+  ];
+
   private db!: DatabaseSync;
   private readonly rootDir: string;
   private readonly logRootDir: string;
@@ -600,6 +619,14 @@ export class SqliteStorage implements IStorage {
         watcher_completed_at TEXT,
         watcher_last_error TEXT,
         watcher_interval_ms INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS usage_daily (
+        date TEXT PRIMARY KEY,
+        app_open_count INTEGER NOT NULL DEFAULT 0,
+        tracked_pr_count INTEGER NOT NULL DEFAULT 0,
+        merged_pr_count INTEGER NOT NULL DEFAULT 0,
+        fixes_made_count INTEGER NOT NULL DEFAULT 0
       );
 
       CREATE TABLE IF NOT EXISTS agent_runs (
@@ -1421,6 +1448,7 @@ export class SqliteStorage implements IStorage {
 
       this.replaceFeedbackItems(full.id, full.feedbackItems);
     });
+    await this.incrementUsageCounter("trackedPrCount", 1, full.addedAt);
     return full;
   }
 
@@ -1591,6 +1619,80 @@ export class SqliteStorage implements IStorage {
     }
 
     this.exec("DELETE FROM logs");
+  }
+
+  private createEmptyUsageCounters(): UsageCounters {
+    return {
+      appOpenCount: 0,
+      trackedPrCount: 0,
+      mergedPrCount: 0,
+      fixesMadeCount: 0,
+    };
+  }
+
+  private parseUsageDailyRow(row: UsageDailyRow): UsageDailyBucket {
+    return {
+      date: row.date,
+      appOpenCount: row.app_open_count,
+      trackedPrCount: row.tracked_pr_count,
+      mergedPrCount: row.merged_pr_count,
+      fixesMadeCount: row.fixes_made_count,
+    };
+  }
+
+  private usageCounterColumn(counter: UsageCounterKey): keyof Omit<UsageDailyRow, "date"> {
+    switch (counter) {
+      case "appOpenCount":
+        return "app_open_count";
+      case "trackedPrCount":
+        return "tracked_pr_count";
+      case "mergedPrCount":
+        return "merged_pr_count";
+      case "fixesMadeCount":
+        return "fixes_made_count";
+    }
+  }
+
+  async getUsageSummary(): Promise<UsageSummary> {
+    const rows = this.all<UsageDailyRow>(`
+      SELECT date, app_open_count, tracked_pr_count, merged_pr_count, fixes_made_count
+      FROM usage_daily
+      ORDER BY date ASC
+    `);
+    const totals = this.createEmptyUsageCounters();
+    const daily = rows.map((row) => this.parseUsageDailyRow(row));
+
+    for (const bucket of daily) {
+      for (const key of SqliteStorage.usageCounterKeys) {
+        totals[key] += bucket[key];
+      }
+    }
+
+    return {
+      totals,
+      daily,
+    };
+  }
+
+  async incrementUsageCounter(
+    counter: UsageCounterKey,
+    amount = 1,
+    occurredAt = new Date().toISOString(),
+  ): Promise<UsageSummary> {
+    const increment = Math.trunc(amount);
+    if (increment <= 0) {
+      return this.getUsageSummary();
+    }
+
+    const date = new Date(occurredAt).toISOString().slice(0, 10);
+    const column = this.usageCounterColumn(counter);
+    this.run(`
+      INSERT INTO usage_daily (date, ${column})
+      VALUES (?, ?)
+      ON CONFLICT(date) DO UPDATE SET ${column} = ${column} + excluded.${column}
+    `, date, increment);
+
+    return this.getUsageSummary();
   }
 
   async getConfig(): Promise<Config> {

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -102,6 +102,10 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     drainRequestedAt: "2026-03-18T10:00:00.000Z",
     drainReason: "planned update",
   });
+  await first.incrementUsageCounter("appOpenCount", 1, "2026-06-07T12:00:00.000Z");
+  await first.incrementUsageCounter("trackedPrCount", 2, "2026-06-07T13:00:00.000Z");
+  await first.incrementUsageCounter("mergedPrCount", 1, "2026-06-08T00:30:00.000Z");
+  await first.incrementUsageCounter("fixesMadeCount", 1, "2026-06-08T01:30:00.000Z");
 
   const pr = await first.addPR({
     number: 106,
@@ -207,6 +211,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   const runningRuns = await second.listAgentRuns({ status: "running" });
   const release = await second.getReleaseRun(releaseRun.id);
   const logs = await second.getLogs(pr.id);
+  const usage = await second.getUsageSummary();
 
   assert.equal(config.pollIntervalMs, 45000);
   assert.equal(config.fallbackToNextCodingAgent, true);
@@ -230,6 +235,45 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(runtime.drainMode, true);
   assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
   assert.equal(runtime.drainReason, "planned update");
+  const expectedUsageByDate = new Map([
+    ["2026-06-07", {
+      date: "2026-06-07",
+      appOpenCount: 1,
+      trackedPrCount: 2,
+      mergedPrCount: 0,
+      fixesMadeCount: 0,
+    }],
+    ["2026-06-08", {
+      date: "2026-06-08",
+      appOpenCount: 0,
+      trackedPrCount: 0,
+      mergedPrCount: 1,
+      fixesMadeCount: 1,
+    }],
+  ]);
+  const prUsageDate = pr.addedAt.slice(0, 10);
+  const prUsageBucket = expectedUsageByDate.get(prUsageDate) ?? {
+    date: prUsageDate,
+    appOpenCount: 0,
+    trackedPrCount: 0,
+    mergedPrCount: 0,
+    fixesMadeCount: 0,
+  };
+  expectedUsageByDate.set(prUsageDate, {
+    ...prUsageBucket,
+    trackedPrCount: prUsageBucket.trackedPrCount + 1,
+  });
+
+  assert.deepEqual(usage.totals, {
+    appOpenCount: 1,
+    trackedPrCount: 3,
+    mergedPrCount: 1,
+    fixesMadeCount: 1,
+  });
+  assert.deepEqual(
+    usage.daily,
+    Array.from(expectedUsageByDate.values()).sort((a, b) => a.date.localeCompare(b.date)),
+  );
   assert.equal(reloadedPr?.repo, "alex-morgan-o/lolodex");
   assert.equal(reloadedPr?.feedbackItems.length, 1);
   assert.equal(reloadedPr?.feedbackItems[0]?.bodyHtml, "<p>Please fix <code>thing</code></p>");

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -300,6 +300,32 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   second.close();
 });
 
+test("SqliteStorage falls back to the current UTC date for invalid usage timestamps", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const storage = new SqliteStorage(root);
+
+  try {
+    const validFallbackDates = new Set([
+      new Date().toISOString().slice(0, 10),
+    ]);
+
+    const usage = await storage.incrementUsageCounter("appOpenCount", 1, "not-a-date");
+    validFallbackDates.add(new Date().toISOString().slice(0, 10));
+
+    assert.deepEqual(usage.totals, {
+      appOpenCount: 1,
+      trackedPrCount: 0,
+      mergedPrCount: 0,
+      fixesMadeCount: 0,
+    });
+    assert.equal(usage.daily.length, 1);
+    assert.equal(validFallbackDates.has(usage.daily[0]?.date ?? ""), true);
+    assert.equal(usage.daily[0]?.appOpenCount, 1);
+  } finally {
+    storage.close();
+  }
+});
+
 test("SqliteStorage getLogs returns the latest 500 entries in chronological order", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
   const storage = new SqliteStorage(root);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -21,6 +21,8 @@ import type {
   ReleaseRunStatus,
   RuntimeState,
   SocialChangelog,
+  UsageCounterKey,
+  UsageSummary,
   WatchedRepo,
 } from "@shared/schema";
 export { MemStorage } from "./memoryStorage";
@@ -54,6 +56,10 @@ export interface IStorage {
     },
   ): Promise<LogEntry>;
   clearLogs(prId?: string): Promise<void>;
+
+  // Usage
+  getUsageSummary(): Promise<UsageSummary>;
+  incrementUsageCounter(counter: UsageCounterKey, amount?: number, occurredAt?: string): Promise<UsageSummary>;
 
   // Config
   getConfig(): Promise<Config>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -441,6 +441,33 @@ export const deploymentHealingSessionSchema = z.object({
 });
 export type DeploymentHealingSession = z.infer<typeof deploymentHealingSessionSchema>;
 
+export const usageCounterKeyEnum = z.enum([
+  "appOpenCount",
+  "trackedPrCount",
+  "mergedPrCount",
+  "fixesMadeCount",
+]);
+export type UsageCounterKey = z.infer<typeof usageCounterKeyEnum>;
+
+export const usageCountersSchema = z.object({
+  appOpenCount: z.number().int().nonnegative(),
+  trackedPrCount: z.number().int().nonnegative(),
+  mergedPrCount: z.number().int().nonnegative(),
+  fixesMadeCount: z.number().int().nonnegative(),
+});
+export type UsageCounters = z.infer<typeof usageCountersSchema>;
+
+export const usageDailyBucketSchema = usageCountersSchema.extend({
+  date: z.string(),
+});
+export type UsageDailyBucket = z.infer<typeof usageDailyBucketSchema>;
+
+export const usageSummarySchema = z.object({
+  totals: usageCountersSchema,
+  daily: z.array(usageDailyBucketSchema),
+});
+export type UsageSummary = z.infer<typeof usageSummarySchema>;
+
 export const configSchema = z.object({
   githubTokens: z.array(z.string()),
   githubToken: z.string().optional(),


### PR DESCRIPTION
## Summary

- Adds anonymous local usage counters for app opens, PRs tracked, PRs merged, and fixes made by oh-my-pr.
- Exposes usage totals and daily buckets through `/api/usage`.
- Adds Settings > Usage plus a `/usage` page with simple daily charts.

## Verification

- `npm run check`
- `npm run test:all` (559 passing)
- `npm run build`
- Browser QA against an isolated local server: Settings and `/usage` render, no console errors, mobile width has no horizontal overflow.
- Pre-commit `/simplify` was attempted through the Claude CLI, but the CLI produced no output after about 90 seconds; the stuck process was no longer running when rechecked.
