### PR TITLE
[codex] Add repository unwatch action

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -102,6 +102,11 @@ and authenticate the matching platform CLI on the same machine:
 # List watched repos
 curl http://localhost:5001/api/repos
 
+# Stop watching a repo without deleting existing PR records
+curl -X DELETE http://localhost:5001/api/repos \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"owner/repo"}'
+
 # Add a PR
 curl -X POST http://localhost:5001/api/prs \
   -H "Content-Type: application/json" \
@@ -275,8 +280,9 @@ including release automation, CI healing, and deployment-healing keys.
 #### `GET /api/repos`
 
 Returns the union of explicitly watched repos and repos inferred from tracked PRs.
-Use `GET /api/repos/settings` when you need per-repo settings such as
-`ownPrsOnly`.
+Repos that are no longer watched can still appear here when existing PR records
+belong to them. Use `GET /api/repos/settings` when you need the active watch
+list and per-repo settings such as `ownPrsOnly`.
 
 **Response** `200`
 ```json
@@ -287,8 +293,7 @@ Use `GET /api/repos/settings` when you need per-repo settings such as
 
 #### `GET /api/repos/settings`
 
-Returns repo-level settings for explicitly watched repos plus any repos inferred
-from currently tracked PRs.
+Returns repo-level settings for explicitly watched repos.
 
 `ownPrsOnly: true` means the watcher auto-discovers only PRs authored by the
 authenticated GitHub user for that repo. `ownPrsOnly: false` enables team-wide
@@ -310,11 +315,35 @@ Accepts `"owner/repo"` slugs or full `https://github.com/owner/repo` URLs.
 
 New watched repos default to `ownPrsOnly: true` (`My PRs only`). To switch a
 repo to team-wide discovery, call `PATCH /api/repos/settings` after adding it.
+To stop watching the repo later, call `DELETE /api/repos`.
 
 **Response** `201`
 ```json
 { "repo": "owner/repo" }
 ```
+
+---
+
+#### `DELETE /api/repos`
+
+Remove a repository from the watch list.
+
+This stops repo-level auto-discovery and removes repo-level settings for the
+repository. Existing tracked or archived PR records are preserved; remove those
+separately with PR endpoints if you want them gone. After a repo is unwatched,
+old PR records do not cause the watcher to auto-register new PRs for that repo.
+
+**Body**
+```json
+{ "repo": "owner/repo" }
+```
+Accepts `"owner/repo"` slugs or full `https://github.com/owner/repo` URLs.
+
+**Response** `200`
+```json
+{ "repo": "owner/repo" }
+```
+**Response** `400` — invalid body or repository slug
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can authenticate with:
 
 ### Watch Scope
 
-Watched repositories default to `My PRs only`. You can switch a repo to `My PRs + teammates`, or skip auto-discovery entirely and register a single PR by URL.
+Watched repositories default to `My PRs only`. You can switch a repo to `My PRs + teammates`, stop watching a repo when you no longer want auto-discovery for it, or skip auto-discovery entirely and register a single PR by URL. Stopping watch preserves existing PR records; remove individual PRs separately if you want them gone.
 
 ### Interfaces
 

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -280,6 +280,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["add PR submit", "button-add-pr"],
     ["watch repo input", "input-add-repo"],
     ["watch repo submit", "button-add-repo"],
