### PR TITLE
[codex] improve log scan observability

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -187,6 +187,49 @@ test("runtime persists watcher lifecycle freshness in runtime state", async () =
   assert.ok(stopped.watcherCompletedAt);
 });
 
+test("runtime warns when watcher heartbeat is delayed", async () => {
+  const storage = new MemStorage();
+  let heartbeat: (() => void) | null = null;
+  let nowMs = Date.parse("2026-06-25T10:00:00.000Z");
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const fakeTimer = {} as ReturnType<typeof globalThis.setInterval>;
+
+  globalThis.setInterval = ((callback: (...args: unknown[]) => void) => {
+    heartbeat = () => callback();
+    return fakeTimer;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = (() => undefined) as typeof globalThis.clearInterval;
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: true,
+    now: () => new Date(nowMs),
+    watcherScheduler: {
+      run: () => {},
+      runAndReportErrors: async () => {},
+    },
+  });
+
+  _resetRingBufferForTests();
+
+  try {
+    await runtime.start();
+    nowMs += 250_000;
+    heartbeat?.();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const ring = readRingBuffer().join("\n");
+    assert.match(ring, /Repository watcher heartbeat delayed/);
+    assert.match(ring, /delayMs/);
+  } finally {
+    runtime.stop();
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
+});
+
 test("runtime logs watcher runtime state write failures", async () => {
   const storage = new MemStorage();
   const originalUpdateRuntimeState = storage.updateRuntimeState.bind(storage);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -75,6 +75,7 @@ export type AppRuntimeDependencies = {
   startBackgroundServices?: boolean;
   startWatcher?: boolean;
   checkOnboardingStatusFn?: typeof checkOnboardingStatus;
+  now?: () => Date;
 };
 
 export type RuntimeSnapshot = RuntimeState & {
@@ -299,6 +300,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   const events = new EventEmitter();
   const backgroundJobQueue = dependencies.backgroundJobQueue ?? new BackgroundJobQueue(storage);
   const checkOnboardingStatusFn = dependencies.checkOnboardingStatusFn ?? checkOnboardingStatus;
+  const now = dependencies.now ?? (() => new Date());
   // eslint-disable-next-line prefer-const -- circular dep: closure references this before it can be initialized
   let backgroundJobDispatcher!: BackgroundJobDispatcher;
 
@@ -410,6 +412,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
   let watcherTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
+  let lastWatcherHeartbeatAtMs: number | null = null;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
     async () => {
       await scheduleBackgroundJob(
@@ -739,7 +742,16 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     watcherIntervalMs = interval;
     watcherTimer = setInterval(() => {
-      const heartbeatAt = new Date().toISOString();
+      const current = now();
+      if (lastWatcherHeartbeatAtMs !== null) {
+        const delayMs = current.getTime() - lastWatcherHeartbeatAtMs;
+        if (delayMs > watcherIntervalMs * 2) {
+          log.warn({ delayMs, pollIntervalMs: watcherIntervalMs }, "Repository watcher heartbeat delayed");
+        }
+      }
+
+      lastWatcherHeartbeatAtMs = current.getTime();
+      const heartbeatAt = current.toISOString();
       void storage.updateRuntimeState({
         watcherHeartbeatAt: heartbeatAt,
         watcherIntervalMs,
@@ -749,7 +761,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       log.info({ pollIntervalMs: watcherIntervalMs }, "Repository watcher heartbeat");
       void runWatcher();
     }, interval);
-    const startedAt = new Date().toISOString();
+    const started = now();
+    lastWatcherHeartbeatAtMs = started.getTime();
+    const startedAt = started.toISOString();
     void storage.updateRuntimeState({
       watcherStartedAt: startedAt,
       watcherHeartbeatAt: startedAt,

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -771,7 +771,9 @@ test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitt
   };
   let feedbackFetches = 0;
   let failingStatusFetches = 0;
-  const nowMs = Date.parse("2026-06-02T10:00:00.000Z");
+  let healthChecks = 0;
+  let healthCheckHealthy = true;
+  let nowMs = Date.parse("2026-06-02T10:00:00.000Z");
 
   const babysitter = new PRBabysitter(
     storage,
@@ -790,6 +792,12 @@ test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitt
     {
       resolveAgent: async () => "codex",
       now: () => new Date(nowMs),
+      checkAgentHealth: async () => {
+        healthChecks += 1;
+        return healthCheckHealthy
+          ? { ok: true }
+          : { ok: false, reason: "codex health check failed: Command timed out after 30000ms" };
+      },
       ciPollIntervalMs: 0,
       evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
       applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
@@ -800,6 +808,8 @@ test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitt
   );
 
   await babysitter.babysitPR(pr.id, "codex");
+  nowMs += 120_000;
+  healthCheckHealthy = false;
   await babysitter.syncAndBabysitTrackedRepos();
 
   const jobs = await storage.listBackgroundJobs({
@@ -808,6 +818,7 @@ test("syncAndBabysitTrackedRepos skips unchanged PR heads after a no-op babysitt
   });
   const logs = await storage.getLogs(pr.id);
   assert.equal(jobs.length, 0);
+  assert.equal(healthChecks, 1);
   assert.equal(feedbackFetches, 1);
   assert.equal(failingStatusFetches, 1);
   assert.ok(logs.some((log) =>
@@ -1816,9 +1827,16 @@ test("syncAndBabysitTrackedRepos pauses automation when the selected agent is un
   const babysitter = new PRBabysitter(
     storage,
     makeWatcherGitHubService({
-      listOpenPullsForRepo: async () => {
-        throw new Error("watcher should not fetch PRs when agent health fails");
-      },
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Needs watching",
+        branch: "feature/example",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+        headSha: "new-head",
+        baseRef: "main",
+        baseSha: "base123",
+      }],
     }) as never,
     {
       resolveAgent: async () => "claude",
@@ -1889,9 +1907,16 @@ test("syncAndBabysitTrackedRepos does not enter drain mode for transient agent h
   const babysitter = new PRBabysitter(
     storage,
     makeWatcherGitHubService({
-      listOpenPullsForRepo: async () => {
-        throw new Error("watcher should skip this cycle when agent health times out");
-      },
+      listOpenPullsForRepo: async () => [{
+        number: 42,
+        title: "Needs watching",
+        branch: "feature/example",
+        author: "octocat",
+        url: "https://github.com/octo/example/pull/42",
+        headSha: "new-head",
+        baseRef: "main",
+        baseSha: "base123",
+      }],
     }) as never,
     {
       resolveAgent: async () => "codex",

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1950,19 +1950,6 @@ export class PRBabysitter {
       ...config.watchedRepos,
     ]);
     const selectedAgent = config.codingAgent as CodingAgent;
-    let watcherAgent = selectedAgent;
-    const watchedPrIds = tracked
-      .filter((pr) => pr.watchEnabled !== false && pr.status !== "archived")
-      .map((pr) => pr.id);
-    if (!automationBlocked && repoCandidates.size > 0) {
-      try {
-        watcherAgent = (await this.ensureAgentHealthy(selectedAgent, watchedPrIds, {
-          allowFallback: config.fallbackToNextCodingAgent,
-        })).agent;
-      } catch {
-        return;
-      }
-    }
 
     const repoSettingsByRepo = new Map(
       (await this.storage.listRepoSettings()).map((repo) => [repo.repo, repo]),
@@ -2358,17 +2345,27 @@ export class PRBabysitter {
           }
         }
 
+        let runAgent: CodingAgent;
+        try {
+          runAgent = (await this.ensureAgentHealthy(selectedAgent, [local.id], {
+            allowFallback: config.fallbackToNextCodingAgent,
+          })).agent;
+        } catch {
+          continue;
+        }
+
         await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
           phase: "watcher",
           metadata: { repo: repoSlug },
         });
+
         if (this.scheduleBackgroundJob) {
           await this.scheduleBackgroundJob(
             "babysit_pr",
             local.id,
             buildBackgroundJobDedupeKey("babysit_pr", local.id),
             {
-              preferredAgent: watcherAgent,
+              preferredAgent: runAgent,
               ...buildActivityPayload({
                 label: `Babysitting PR #${local.number}`,
                 detail: `${local.repo} - ${local.title}`,
@@ -2377,7 +2374,7 @@ export class PRBabysitter {
             },
           );
         } else {
-          await this.babysitPR(local.id, watcherAgent);
+          await this.babysitPR(local.id, runAgent);
         }
       }
     }

--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -348,7 +348,7 @@ test("BackgroundJobDispatcher retries transient handler errors before completing
     const stored = await storage.getBackgroundJob(job.id);
     assert.equal(stored?.status, "completed");
     assert.equal(stored?.attemptCount, 2);
-    assert.equal(stored?.lastError, null);
+    assert.match(stored?.lastError ?? "", /temporary GitHub outage/);
   } finally {
     dispatcher.stop();
   }

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -612,7 +612,6 @@ export class MemStorage implements IStorage {
       leaseToken: null,
       leaseExpiresAt: null,
       heartbeatAt: null,
-      lastError: null,
       completedAt,
     });
     this.backgroundJobs.set(id, updated);

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1177,13 +1177,14 @@ export class SqliteStorage implements IStorage {
         return undefined;
       }
 
-      const updated = applyBackgroundJobUpdate(this.parseBackgroundJobRow(current), {
+      const existing = this.parseBackgroundJobRow(current);
+      const updated = applyBackgroundJobUpdate(existing, {
         status,
         leaseOwner: null,
         leaseToken: null,
         leaseExpiresAt: null,
         heartbeatAt: null,
-        lastError: error,
+        lastError: status === "completed" ? existing.lastError : error,
         completedAt,
       });
 

--- a/tasks/log-scan-observability-fixes-2026-06-25.md
+++ b/tasks/log-scan-observability-fixes-2026-06-25.md
@@ -1,0 +1,24 @@
+# Log Scan Observability Fix Baseline - 2026-06-25
+
+## Boundary
+- Prepared at: 2026-06-25T11:25:52Z
+- Branch: main
+- Base commit before patch: e4ef93ae1d9232360e78df3f02387870b47bb295
+- Trigger: daily local log scan found repeated transient Codex health-check timeouts, watcher heartbeat gaps without warning logs, and completed retry jobs with empty `lastError`.
+
+## Changes to Evaluate Next Run
+- Watcher sync/no-op observation should continue even when the selected coding agent has a transient health-check timeout. Health checks now run only when a babysitter run is actually about to be queued.
+- Completed background jobs that needed retry should retain the last retry error in `lastError` instead of erasing the reason on completion.
+- Watcher heartbeat gaps greater than two poll intervals should emit `Repository watcher heartbeat delayed` with `delayMs` and `pollIntervalMs`.
+
+## Expected Runtime Signals
+- A transient `codex health check failed: Command timed out after 30000ms` should not prevent GitHub polling or no-op suppression logs for unchanged PR heads.
+- If a `sync_watched_repos` job completes with `attempt_count > 1`, its `last_error` should show the transient failure that caused the retry.
+- Future heartbeat gaps like the 18.5-minute gap ending `2026-06-24T02:35:43Z` should have a paired runtime warning.
+
+## Verification
+- `npx tsx --test server/babysitter.test.ts`
+- `npx tsx --test server/backgroundJobDispatcher.test.ts`
+- `npx tsx --test server/appRuntime.test.ts`
+- `npm run check`
+- `npm run test`


### PR DESCRIPTION
## Summary

- Move watcher agent health checks from the whole watched-repo scan to the point where an autonomous babysitter run is actually about to be queued.
- Preserve retry failure context on completed background jobs so transient failures are still visible after recovery.
- Emit a structured warning when repository watcher heartbeats are delayed by more than two poll intervals.
- Add a 2026-06-25 log-scan baseline with expected future runtime signals.

## Why

The daily local log scan found that transient Codex health-check timeouts could suppress watcher observation, completed retry jobs erased the failure cause, and long watcher heartbeat gaps had no paired warning. The patch keeps observation running, makes recovered retry causes inspectable, and creates a baseline for the next log scan.

## Verification

- `npx tsx --test server/babysitter.test.ts server/backgroundJobDispatcher.test.ts server/appRuntime.test.ts`
- `npm run check`
- `npm run test`

Pre-commit simplify check was attempted with `claude -p "/simplify ..."` but local Claude auth failed with `401 Invalid authentication credentials`.

## Notes

Left unrelated untracked file out of scope:

- `docs/superpowers/plans/2026-05-02-log-failure-fixes.md`