+    ["unwatch repo action", /tracked-repo-unwatch-\$\{repo\.repo\.replace\(\s*["']\/["']\s*,\s*["']-["']\s*\)\}/],
     ["run-now action", "button-apply"],
     ["pause-resume watch action", "button-toggle-watch"],
     ["CI healing panel", "panel-ci-healing"],
@@ -310,6 +311,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
 
   assertHasApiRequest(sourceFile, "add PR mutation", "POST", "/api/prs");
   assertHasApiRequest(sourceFile, "watch repo mutation", "POST", "/api/repos");
+  assertHasApiRequest(sourceFile, "unwatch repo mutation", "DELETE", "/api/repos");
   assertHasApiRequest(sourceFile, "sync repos mutation", "POST", "/api/repos/sync");
   assertHasApiRequest(sourceFile, "manual release mutation", "POST", "/api/repos/release");
   assertHasApiRequest(sourceFile, "failed activity clear mutation", "DELETE", "/api/activities/failed");

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "rea
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { Activity as ActivityIcon } from "lucide-react";
+import { Activity as ActivityIcon, Trash2 } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import { getRepoHref } from "@/lib/repoHref";
 import { getRepoAddControlsOpen } from "@/lib/repoAddControls";
@@ -1479,6 +1479,24 @@ export default function Dashboard() {
     },
   });
 
+  const removeRepoMutation = useMutation({
+    mutationFn: async (repo: string) => {
+      const res = await apiRequest("DELETE", "/api/repos", { repo });
+      return res.json() as Promise<{ repo: string }>;
+    },
+    onSuccess: ({ repo }) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
+      toast({ description: `Stopped watching ${repo}.` });
+    },
+    onError: (error) => {
+      showMutationError("Could not unwatch repository", error);
+    },
+  });
+
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
       <UpdateBanner />
@@ -1715,6 +1733,8 @@ export default function Dashboard() {
                       {repos.map((repo) => {
                         const manualReleasePending = manualReleaseMutation.isPending
                           && manualReleaseMutation.variables === repo.repo;
+                        const removeRepoPending = removeRepoMutation.isPending
+                          && removeRepoMutation.variables === repo.repo;
 
                         return (
                           <div
@@ -1776,6 +1796,29 @@ export default function Dashboard() {
                                 >
                                   {globalDrainMode ? DRAIN_PAUSED_LABEL : manualReleasePending ? "Releasing..." : "Release"}
                                 </button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      type="button"
+                                      onClick={() => removeRepoMutation.mutate(repo.repo)}
+                                      disabled={removeRepoMutation.isPending}
+                                      title="Unwatch repository"
+                                      aria-label={`Unwatch ${repo.repo}`}
+                                      data-testid={`tracked-repo-unwatch-${repo.repo.replace("/", "-")}`}
+                                      className="flex h-6 w-6 items-center justify-center border border-border text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+                                    >
+                                      <Trash2 className="h-3 w-3" aria-hidden="true" />
+                                      <span className="sr-only">
+                                        {removeRepoPending ? "Unwatching" : "Unwatch"}
+                                      </span>
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top">
+                                    <p className="text-xs">
+                                      {removeRepoPending ? "Unwatching repository" : "Unwatch repository"}
+                                    </p>
+                                  </TooltipContent>
+                                </Tooltip>
                               </div>
                             </div>
                           </div>

--- a/docs/plans/2026-06-25-delete-watched-repository.md
+++ b/docs/plans/2026-06-25-delete-watched-repository.md
@@ -1,0 +1,47 @@
+# Delete Watched Repository Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a non-destructive way to unwatch a repository from the dashboard.
+
+**Architecture:** Add a repo-scoped `DELETE /api/repos` runtime path that removes the canonical repo from `config.watchedRepos`; existing storage config writes prune persisted repo settings. Treat repo discovery as driven by explicit watched repos so old PR records do not keep an unwatched repo polling for new PRs.
+
+**Tech Stack:** Express routes, `AppRuntime`, `MemStorage`/`SqliteStorage` config persistence, React Query dashboard mutation, Node test runner.
+
+---
+
+### Task 1: Server Behavior
+
+**Files:**
+- Modify: `server/routes.test.ts`
+- Modify: `server/babysitter.test.ts`
+- Modify: `server/appRuntime.ts`
+- Modify: `server/routes.ts`
+- Modify: `server/babysitter.ts`
+
+**Steps:**
+1. Add a failing route test for `DELETE /api/repos` that removes a watched repo from `/api/repos/settings` while preserving existing PR records.
+2. Add a failing watcher test proving a repo that is no longer in `watchedRepos` does not auto-register newly discovered PRs just because an old PR exists.
+3. Implement `AppRuntime.removeRepo(repoInput)` by canonicalizing input, removing it from `watchedRepos`, invalidating onboarding, notifying subscribers, and returning `{ repo }`.
+4. Add `DELETE /api/repos` to `server/routes.ts`.
+5. Change watcher repo discovery to use explicit watched repos.
+6. Run the focused server tests and confirm they pass.
+
+### Task 2: Dashboard UI
+
+**Files:**
+- Modify: `client/src/pages/dashboard.tsx`
+- Modify: `client/src/lib/fullAppQaSurface.test.ts`
+
+**Steps:**
+1. Add a failing client surface test for the unwatch button test id and `DELETE /api/repos` mutation.
+2. Add a React Query mutation for unwatching a repo.
+3. Add a compact row-level `Unwatch` button in the tracked repositories action cluster.
+4. Invalidate repo settings, PRs, config, and onboarding status on success; show mutation errors through the existing toast helper.
+5. Run the client surface test and confirm it passes.
+
+### Task 3: Verification
+
+**Commands:**
+- `npx tsx --test server/routes.test.ts server/babysitter.test.ts client/src/lib/fullAppQaSurface.test.ts`
+- `npm run check`

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -298,7 +298,8 @@ oh-my-pr --no-log-file
 </tr>
 </tbody></table>
 <p>New watched repos default to <strong>My PRs only</strong> with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
-<p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting.</p>
+<p>Use the repository row&#39;s unwatch action, or <code>DELETE /api/repos</code>, to stop watching a repository. This removes repo-level auto-discovery and settings while preserving existing PR records; old PRs do not make the watcher discover new PRs for that repo after it is unwatched.</p>
+<p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting or whether the repo is currently watched.</p>
 <h2>Manual Repository Releases</h2>
 <p>Each watched repository row in the dashboard includes a <strong>Release</strong> button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.</p>
 <p>Manual release runs are allowed even when <code>autoCreateReleases</code> is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns <code>409</code> and no release run is created.</p>

--- a/docs/public/_site/pr-babysitter.html
+++ b/docs/public/_site/pr-babysitter.html
@@ -168,6 +168,7 @@
 <li><strong>My PRs + teammates</strong> — team-wide mode. The watcher auto-discovers every open PR in the repository.</li>
 <li><strong>Direct PR URLs</strong> — PRs you add explicitly by URL stay tracked regardless of the repo&#39;s watch scope.</li>
 </ul>
+<p>You can stop watching a repository from the dashboard when you no longer want repo-level auto-discovery. Existing PR records are preserved, and old PRs do not cause the watcher to auto-register new PRs for that unwatched repository.</p>
 <p>For tracked PRs, the babysitter syncs:</p>
 <ul>
 <li>New PRs opened against the repository.</li>
@@ -277,6 +278,7 @@
 <p>You can control babysitter behavior per repository:</p>
 <ul>
 <li><strong>Repo watch scope</strong> — Choose <code>My PRs only</code> (default) or <code>My PRs + teammates</code> for auto-discovery.</li>
+<li><strong>Unwatch repository</strong> — Stop repo-level auto-discovery while preserving existing PR records.</li>
 <li><strong>Poll interval</strong> — How often to check for new reviews (default: 60 seconds).</li>
 <li><strong>Auto-dispatch</strong> — Whether to automatically dispatch agents or require approval.</li>
 <li><strong>Agent preference</strong> — Choose the global coding agent, with CLI fallback when the preferred tool is not installed.</li>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -105,7 +105,9 @@ Watched repositories also have repo-level settings exposed in the dashboard's re
 
 New watched repos default to **My PRs only** with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to **My PRs + teammates** in the dashboard or patch `ownPrsOnly: false` through `/api/repos/settings`.
 
-PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting.
+Use the repository row's unwatch action, or `DELETE /api/repos`, to stop watching a repository. This removes repo-level auto-discovery and settings while preserving existing PR records; old PRs do not make the watcher discover new PRs for that repo after it is unwatched.
+
+PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting or whether the repo is currently watched.
 
 ## Manual Repository Releases
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -12,6 +12,8 @@ When you add a repository to oh-my-pr, the babysitter begins polling for open pu
 - **My PRs + teammates** — team-wide mode. The watcher auto-discovers every open PR in the repository.
 - **Direct PR URLs** — PRs you add explicitly by URL stay tracked regardless of the repo's watch scope.
 
+You can stop watching a repository from the dashboard when you no longer want repo-level auto-discovery. Existing PR records are preserved, and old PRs do not cause the watcher to auto-register new PRs for that unwatched repository.
+
 For tracked PRs, the babysitter syncs:
 
 - New PRs opened against the repository.
@@ -119,6 +121,7 @@ When a PR branch falls behind the base branch, oh-my-pr can automatically:
 You can control babysitter behavior per repository:
 
 - **Repo watch scope** — Choose `My PRs only` (default) or `My PRs + teammates` for auto-discovery.
+- **Unwatch repository** — Stop repo-level auto-discovery while preserving existing PR records.
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
 - **Agent preference** — Choose the global coding agent, with CLI fallback when the preferred tool is not installed.

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -99,6 +99,7 @@ export type AppRuntime = {
   listRepos(): Promise<string[]>;
   listRepoSettings(): Promise<WatchedRepo[]>;
   addRepo(repoInput: string): Promise<{ repo: string }>;
+  removeRepo(repoInput: string): Promise<{ repo: string }>;
   updateRepoSettings(repoInput: string, updates: Partial<Omit<WatchedRepo, "repo">>): Promise<WatchedRepo>;
   syncRepos(): Promise<{ ok: true }>;
   createManualRelease(repoInput: string): Promise<ReleaseRun>;
@@ -941,23 +942,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async listRepoSettings() {
-      const [configuredRepos, prs] = await Promise.all([
-        storage.listRepoSettings(),
-        storage.getPRs(),
-      ]);
-      const byRepo = new Map(configuredRepos.map((repo) => [repo.repo, repo]));
-
-      for (const pr of prs) {
-        if (!byRepo.has(pr.repo)) {
-          byRepo.set(pr.repo, {
-            repo: pr.repo,
-            autoCreateReleases: false,
-            ownPrsOnly: true,
-          });
-        }
-      }
-
-      return Array.from(byRepo.values()).sort((a, b) => a.repo.localeCompare(b.repo));
+      const configuredRepos = await storage.listRepoSettings();
+      return configuredRepos.sort((a, b) => a.repo.localeCompare(b.repo));
     },
 
     async addRepo(repoInput) {
@@ -976,6 +962,25 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       }
 
       void runWatcher();
+      notifyChange();
+      return { repo: canonical };
+    },
+
+    async removeRepo(repoInput) {
+      const parsedRepo = parseRepoSlug(repoInput);
+      if (!parsedRepo) {
+        throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+      }
+
+      const canonical = formatRepoSlug(parsedRepo);
+      const config = await storage.getConfig();
+      if (config.watchedRepos.includes(canonical)) {
+        await storage.updateConfig({
+          watchedRepos: config.watchedRepos.filter((repo) => repo !== canonical),
+        });
+        invalidateOnboardingStatusCache("watched repo removed");
+      }
+
       notifyChange();
       return { repo: canonical };
     },

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -7171,6 +7171,69 @@ test("syncAndBabysitTrackedRepos does not auto-register new PRs for unwatched re
   assert.deepEqual(prs.map((pr) => pr.number), [105]);
 });
 
+test("syncAndBabysitTrackedRepos matches explicitly watched repos case-insensitively", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["Alex-Morgan-O/LoloDex"],
+    autoUpdateDocs: false,
+  });
+  await storage.addPR({
+    number: 105,
+    title: "Old tracked PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/old",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/105",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async (_octokit: unknown, repo: { owner: string; repo: string }) => {
+        if (repo.owner !== "alex-morgan-o" || repo.repo !== "lolodex") {
+          return [];
+        }
+
+        return [
+          {
+            number: 105,
+            title: "Old tracked PR",
+            branch: "feature/old",
+            author: "octocat",
+            url: "https://github.com/alex-morgan-o/lolodex/pull/105",
+          },
+          {
+            number: 106,
+            title: "New PR from watched repo",
+            branch: "feature/new",
+            author: "octocat",
+            url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+          },
+        ];
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const prs = await storage.getPRs();
+  assert.deepEqual(prs.map((pr) => pr.number).sort((a, b) => a - b), [105, 106]);
+});
+
 test("syncAndBabysitTrackedRepos can include teammate PRs when repo setting disables own-only filtering", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -7116,6 +7116,61 @@ test("syncAndBabysitTrackedRepos auto-registers only the authenticated user's PR
   assert.deepEqual(queuedTargets, [prs[0]!.id]);
 });
 
+test("syncAndBabysitTrackedRepos does not auto-register new PRs for unwatched repos with old tracked PRs", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 105,
+    title: "Old tracked PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/old",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/105",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        return [
+          {
+            number: 105,
+            title: "Old tracked PR",
+            branch: "feature/old",
+            author: "octocat",
+            url: "https://github.com/alex-morgan-o/lolodex/pull/105",
+          },
+          {
+            number: 106,
+            title: "New PR from unwatched repo",
+            branch: "feature/new",
+            author: "octocat",
+            url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+          },
+        ];
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const prs = await storage.getPRs();
+  assert.deepEqual(prs.map((pr) => pr.number), [105]);
+});
+
 test("syncAndBabysitTrackedRepos can include teammate PRs when repo setting disables own-only filtering", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1945,7 +1945,7 @@ export class PRBabysitter {
 
     const config = await this.storage.getConfig();
     const tracked = await this.storage.getPRs();
-    const explicitlyWatchedRepos = new Set(config.watchedRepos);
+    const explicitlyWatchedRepos = new Set(config.watchedRepos.map((repo) => repo.toLowerCase()));
     const repoCandidates = new Set<string>([
       ...tracked.map((pr) => pr.repo),
       ...config.watchedRepos,
@@ -1999,7 +1999,7 @@ export class PRBabysitter {
 
     for (const repo of repos) {
       const repoSlug = formatRepoSlug(repo);
-      const repoIsExplicitlyWatched = explicitlyWatchedRepos.has(repoSlug);
+      const repoIsExplicitlyWatched = explicitlyWatchedRepos.has(repoSlug.toLowerCase());
 
       let openPulls;
       try {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1945,6 +1945,7 @@ export class PRBabysitter {
 
     const config = await this.storage.getConfig();
     const tracked = await this.storage.getPRs();
+    const explicitlyWatchedRepos = new Set(config.watchedRepos);
     const repoCandidates = new Set<string>([
       ...tracked.map((pr) => pr.repo),
       ...config.watchedRepos,
@@ -1998,6 +1999,7 @@ export class PRBabysitter {
 
     for (const repo of repos) {
       const repoSlug = formatRepoSlug(repo);
+      const repoIsExplicitlyWatched = explicitlyWatchedRepos.has(repoSlug);
 
       let openPulls;
       try {
@@ -2167,7 +2169,7 @@ export class PRBabysitter {
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
-          if (!automationScopeNumbers.has(pull.number)) {
+          if (!repoIsExplicitlyWatched || !automationScopeNumbers.has(pull.number)) {
             continue;
           }
 

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1287,6 +1287,49 @@ test("PATCH /api/repos/settings can update only ownPrsOnly", async () => {
   }
 });
 
+test("DELETE /api/repos unwatches a repository without deleting existing PRs", async () => {
+  const harness = await createHarness();
+  await harness.storage.updateConfig({
+    watchedRepos: ["acme/api", "acme/widgets"],
+  });
+  await harness.storage.updateRepoSettings("acme/widgets", {
+    autoCreateReleases: true,
+    ownPrsOnly: false,
+  });
+  const pr = await seedPR(harness.storage);
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/repos`, {
+      method: "DELETE",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        repo: "https://github.com/acme/widgets",
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      repo: "acme/widgets",
+    });
+
+    const config = await harness.storage.getConfig();
+    assert.deepEqual(config.watchedRepos, ["acme/api"]);
+
+    const settingsResponse = await fetch(`${harness.baseUrl}/api/repos/settings`);
+    assert.equal(settingsResponse.status, 200);
+    assert.deepEqual(await settingsResponse.json(), [{
+      repo: "acme/api",
+      autoCreateReleases: false,
+      ownPrsOnly: true,
+    }]);
+
+    assert.deepEqual(await harness.storage.getPR(pr.id), pr);
+  } finally {
+    await harness.close();
+  }
+});
+
 test("GET /api/app-update exposes the app update check result", async () => {
   const originalVersion = process.env.APP_VERSION;
   process.env.APP_VERSION = "1.0.0";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -247,6 +247,15 @@ export async function registerRoutes(
     }
   });
 
+  app.delete("/api/repos", async (req, res) => {
+    try {
+      const { repo } = z.object({ repo: z.string().min(1) }).parse(req.body);
+      res.json(await runtime.removeRepo(repo));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.patch("/api/repos/settings", async (req, res) => {
     try {
       const payload = z.object({


### PR DESCRIPTION
## Summary
- Add a non-destructive unwatch flow for watched repositories.
- Wire tracked repository rows to a visible trash-icon Unwatch action in the dashboard.
- Prevent unwatched repositories from auto-registering new PRs while preserving existing PR records.

## Verification
- npx tsx --test server/routes.test.ts server/babysitter.test.ts client/src/lib/fullAppQaSurface.test.ts
- npm run check
- npm run test:all
- npm run build

## Notes
- Local UI smoke was checked on an isolated dev server at http://127.0.0.1:5011/.